### PR TITLE
Fix crash when ignoring devices or folders (fixes #50)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/model/Config.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/model/Config.java
@@ -8,8 +8,8 @@ public class Config {
     public List<Folder> folders;
     public Gui gui;
     public Options options;
-    public List<String> ignoredFolders;
-    public List<String> ignoredDevices;
+    public List<PendingDevice> pendingDevices;
+    public List<RemoteIgnoredDevice> remoteIgnoredDevices;
 
     public class Gui {
         public boolean enabled;

--- a/app/src/main/java/com/nutomic/syncthingandroid/model/FolderIgnoreList.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/model/FolderIgnoreList.java
@@ -1,5 +1,9 @@
 package com.nutomic.syncthingandroid.model;
 
+/**
+ * To avoid name confusion:
+ * This is the exclude and include items list associated with every folder.
+ */
 public class FolderIgnoreList {
     public String[] expanded;
     public String[] ignore;

--- a/app/src/main/java/com/nutomic/syncthingandroid/model/IgnoredFolder.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/model/IgnoredFolder.java
@@ -1,0 +1,18 @@
+package com.nutomic.syncthingandroid.model;
+
+import android.text.TextUtils;
+
+public class IgnoredFolder {
+    public String time = "";
+    public String id = "";
+    public String label = "";
+
+    /**
+     * Returns the folder label, or the first characters of the ID if the label is empty.
+     */
+    public String getDisplayLabel() {
+        return (TextUtils.isEmpty(label))
+                ? id.substring(0, 7)
+                : label;
+    }
+}

--- a/app/src/main/java/com/nutomic/syncthingandroid/model/PendingDevice.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/model/PendingDevice.java
@@ -2,18 +2,11 @@ package com.nutomic.syncthingandroid.model;
 
 import android.text.TextUtils;
 
-import java.util.List;
-
-public class Device {
-    public String deviceID;
+public class PendingDevice {
+    public String time = "";
+    public String deviceID = "";
     public String name = "";
-    public List<String> addresses;
-    public String compression;
-    public String certName;
-    public boolean introducer;
-    public boolean paused;
-    public List<PendingFolder> pendingFolders;
-    public List<IgnoredFolder> ignoredFolders;
+    public String address = "";
 
     /**
      * Returns the device name, or the first characters of the ID if the name is empty.

--- a/app/src/main/java/com/nutomic/syncthingandroid/model/PendingFolder.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/model/PendingFolder.java
@@ -1,0 +1,18 @@
+package com.nutomic.syncthingandroid.model;
+
+import android.text.TextUtils;
+
+public class PendingFolder {
+    public String time = "";
+    public String id = "";
+    public String label = "";
+
+    /**
+     * Returns the folder label, or the first characters of the ID if the label is empty.
+     */
+    public String getDisplayLabel() {
+        return (TextUtils.isEmpty(label))
+                ? id.substring(0, 7)
+                : label;
+    }
+}

--- a/app/src/main/java/com/nutomic/syncthingandroid/model/RemoteIgnoredDevice.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/model/RemoteIgnoredDevice.java
@@ -2,18 +2,11 @@ package com.nutomic.syncthingandroid.model;
 
 import android.text.TextUtils;
 
-import java.util.List;
-
-public class Device {
-    public String deviceID;
+public class RemoteIgnoredDevice {
+    public String time = "";
+    public String deviceID = "";
     public String name = "";
-    public List<String> addresses;
-    public String compression;
-    public String certName;
-    public boolean introducer;
-    public boolean paused;
-    public List<PendingFolder> pendingFolders;
-    public List<IgnoredFolder> ignoredFolders;
+    public String address = "";
 
     /**
      * Returns the device name, or the first characters of the ID if the name is empty.

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/EventProcessor.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/EventProcessor.java
@@ -275,6 +275,7 @@ public class EventProcessor implements  Runnable, RestApi.OnReceiveEventListener
         // Prepare "ignore" action.
         Intent intentIgnore = new Intent(mContext, SyncthingService.class)
                 .putExtra(SyncthingService.EXTRA_NOTIFICATION_ID, notificationId)
+                .putExtra(SyncthingService.EXTRA_DEVICE_ID, deviceId)
                 .putExtra(SyncthingService.EXTRA_FOLDER_ID, folderId);
         intentIgnore.setAction(SyncthingService.ACTION_IGNORE_FOLDER);
         PendingIntent piIgnore = PendingIntent.getService(mContext, 0,

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
@@ -259,7 +259,7 @@ public class SyncthingService extends Service {
             mNotificationHandler.cancelConsentNotification(intent.getIntExtra(EXTRA_NOTIFICATION_ID, 0));
         } else if (ACTION_IGNORE_FOLDER.equals(intent.getAction()) && mCurrentState == State.ACTIVE) {
             // mApi is not null due to State.ACTIVE
-            mApi.ignoreFolder(intent.getStringExtra(EXTRA_FOLDER_ID));
+            mApi.ignoreFolder(intent.getStringExtra(EXTRA_DEVICE_ID), intent.getStringExtra(EXTRA_FOLDER_ID));
             mNotificationHandler.cancelConsentNotification(intent.getIntExtra(EXTRA_NOTIFICATION_ID, 0));
         } else if (ACTION_OVERRIDE_CHANGES.equals(intent.getAction()) && mCurrentState == State.ACTIVE) {
             mApi.overrideChanges(intent.getStringExtra(EXTRA_FOLDER_ID));


### PR DESCRIPTION
Purpose
Fix unignoring devices and folders
Improve performance of RestApi#getDevices

Related issues 
#50 

Testing
Verified working correctly on device lg-h815 running Android 7.1.2