### PR TITLE
Default global pref PREF_RUN_ON_WIFI to true

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SyncConditionsActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SyncConditionsActivity.java
@@ -116,7 +116,7 @@ public class SyncConditionsActivity extends SyncthingActivity
         /**
          * Load global run conditions.
          */
-        Boolean globalRunOnWifiEnabled = mPreferences.getBoolean(Constants.PREF_RUN_ON_WIFI, false);
+        Boolean globalRunOnWifiEnabled = mPreferences.getBoolean(Constants.PREF_RUN_ON_WIFI, true);
         Boolean globalWhitelistEnabled = !mPreferences.getStringSet(Constants.PREF_WIFI_SSID_WHITELIST, new HashSet<>())
                 .isEmpty();
         Set<String> globalWhitelistedSsid = mPreferences.getStringSet(Constants.PREF_WIFI_SSID_WHITELIST, new HashSet<>());


### PR DESCRIPTION
Default global pref PREF_RUN_ON_WIFI to true in SyncConditionsActivity, according to definition in app_settings.xml

This fixes a minor UI glitch where after fresh installation individual sync conditions aren't available until the user opens (and closes) the global run conditions settings screen first.

Follow-up PR for #66 