### PR TITLE
Better default prefs and crash detection (fixes #17)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/service/NotificationHandler.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/NotificationHandler.java
@@ -168,18 +168,16 @@ public class NotificationHandler {
         mNotificationManager.cancel(ID_PERSISTENT_WAITING);
     }
 
-    public void showCrashedNotification(@StringRes int title, boolean force) {
-        if (force || mPreferences.getBoolean("notify_crashes", false)) {
-            Intent intent = new Intent(mContext, LogActivity.class);
-            Notification n = getNotificationBuilder(mInfoChannel)
-                    .setContentTitle(mContext.getString(title))
-                    .setContentText(mContext.getString(R.string.notification_crash_text))
-                    .setSmallIcon(R.drawable.ic_stat_notify)
-                    .setContentIntent(PendingIntent.getActivity(mContext, 0, intent, 0))
-                    .setAutoCancel(true)
-                    .build();
-            mNotificationManager.notify(ID_CRASH, n);
-        }
+    public void showCrashedNotification(@StringRes int title) {
+        Intent intent = new Intent(mContext, LogActivity.class);
+        Notification n = getNotificationBuilder(mInfoChannel)
+                .setContentTitle(mContext.getString(title))
+                .setContentText(mContext.getString(R.string.notification_crash_text))
+                .setSmallIcon(R.drawable.ic_stat_notify)
+                .setContentIntent(PendingIntent.getActivity(mContext, 0, intent, 0))
+                .setAutoCancel(true)
+                .build();
+        mNotificationManager.notify(ID_CRASH, n);
     }
 
     /**

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
@@ -185,7 +185,7 @@ public class SyncthingRunnable implements Runnable {
                     break;
                 default:
                     Log.w(TAG, "Syncthing has crashed (exit code " + ret + ")");
-                    mNotificationHandler.showCrashedNotification(R.string.notification_crash_title, false);
+                    mNotificationHandler.showCrashedNotification(R.string.notification_crash_title);
             }
         } catch (IOException | InterruptedException e) {
             Log.e(TAG, "Failed to execute syncthing binary or read output", e);

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
@@ -337,7 +337,7 @@ public class SyncthingService extends Service {
                  syncthingService.mConfig = new ConfigXml(syncthingService);
                  syncthingService.mConfig.updateIfNeeded();
              } catch (ConfigXml.OpenConfigException e) {
-                 syncthingService.mNotificationHandler.showCrashedNotification(R.string.config_read_failed, true);
+                 syncthingService.mNotificationHandler.showCrashedNotification(R.string.config_read_failed);
                  synchronized (syncthingService.mStateLock) {
                      syncthingService.onServiceStateChange(State.ERROR);
                  }

--- a/app/src/main/res/values-ca-rES/strings.xml
+++ b/app/src/main/res/values-ca-rES/strings.xml
@@ -266,8 +266,6 @@ Ens podeu informar dels problemes que trobeu a través de Github.</string>
   <string name="open_log">Obre el registre</string>
   <!--Summary for the log activity-->
   <string name="open_log_summary">Obre la finestra de registre del Syncthing i de l\'Android</string>
-  <string name="notify_crashes_title">Notifica els bloquejos del Syncthing</string>
-  <string name="notify_crashes_summary">Mostra una notificació si es detecta que el Syncthing s\'ha bloquejat</string>
   <!--Settings item that opens issue tracker-->
   <string name="report_issue_title">Informeu d\'un problema</string>
   <!--Summary for the issue tracker settings item-->

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -239,8 +239,6 @@ Všechny zaznamenané chyby prosím hlašte přes Github.</string>
   <string name="open_log">Otevřít log</string>
   <!--Summary for the log activity-->
   <string name="open_log_summary">Otevřít okno logu pro Syncthing a Android</string>
-  <string name="notify_crashes_title">Upozornit na pády Syncthing</string>
-  <string name="notify_crashes_summary">Zobraz upozornění pokaždé, kdy je zaznamenán pád Syncthing</string>
   <!--Settings item that opens issue tracker-->
   <string name="report_issue_title">Nahlásit chybu</string>
   <!--Summary for the issue tracker settings item-->

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -236,8 +236,6 @@ Vær venlig at rapportere ethvert problem, du støder på, via Github. </string>
   <string name="open_log">Åben Log</string>
   <!--Summary for the log activity-->
   <string name="open_log_summary">Åben Syncthing\'s og Android\'s log vindue</string>
-  <string name="notify_crashes_title">Underret om Syncthing crashes</string>
-  <string name="notify_crashes_summary">Vis en notifikation hver gang et Syncthing crash bliver opdaget</string>
   <!--Settings item that opens issue tracker-->
   <string name="report_issue_title">Rapporter problem</string>
   <!--Summary for the issue tracker settings item-->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -184,7 +184,7 @@ Bitte melden Sie auftretende Probleme via GitHub.</string>
   <string name="advanced_folder_picker">Erweiterte Verzeichnisauswahl benutzen</string>
   <string name="advanced_folder_picker_summary">Alle Verzeichnisse auf dem Gerät für Synchronisation auswählbar</string>
   <string name="use_root_title">Syncthing mit Superuser Rechten ausführen</string>
-  <string name="use_root_summary">Dies ist eine instabile Funktion, welche Probleme mit Syncthing und deinem Gerät verursachen könnte. Wenn du Probleme feststellst, musst du Syncthing möglicherweise neu installieren.</string>
+  <string name="use_root_summary">Wenn Syncthing unter dem Root-Benutzer ausgeführt wird, hat es Schreibzugriff auf Ordner, die Android normalerweise auf schreibgeschützten Zugriff beschränkt. Verwende diese Funktion mit Bedacht.</string>
   <string name="notification_type_title">Permanente Benachrichtigung</string>
   <string name="notification_type_summary">Wähle die Art der Benachrichtigung</string>
   <string-array name="notification_type_entries">
@@ -282,8 +282,6 @@ Bitte melden Sie auftretende Probleme via GitHub.</string>
   <string name="open_log">Log öffnen</string>
   <!--Summary for the log activity-->
   <string name="open_log_summary">Öffne das Syncthing und Android Log Fenster</string>
-  <string name="notify_crashes_title">Syncthing Abstürze benachrichtigen</string>
-  <string name="notify_crashes_summary">Benachrichtigung anzeigen wenn ein Syncthing Absturz erkannt wurde</string>
   <!--Settings item that opens issue tracker-->
   <string name="report_issue_title">Fehler melden</string>
   <!--Summary for the issue tracker settings item-->

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -236,8 +236,6 @@
   <string name="open_log">Άνοιγμα καταγραφής συμβάντων</string>
   <!--Summary for the log activity-->
   <string name="open_log_summary">Άνοιγμα του παραθύρου καταγραφής συμβάντων του Syncthing και Android</string>
-  <string name="notify_crashes_title">Ειδοποίηση για καταρρεύσεις του Syncthing</string>
-  <string name="notify_crashes_summary">Να εμφανίζεται μια ειδοποίηση όποτε ανιχνεύεται κατάρρευση του Syncthing</string>
   <!--Settings item that opens issue tracker-->
   <string name="report_issue_title">Αναφορά προβλήματος</string>
   <!--Summary for the issue tracker settings item-->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -214,8 +214,6 @@
   <string name="open_log">Abrir registro</string>
   <!--Summary for the log activity-->
   <string name="open_log_summary">Abrir ventana de registro de Syncthing y Android</string>
-  <string name="notify_crashes_title">Notificar sobre los accidentes de Syncthing</string>
-  <string name="notify_crashes_summary">Mostrar una notificación cada vez que se detecta un bloqueo de Syncthing</string>
   <!--Settings item that opens issue tracker-->
   <string name="report_issue_title">Informar de un problema</string>
   <!--Summary for the issue tracker settings item-->

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -219,8 +219,6 @@ Ilmoitathan ystävällisesti kaikista havaitsemistasi ongelmista Githubin kautta
   <string name="open_log">Avaa loki</string>
   <!--Summary for the log activity-->
   <string name="open_log_summary">Avaa Syncthingin ja Androidin loki-ikkuna</string>
-  <string name="notify_crashes_title">Ilmoita Syncthingin kaatumisista</string>
-  <string name="notify_crashes_summary">Näytä ilmoitus kun Syncthingin kaatuminen havaitaan</string>
   <!--Settings item that opens issue tracker-->
   <string name="report_issue_title">Ilmoita ongelmasta</string>
   <!--Summary for the issue tracker settings item-->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -267,8 +267,6 @@ S\'il vous plaît, soumettez les problèmes que vous rencontrez via Github.</str
   <string name="open_log">Ouvrir le journal</string>
   <!--Summary for the log activity-->
   <string name="open_log_summary">Ouvre la fenêtre du journal de Syncthing et Android</string>
-  <string name="notify_crashes_title">Prévenir quand Syncthing se plante</string>
-  <string name="notify_crashes_summary">Affiche une notification quand un plantage de Syncthing est détecté.</string>
   <!--Settings item that opens issue tracker-->
   <string name="report_issue_title">Signaler un problème</string>
   <!--Summary for the issue tracker settings item-->

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -270,8 +270,6 @@ VIGYÁZAT! Más alkalmazások kiolvashatják a backupból a titkos kulcsot, és 
   <string name="open_log">Napló megnyitása</string>
   <!--Summary for the log activity-->
   <string name="open_log_summary">A Syncthing és az Android naplók megnyitása</string>
-  <string name="notify_crashes_title">Értesítés a Syncthing összeomlásáról</string>
-  <string name="notify_crashes_summary">Megjelenít egy értesítést, amennyiben a Syncthing összeomlik</string>
   <!--Settings item that opens issue tracker-->
   <string name="report_issue_title">Hibabejelentés</string>
   <!--Summary for the issue tracker settings item-->

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -223,8 +223,6 @@ Jika ada masalah silakan laporkan lewat Github.</string>
   <string name="open_log">Buka Log</string>
   <!--Summary for the log activity-->
   <string name="open_log_summary">Buat jendela log Syncthing dan Android</string>
-  <string name="notify_crashes_title">Beritahu jika aplikasi Syncthing mati</string>
-  <string name="notify_crashes_summary">Tampilkan notifikasi jika kegagalan Syncthing ditemukan</string>
   <!--Settings item that opens issue tracker-->
   <string name="report_issue_title">Laporkan Masalah</string>
   <!--Summary for the issue tracker settings item-->

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -267,8 +267,6 @@ Si prega di segnalare eventuali problemi che si incontrano via Github.</string>
   <string name="open_log">Apri Registro</string>
   <!--Summary for the log activity-->
   <string name="open_log_summary">Apre la finestra di log di Syncthing e Android</string>
-  <string name="notify_crashes_title">Notifica i crash di Syncthing</string>
-  <string name="notify_crashes_summary">Mostra una notifica ogni volta che viene rilevato un crash di Syncthing</string>
   <!--Settings item that opens issue tracker-->
   <string name="report_issue_title">Segnala Problema</string>
   <!--Summary for the issue tracker settings item-->

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -236,8 +236,6 @@
   <string name="open_log">ログを開く</string>
   <!--Summary for the log activity-->
   <string name="open_log_summary">Syncthing と Android のログウインドウを開く</string>
-  <string name="notify_crashes_title">Syncthing のクラッシュを通知</string>
-  <string name="notify_crashes_summary">Syncthing のクラッシュを検知した時に通知を表示します</string>
   <!--Settings item that opens issue tracker-->
   <string name="report_issue_title">問題を報告</string>
   <!--Summary for the issue tracker settings item-->

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -235,8 +235,6 @@
   <string name="open_log">로그 열기</string>
   <!--Summary for the log activity-->
   <string name="open_log_summary">Syncthing 및 Android 로그 윈도우 열기</string>
-  <string name="notify_crashes_title">Syncthing 충돌에 대해 알려주기</string>
-  <string name="notify_crashes_summary">Syncthing 충돌이 감지 되었을 때 알림을 보여줍니다</string>
   <!--Settings item that opens issue tracker-->
   <string name="report_issue_title">문제 보고</string>
   <!--Summary for the issue tracker settings item-->

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -267,8 +267,6 @@ Als je problemen tegenkomt, meld ze dan via GitHub.</string>
   <string name="open_log">Log openen</string>
   <!--Summary for the log activity-->
   <string name="open_log_summary">Open het Syncthing- en Android-logvenster</string>
-  <string name="notify_crashes_title">Toon melding wanneer Syncthing crasht</string>
-  <string name="notify_crashes_summary">Toon een melding wanneer een crash van Syncthing wordt gedetecteerd</string>
   <!--Settings item that opens issue tracker-->
   <string name="report_issue_title">Probleem rapporteren</string>
   <!--Summary for the issue tracker settings item-->

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -234,8 +234,6 @@ Proszę zgłaszać napotkane błędy programu za pośrednictwem serwisu Github.<
   <string name="open_log">Otwórz dziennik</string>
   <!--Summary for the log activity-->
   <string name="open_log_summary">Wyświetla dzienniki Syncthing oraz Androida</string>
-  <string name="notify_crashes_title">Powiadamiaj o awariach Syncthing</string>
-  <string name="notify_crashes_summary">Powiadamiaj za każdym razem, kiedy wykryta zostanie awaria Syncthing</string>
   <!--Settings item that opens issue tracker-->
   <string name="report_issue_title">Zgłoś błąd</string>
   <!--Summary for the issue tracker settings item-->

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -258,8 +258,6 @@ Por favor, nos avise sobre quaisquer problemas que você encontrar via Github.</
   <string name="open_log">Abrir log</string>
   <!--Summary for the log activity-->
   <string name="open_log_summary">Abrir a janela de log do Syncthing e do Android</string>
-  <string name="notify_crashes_title">Notificar sobre as falhas do Syncthing</string>
-  <string name="notify_crashes_summary">Exibir uma notificação quando uma falha no Syncthing for detectada</string>
   <!--Settings item that opens issue tracker-->
   <string name="report_issue_title">Reportar problema</string>
   <!--Summary for the issue tracker settings item-->

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -286,8 +286,6 @@ Vă rugăm să raportați orice problemă întâlniți, prin intermediul GitHub.
   <string name="open_log">Deschide jurnal de erori</string>
   <!--Summary for the log activity-->
   <string name="open_log_summary">Deschide fereastra de jurnal de erori Syncthing și Android</string>
-  <string name="notify_crashes_title">Notifică despre opririle neașteptate ale Syncthing</string>
-  <string name="notify_crashes_summary">Arată o notificare de fiecare dată când Syncthing s-a oprit pe neașteptate</string>
   <!--Settings item that opens issue tracker-->
   <string name="report_issue_title">Raportează problemă</string>
   <!--Summary for the issue tracker settings item-->

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -267,8 +267,6 @@
   <string name="open_log">Открыть лог</string>
   <!--Summary for the log activity-->
   <string name="open_log_summary">Открывает логи Syncthing и Android</string>
-  <string name="notify_crashes_title">Сообщать о сбоях Syncthing</string>
-  <string name="notify_crashes_summary">Показывать уведомлениепри обнаружении сбоев Syncthing</string>
   <!--Settings item that opens issue tracker-->
   <string name="report_issue_title">Сообщить о проблеме</string>
   <!--Summary for the issue tracker settings item-->

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -284,8 +284,6 @@ Vänligen rapportera eventuella problem du stöter på via Github.</string>
   <string name="open_log">Öppna logg</string>
   <!--Summary for the log activity-->
   <string name="open_log_summary">Öppna loggfönstret för Syncthing och Android</string>
-  <string name="notify_crashes_title">Meddela om Syncthing kraschar</string>
-  <string name="notify_crashes_summary">Visa en avisering när en Syncthing krasch detekteras</string>
   <!--Settings item that opens issue tracker-->
   <string name="report_issue_title">Rapportera problem</string>
   <!--Summary for the issue tracker settings item-->

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -188,7 +188,6 @@
   <!--Settings item that opens the log activity-->
   <string name="open_log">Відкрити журнал</string>
   <!--Summary for the log activity-->
-  <string name="notify_crashes_title">Повідомляти про аварійні завершення роботи Syncthing </string>
   <!--Settings item that opens issue tracker-->
   <string name="report_issue_title">Повідомити про проблему</string>
   <!--Summary for the issue tracker settings item-->

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -238,8 +238,6 @@
   <string name="open_log">打开日志</string>
   <!--Summary for the log activity-->
   <string name="open_log_summary">打开 Syncthing 与 Android 系统日志窗口</string>
-  <string name="notify_crashes_title">通知 Syncthing 崩溃</string>
-  <string name="notify_crashes_summary">当检查到 Syncthing 崩溃时显示通知</string>
   <!--Settings item that opens issue tracker-->
   <string name="report_issue_title">回报问题</string>
   <!--Summary for the issue tracker settings item-->

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -235,8 +235,6 @@
   <string name="open_log">打開日誌</string>
   <!--Summary for the log activity-->
   <string name="open_log_summary">開啟 Syncthing 及 Android 日誌視窗</string>
-  <string name="notify_crashes_title">通知關於 Syncthing 當機</string>
-  <string name="notify_crashes_summary">當偵測到 Syncthing 當機，顯示通知</string>
   <!--Settings item that opens issue tracker-->
   <string name="report_issue_title">回報問題</string>
   <!--Summary for the issue tracker settings item-->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -353,7 +353,7 @@ Please report any problems you encounter via Github.</string>
 
     <string name="use_root_title">Run Syncthing as Superuser</string>
 
-    <string name="use_root_summary">This is an unstable feature that may cause problems with Syncthing and with your device. If you encounter problems, you may have to reinstall Syncthing.</string>
+    <string name="use_root_summary">Running Syncthing as root allows it to write to folders Android normally restricts to be readonly accessed. Use this feature cautious.</string>
 
     <string name="notification_type_title">Notification</string>
 
@@ -516,11 +516,6 @@ Please report any problems you encounter via Github.</string>
 
     <!-- Summary for the log activity -->
     <string name="open_log_summary">Open the Syncthing and Android log window</string>
-
-    <string name="notify_crashes_title">Notify about Syncthing crashes</string>
-
-    <string name="notify_crashes_summary">Show a notification whenever a Syncthing crash is detected</string>
-
     <!-- Settings item that opens issue tracker -->
     <string name="report_issue_title">Report Issue</string>
 

--- a/app/src/main/res/xml/app_settings.xml
+++ b/app/src/main/res/xml/app_settings.xml
@@ -68,6 +68,12 @@
         android:title="@string/category_behaviour">
 
         <CheckBoxPreference
+            android:key="use_root"
+            android:title="@string/use_root_title"
+            android:summary="@string/use_root_summary"
+            android:defaultValue="false" />
+
+        <CheckBoxPreference
             android:key="advanced_folder_picker"
             android:title="@string/advanced_folder_picker"
             android:summary="@string/advanced_folder_picker_summary"
@@ -210,11 +216,6 @@
                 android:action=".activities.LogActivity" />
         </Preference>
 
-        <CheckBoxPreference
-            android:key="notify_crashes"
-            android:title="@string/notify_crashes_title"
-            android:summary="@string/notify_crashes_summary"/>
-
         <com.nutomic.syncthingandroid.views.SttracePreference
             android:key="debug_facilities_enabled"
             android:title="@string/sttrace_title" />
@@ -240,12 +241,6 @@
     <PreferenceScreen
         android:title="@string/category_experimental"
         android:key="category_experimental">
-
-        <CheckBoxPreference
-            android:key="use_root"
-            android:title="@string/use_root_title"
-            android:summary="@string/use_root_summary"
-            android:defaultValue="false" />
 
         <CheckBoxPreference
             android:key="wakelock_while_binary_running"


### PR DESCRIPTION
Move pref "use_root" to behaviour category
Always show notification if syncthing binary crashed
fixes #https://github.com/Catfriend1/syncthing-android/issues/17
fixes #https://github.com/syncthing/syncthing-android/issues/1172
fixes #https://github.com/syncthing/syncthing-android/issues/1220