### PR TITLE
Allow stopping the service manually when running as a service (fixes #63)

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,6 +48,10 @@ Please report any problems you encounter via Github.</string>
 
 
 
+    <!-- Title of the exit app when running as a service confirmation dialog -->
+    <string name="dialog_exit_while_running_as_service_title">Confirm to stop service</string>
+    <string name="dialog_exit_while_running_as_service_message">For your consideration: You configured Syncthing to run as a service. Therefore it monitors run conditions and syncs at any time in the background when conditions match. You should only stop the service manually if you ran into severe problems. Otherwise, uncheck running as a service in the settings. Would you like to stop the service now until the next device reboot?</string>
+
     <!-- Title of the "add folder" menu action -->
     <string name="add_folder">Add Folder</string>
 


### PR DESCRIPTION
Purpose
Allow stopping the service manually when running as a service in extraordinary cases to avoid the user has to reboot the phone

Related issue
#63 [FR] Exit button that can disable service mode

Testing
Verified working under Android 7.1.2, device lg-h815 at commit https://github.com/Catfriend1/syncthing-android/commit/6c7e3e7915afc347f311c0e7c1bec45ebd905a9b .