### PR TITLE
Tell user if location is disabled but "run on selected" WiFi is enabled (fixes #16)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/fragments/StatusFragment.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/fragments/StatusFragment.java
@@ -226,14 +226,15 @@ public class StatusFragment extends ListFragment implements SyncthingService.OnS
      * while the user is looking at the current tab.
      */
     private void onTimerEvent() {
-        if (mServiceState != SyncthingService.State.ACTIVE) {
-            return;
-        }
         MainActivity mainActivity = (MainActivity) getActivity();
         if (mainActivity == null) {
             return;
         }
         if (mainActivity.isFinishing()) {
+            return;
+        }
+        if (mServiceState != SyncthingService.State.ACTIVE) {
+            updateStatus();
             return;
         }
         RestApi restApi = mainActivity.getApi();
@@ -243,6 +244,7 @@ public class StatusFragment extends ListFragment implements SyncthingService.OnS
         Log.v(TAG, "Invoking REST status queries");
         restApi.getSystemStatus(this::onReceiveSystemStatus);
         restApi.getConnections(this::onReceiveConnections);
+        // onReceiveSystemStatus, onReceiveConnections will call {@link #updateStatus}.
     }
 
     /**

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -634,6 +634,7 @@ Please report any problems you encounter via Github.</string>
     <string name="reason_not_on_whitelisted_wifi">Syncthing is not running as the current WiFi network\'s name is not whitelisted.</string>
     <string name="reason_on_nonmetered_wifi">Syncthing is allowed to run on non-metered WiFi connections. The active WiFi connection is non-metered.</string>
     <string name="reason_not_nonmetered_wifi">Syncthing is not running as you disallowed it to run on metered WiFi connections.</string>
+    <string name="reason_location_unavailable">You enabled \'Run on selected WiFi networks\' in the settings. Android location services are currently turned off. According to Android restrictions, Syncthing cannot determine the current WiFi network name to decide if it should run.</string>
     <string name="reason_on_flight_mode">Syncthing is running as you allowed it to run when flight mode is active.</string>
 
     <!-- SyncthingService -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -634,7 +634,7 @@ Please report any problems you encounter via Github.</string>
     <string name="reason_not_on_whitelisted_wifi">Syncthing is not running as the current WiFi network\'s name is not whitelisted.</string>
     <string name="reason_on_nonmetered_wifi">Syncthing is allowed to run on non-metered WiFi connections. The active WiFi connection is non-metered.</string>
     <string name="reason_not_nonmetered_wifi">Syncthing is not running as you disallowed it to run on metered WiFi connections.</string>
-    <string name="reason_location_unavailable">You enabled \'Run on selected WiFi networks\' in the settings. Android location services are currently turned off. According to Android restrictions, Syncthing cannot determine the current WiFi network name to decide if it should run.</string>
+    <string name="reason_location_unavailable">You enabled \'Run on selected WiFi networks\' in the settings. Android location services are currently turned off. According to Android restrictions, Syncthing cannot determine the current WiFi network name to decide if it should run. Solution: Turn location on and reconnect WiFi.</string>
     <string name="reason_on_flight_mode">Syncthing is running as you allowed it to run when flight mode is active.</string>
 
     <!-- SyncthingService -->


### PR DESCRIPTION
Purpose:
1) Update status tab while user looks at the UI and syncthing is disabled
2) Tell user if location is disabled but "run on selected" WiFi is enabled.

Related issue:
#16 "Wifi run condition needs location to be turned on (Android 8+)"

Testing:
Verified working on AVD Android 9.0 at commit https://github.com/Catfriend1/syncthing-android/pull/87/commits/7b6a0eca003fc1d6e55521afed46d02154d86dbe .