### PR TITLE
Preserve xml encoding on read, parse and save (fixes #88)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/util/ConfigXml.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/ConfigXml.java
@@ -21,7 +21,6 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.OutputStreamWriter;
 import java.io.UnsupportedEncodingException;
-
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Locale;
@@ -112,7 +111,7 @@ public class ConfigXml {
             Log.d(TAG, "Parsing config file '" + mConfigFile + "'");
             mConfig = db.parse(inputSource);
             inputStream.close();
-            Log.i(TAG, "Sucessfully parsed config file");
+            Log.i(TAG, "Successfully parsed config file");
         } catch (SAXException | ParserConfigurationException | IOException e) {
             Log.w(TAG, "Failed to parse config file '" + mConfigFile + "'", e);
             throw new OpenConfigException();
@@ -256,12 +255,6 @@ public class ConfigXml {
              * with the fsWatcher GUI notification.
              */
             iConfigVersion = 28;
-        }
-
-        NodeList folders = mConfig.getDocumentElement().getElementsByTagName("folder");
-        for (int i = 0; i < folders.getLength(); i++) {
-            Element r = (Element) folders.item(i);
-            Log.v(TAG, "folder -" + r.getAttribute("label") + "-");
         }
 
         if (iConfigVersion != iOldConfigVersion) {

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/ConfigXml.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/ConfigXml.java
@@ -359,8 +359,6 @@ public class ConfigXml {
         Log.i(TAG, "Writing updated config file");
         File mConfigTempFile = Constants.getConfigTempFile(mContext);
         try {
-            mConfig.setXmlStandalone(true);
-
             // Write XML header.
             FileOutputStream fileOutputStream = new FileOutputStream(mConfigTempFile);
             fileOutputStream.write("<?xml version=\"1.0\" encoding=\"UTF-8\"?>".getBytes("UTF-8"));
@@ -374,12 +372,10 @@ public class ConfigXml {
             transformer.setOutputProperty(OutputKeys.INDENT, "no");
 
             // Output XML body.
-            // transformer.transform(new DOMSource(mConfig), new StreamResult(fileOutputStream));
-            ByteArrayOutputStream bos = new ByteArrayOutputStream();
-            StreamResult sr = new StreamResult(new OutputStreamWriter(bos, "UTF-8"));
-            transformer.transform(new DOMSource(mConfig), sr);
-            byte[] outputBytes = bos.toByteArray();
-            //bos.writeTo(fileOutputStream);
+            ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+            StreamResult streamResult = new StreamResult(new OutputStreamWriter(byteArrayOutputStream, "UTF-8"));
+            transformer.transform(new DOMSource(mConfig), streamResult);
+            byte[] outputBytes = byteArrayOutputStream.toByteArray();
             fileOutputStream.write(outputBytes);
             fileOutputStream.close();
         } catch (TransformerException e) {


### PR DESCRIPTION
Purpose
Preserve xml encoding on read, parse and save (fixes #88)

Related issue
#88 "UTF-8 (emoji) replaced by "characters" when restarting"
https://github.com/syncthing/syncthing-android/issues/1234

Testing
Verified working on Android 9.0 (AVD).
![image](https://user-images.githubusercontent.com/16361913/46832197-b7198100-cda5-11e8-83e7-3d5e089cf6d5.png)
![image](https://user-images.githubusercontent.com/16361913/46832207-bd0f6200-cda5-11e8-8ce8-b03fe1319edd.png)
![image](https://user-images.githubusercontent.com/16361913/46832221-c8628d80-cda5-11e8-910b-282b3b4ffe55.png)
![image](https://user-images.githubusercontent.com/16361913/46832227-cc8eab00-cda5-11e8-98be-1ae84ebb01a8.png)
![image](https://user-images.githubusercontent.com/16361913/46832239-d31d2280-cda5-11e8-8e79-72c5f33ec88b.png)
