### PR TITLE
Disable wakelock experimental option on Android 6+

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
@@ -231,6 +231,12 @@ public class SettingsActivity extends SyncthingActivity {
 
             mRunOnMeteredWifi.setEnabled(mRunOnWifi.isChecked());
             mWifiSsidWhitelist.setEnabled(mRunOnWifi.isChecked());
+            /* Experimental options */
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                /* Wakelocks are only valid on Android 5 or lower. */
+                mUseWakelock.setEnabled(false);
+                mUseWakelock.setChecked(false);
+            }
 
             mCategorySyncthingOptions = findPreference("category_syncthing_options");
             setPreferenceCategoryChangeListener(mCategorySyncthingOptions, this::onSyncthingPreferenceChange);

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -434,7 +434,7 @@ Bitte melden Sie auftretende Probleme via GitHub.</string>
 
     <string name="keep_wakelock_while_binary_running">Prozessor wach halten während Syncthing läuft.</string>
 
-    <string name="keep_wakelock_while_binary_running_summary">Nutze dieses Einstellung, wenn du unerwartete Verbindungsabbrüche hast, während du im Batteriebetrieb arbeitest. Das wird zu einem erhöhten Energieverbrauch führen.</string>
+    <string name="keep_wakelock_while_binary_running_summary">Nur für Android 5 oder niedriger. Nutze diese Einstellung, wenn du unerwartete Verbindungsabbrüche hast, während du im Batteriebetrieb arbeitest. Das wird zu einem erhöhten Energieverbrauch führen.</string>
 
     <string name="use_tor_title">Tor benutzen</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -438,7 +438,7 @@ Please report any problems you encounter via Github.</string>
 
     <string name="keep_wakelock_while_binary_running">Keep the CPU awake while Syncthing is running</string>
 
-    <string name="keep_wakelock_while_binary_running_summary">Use this setting if you experience unexpected disconnects while operating on battery. This will result in increased battery consumption.</string>
+    <string name="keep_wakelock_while_binary_running_summary">Only for Android 5 or lower. Use this setting if you experience unexpected disconnects while operating on battery. This will result in increased battery consumption.</string>
 
     <string name="use_tor_title">Use Tor</string>
 

--- a/app/src/main/res/xml/app_settings.xml
+++ b/app/src/main/res/xml/app_settings.xml
@@ -243,12 +243,6 @@
         android:key="category_experimental">
 
         <CheckBoxPreference
-            android:key="wakelock_while_binary_running"
-            android:title="@string/keep_wakelock_while_binary_running"
-            android:summary="@string/keep_wakelock_while_binary_running_summary"
-            android:defaultValue="false" />
-
-        <CheckBoxPreference
             android:key="use_tor"
             android:title="@string/use_tor_title"
             android:summary="@string/use_tor_summary" />
@@ -269,6 +263,13 @@
             android:key="use_legacy_hashing"
             android:title="@string/use_legacy_hashing_title"
             android:summary="@string/use_legacy_hashing_summary" />
+
+        <!-- Only valid for Android < 6 -->
+        <CheckBoxPreference
+            android:key="wakelock_while_binary_running"
+            android:title="@string/keep_wakelock_while_binary_running"
+            android:summary="@string/keep_wakelock_while_binary_running_summary"
+            android:defaultValue="false" />
 
     </PreferenceScreen>
 


### PR DESCRIPTION
Purpose
Disable wakelock experimental option on Android 6+ as it's no longer valid for recent Android OS versions. Android Doze forcefully cancels wakelocks so setting them proved to be of no use.

Testing
Verified working on Xiaomi Mi8 running Android 8.1.0.
Issue that wakelocks don't help when the connection cannot be made during screen off periods was confirmed on Huawei P10 running Android 8.1.0.