### PR TITLE
Fix crash if key generation failed (fixes #55)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FirstStartActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FirstStartActivity.java
@@ -462,7 +462,7 @@ public class FirstStartActivity extends Activity {
     /**
      * Sets up the initial configuration and generates secure keys.
      */
-    private static class KeyGenerationTask extends AsyncTask<Void, Void, Void> {
+    private static class KeyGenerationTask extends AsyncTask<Void, String, Void> {
         private WeakReference<FirstStartActivity> refFirstStartActivity;
         ConfigXml configXml;
 
@@ -480,11 +480,23 @@ public class FirstStartActivity extends Activity {
             try {
                 configXml = new ConfigXml(firstStartActivity);
             } catch (ConfigXml.OpenConfigException e) {
-                TextView keygenStatus = firstStartActivity.findViewById(R.id.key_generation_status);
-                keygenStatus.setText(firstStartActivity.getString(R.string.config_create_failed));
+                publishProgress(firstStartActivity.getString(R.string.config_create_failed));
                 cancel(true);
             }
             return null;
+        }
+
+        @Override
+        protected void onProgressUpdate(String... values) {
+            super.onProgressUpdate(values);
+            if (values != null && values.length > 0) {
+                FirstStartActivity firstStartActivity = refFirstStartActivity.get();
+                if (firstStartActivity == null) {
+                    return;
+                }
+                TextView keygenStatus = firstStartActivity.findViewById(R.id.key_generation_status);
+                keygenStatus.setText(values[0]);
+            }
         }
 
         @Override

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -641,7 +641,7 @@ Bitte melden Sie auftretende Probleme via GitHub.</string>
     <string name="syncthing_terminated">Syncthing wurde beendet</string>
 
     <!-- Toast shown if syncthing failed to create or read the config -->
-    <string name="config_create_failed">Erstellen der Konfigurationsdatei fehlgeschalgen</string>
+    <string name="config_create_failed">Erstellen der Konfiguration fehlgeschlagen. Pruefe die logcat-Ausgabe!</string>
     <string name="config_read_failed">Fehler beim Lesen der Konfiguration. Sichere gegebenenfalls Daten aus deinen Sync-Ordnern zu sichern, lösche über die Android-Einstellungen die App-Daten und starte von vorn.</string>
 
     <!-- Toast shown if a config file crucial to operation is missing -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -649,7 +649,7 @@ Please report any problems you encounter via Github.</string>
     <string name="syncthing_terminated">Syncthing was terminated</string>
 
     <!-- Toast shown if syncthing failed to create or read the config -->
-    <string name="config_create_failed">Failed to create configuration.</string>
+    <string name="config_create_failed">Failed to create configuration. Check logcat output.</string>
     <string name="config_read_failed">Failed to read configuration. Consider backing up data from your sync folders, then clear this app\'s data from Android settings and launch it again.</string>
 
     <!-- Toast shown if a config file crucial to operation is missing -->


### PR DESCRIPTION
Purpose
Fix android.view.ViewRootImpl$CalledFromWrongThreadException if key generation failed (fixes #55)

Testing
Verified working on Android 8.1, samsung i9100.