### PR TITLE
Add individual sync conditions for devices

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,8 +35,8 @@ android {
         applicationId "com.github.catfriend1.syncthingandroid"
         minSdkVersion 16
         targetSdkVersion 26
-        versionCode 4169
-        versionName "0.14.51.6"
+        versionCode 4170
+        versionName "0.14.51.7"
         testApplicationId 'com.github.catfriend1.syncthingandroid.test'
         testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
         playAccountConfig = playAccountConfigs.defaultAccountConfig

--- a/app/src/main/java/com/nutomic/syncthingandroid/DaggerComponent.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/DaggerComponent.java
@@ -27,7 +27,7 @@ public interface DaggerComponent {
     void inject(SyncthingApp app);
     void inject(MainActivity activity);
     void inject(FirstStartActivity activity);
-    void Inject(DeviceActivity activity);
+    void inject(DeviceActivity activity);
     void inject(FolderActivity activity);
     void inject(FolderPickerActivity activity);
     void inject(SyncConditionsActivity activity);

--- a/app/src/main/java/com/nutomic/syncthingandroid/DaggerComponent.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/DaggerComponent.java
@@ -1,5 +1,6 @@
 package com.nutomic.syncthingandroid;
 
+import com.nutomic.syncthingandroid.activities.DeviceActivity;
 import com.nutomic.syncthingandroid.activities.FirstStartActivity;
 import com.nutomic.syncthingandroid.activities.FolderActivity;
 import com.nutomic.syncthingandroid.activities.FolderPickerActivity;
@@ -26,6 +27,7 @@ public interface DaggerComponent {
     void inject(SyncthingApp app);
     void inject(MainActivity activity);
     void inject(FirstStartActivity activity);
+    void Inject(DeviceActivity activity);
     void inject(FolderActivity activity);
     void inject(FolderPickerActivity activity);
     void inject(SyncConditionsActivity activity);

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
@@ -263,7 +263,6 @@ public class FolderActivity extends SyncthingActivity
     /**
      * Invoked after user clicked on the {@link mCustomSyncConditionsDialog} label.
      */
-    @SuppressLint("InlinedAPI")
     private void onCustomSyncConditionsDialogClick() {
         startActivityForResult(
             SyncConditionsActivity.createIntent(

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
@@ -366,7 +366,7 @@ public class FolderActivity extends SyncthingActivity
     }
 
     /**
-     * Save current settings in case we are in create mode and they aren't yet stored in the config.
+     * Register for service state change events.
      */
     @Override
     public void onServiceConnected() {
@@ -700,9 +700,17 @@ public class FolderActivity extends SyncthingActivity
         deviceView.setOnCheckedChangeListener(mCheckedListener);
     }
 
+    /**
+     * Sends the updated folder info if in edit mode.
+     * Preconditions: mFolderNeedsToUpdate == true
+     */
     private void updateFolder() {
         if (mIsCreateMode) {
             // If we are about to create this folder, we cannot update via restApi.
+            return;
+        }
+        if (mFolder == null) {
+            Log.e(TAG, "updateFolder: mFolder == null");
             return;
         }
 
@@ -715,18 +723,13 @@ public class FolderActivity extends SyncthingActivity
         );
         editor.apply();
 
-        // Update folder via restApi.
+        // Update folder via restApi and send the config to REST endpoint.
         RestApi restApi = getApi();
-        /**
-         * RestApi is guaranteed not to be null as {@link onServiceStateChange}
-         * immediately finishes this activity if SyncthingService shuts down.
-         */
-        /*
         if (restApi == null) {
             Log.e(TAG, "updateFolder: restApi == null");
             return;
         }
-        */
+
         // Update ignore list.
         String[] ignore = mEditIgnoreListContent.getText().toString().split("\n");
         restApi.postFolderIgnoreList(mFolder.id, ignore);

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
@@ -105,6 +105,7 @@ public class SettingsActivity extends SyncthingActivity {
         private CheckBoxPreference mRunOnMobileData;
         private CheckBoxPreference mRunOnWifi;
         private CheckBoxPreference mRunOnMeteredWifi;
+        private CheckBoxPreference mUseWifiWhitelist;
         private WifiSsidPreference mWifiSsidWhitelist;
         private CheckBoxPreference mRunInFlightMode;
 
@@ -173,6 +174,8 @@ public class SettingsActivity extends SyncthingActivity {
                     (CheckBoxPreference) findPreference(Constants.PREF_RUN_ON_WIFI);
             mRunOnMeteredWifi =
                     (CheckBoxPreference) findPreference(Constants.PREF_RUN_ON_METERED_WIFI);
+            mUseWifiWhitelist =
+                    (CheckBoxPreference) findPreference(Constants.PREF_USE_WIFI_SSID_WHITELIST);
             mWifiSsidWhitelist =
                     (WifiSsidPreference) findPreference(Constants.PREF_WIFI_SSID_WHITELIST);
             mRunInFlightMode =
@@ -225,7 +228,8 @@ public class SettingsActivity extends SyncthingActivity {
             Preference appVersion   = screen.findPreference("app_version");
 
             mRunOnMeteredWifi.setEnabled(mRunOnWifi.isChecked());
-            mWifiSsidWhitelist.setEnabled(mRunOnWifi.isChecked());
+            mUseWifiWhitelist.setEnabled(mRunOnWifi.isChecked());
+            mWifiSsidWhitelist.setEnabled(mRunOnWifi.isChecked() && mUseWifiWhitelist.isChecked());
             /* Experimental options */
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                 /* Wakelocks are only valid on Android 5 or lower. */
@@ -262,7 +266,7 @@ public class SettingsActivity extends SyncthingActivity {
             screen.findPreference(Constants.PREF_POWER_SOURCE).setSummary(mPowerSource.getEntry());
             String wifiSsidSummary = TextUtils.join(", ", mPreferences.getStringSet(Constants.PREF_WIFI_SSID_WHITELIST, new HashSet<>()));
             screen.findPreference(Constants.PREF_WIFI_SSID_WHITELIST).setSummary(TextUtils.isEmpty(wifiSsidSummary) ?
-                getString(R.string.run_on_all_wifi_networks) :
+                getString(R.string.wifi_ssid_whitelist_empty) :
                 getString(R.string.run_on_whitelisted_wifi_networks, wifiSsidSummary)
             );
             handleSocksProxyPreferenceChange(screen.findPreference(Constants.PREF_SOCKS_PROXY_ADDRESS),  mPreferences.getString(Constants.PREF_SOCKS_PROXY_ADDRESS, ""));
@@ -366,12 +370,16 @@ public class SettingsActivity extends SyncthingActivity {
                     break;
                 case Constants.PREF_RUN_ON_WIFI:
                     mRunOnMeteredWifi.setEnabled((Boolean) o);
+                    mUseWifiWhitelist.setEnabled((Boolean) o);
+                    mWifiSsidWhitelist.setEnabled((Boolean) o && mUseWifiWhitelist.isChecked());
+                    break;
+                case Constants.PREF_USE_WIFI_SSID_WHITELIST:
                     mWifiSsidWhitelist.setEnabled((Boolean) o);
                     break;
                 case Constants.PREF_WIFI_SSID_WHITELIST:
                     String wifiSsidSummary = TextUtils.join(", ", (Set<String>) o);
                     preference.setSummary(TextUtils.isEmpty(wifiSsidSummary) ?
-                        getString(R.string.run_on_all_wifi_networks) :
+                        getString(R.string.wifi_ssid_whitelist_empty) :
                         getString(R.string.run_on_whitelisted_wifi_networks, wifiSsidSummary)
                     );
                     break;

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
@@ -386,7 +386,7 @@ public class SettingsActivity extends SyncthingActivity {
                 case "deviceName":
                     Device localDevice = mRestApi.getLocalDevice();
                     localDevice.name = (String) o;
-                    mRestApi.editDevice(localDevice);
+                    mRestApi.updateDevice(localDevice);
                     break;
                 case "listenAddresses":
                     mOptions.listenAddresses = Iterables.toArray(splitter.split((String) o), String.class);

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SyncConditionsActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SyncConditionsActivity.java
@@ -118,9 +118,8 @@ public class SyncConditionsActivity extends SyncthingActivity
          * Load global run conditions.
          */
         Boolean globalRunOnWifiEnabled = mPreferences.getBoolean(Constants.PREF_RUN_ON_WIFI, true);
-        Boolean globalWhitelistEnabled = !mPreferences.getStringSet(Constants.PREF_WIFI_SSID_WHITELIST, new HashSet<>())
-                .isEmpty();
         Set<String> globalWhitelistedSsid = mPreferences.getStringSet(Constants.PREF_WIFI_SSID_WHITELIST, new HashSet<>());
+        Boolean globalWhitelistEnabled = !globalWhitelistedSsid.isEmpty();
         Boolean globalRunOnMeteredWifiEnabled = mPreferences.getBoolean(Constants.PREF_RUN_ON_METERED_WIFI, false);
         Boolean globalRunOnMobileDataEnabled = mPreferences.getBoolean(Constants.PREF_RUN_ON_MOBILE_DATA, false);
 
@@ -144,7 +143,7 @@ public class SyncConditionsActivity extends SyncthingActivity
         mSyncOnMobileData.setOnCheckedChangeListener(mCheckedListener);
 
         // Read selected WiFi Ssid whitelist items.
-        Set<String> selectedWhitelistedSsid = mPreferences.getStringSet(mPrefSelectedWhitelistSsid, new HashSet<>());
+        Set<String> selectedWhitelistedSsid = mPreferences.getStringSet(mPrefSelectedWhitelistSsid, globalWhitelistedSsid);
         // Removes any network that is no longer part of the global WiFi Ssid whitelist.
         selectedWhitelistedSsid.retainAll(globalWhitelistedSsid);
 

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SyncConditionsActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SyncConditionsActivity.java
@@ -109,7 +109,7 @@ public class SyncConditionsActivity extends SyncthingActivity
         mObjectPrefixAndId = intent.getStringExtra(EXTRA_OBJECT_PREFIX_AND_ID);
         Log.v(TAG, "Prefix is \'" + mObjectPrefixAndId + "\' (" + mObjectReadableName + ")");
         mPrefSyncOnWifi = Constants.DYN_PREF_OBJECT_SYNC_ON_WIFI(mObjectPrefixAndId);
-        mPrefSyncOnWhitelistedWifi = Constants.DYN_PREF_OBJECT_SYNC_ON_WHITELISTED_WIFI(mObjectPrefixAndId);
+        mPrefSyncOnWhitelistedWifi = Constants.DYN_PREF_OBJECT_USE_WIFI_SSID_WHITELIST(mObjectPrefixAndId);
         mPrefSelectedWhitelistSsid = Constants.DYN_PREF_OBJECT_SELECTED_WHITELIST_SSID(mObjectPrefixAndId);
         mPrefSyncOnMeteredWifi = Constants.DYN_PREF_OBJECT_SYNC_ON_METERED_WIFI(mObjectPrefixAndId);
         mPrefSyncOnMobileData = Constants.DYN_PREF_OBJECT_SYNC_ON_MOBILE_DATA(mObjectPrefixAndId);
@@ -119,7 +119,7 @@ public class SyncConditionsActivity extends SyncthingActivity
          */
         Boolean globalRunOnWifiEnabled = mPreferences.getBoolean(Constants.PREF_RUN_ON_WIFI, true);
         Set<String> globalWhitelistedSsid = mPreferences.getStringSet(Constants.PREF_WIFI_SSID_WHITELIST, new HashSet<>());
-        Boolean globalWhitelistEnabled = !globalWhitelistedSsid.isEmpty();
+        Boolean globalWhitelistEnabled = mPreferences.getBoolean(Constants.PREF_USE_WIFI_SSID_WHITELIST, false);
         Boolean globalRunOnMeteredWifiEnabled = mPreferences.getBoolean(Constants.PREF_RUN_ON_METERED_WIFI, false);
         Boolean globalRunOnMobileDataEnabled = mPreferences.getBoolean(Constants.PREF_RUN_ON_MOBILE_DATA, false);
 
@@ -162,7 +162,7 @@ public class SyncConditionsActivity extends SyncthingActivity
             setMarginEnd(params, contentInset);
             TextView emptyView = new TextView(mWifiSsidContainer.getContext());
             emptyView.setGravity(CENTER_VERTICAL);
-            emptyView.setText(R.string.wifi_ssid_whitelist_empty);
+            emptyView.setText(R.string.custom_wifi_ssid_whitelist_empty);
             mWifiSsidContainer.addView(emptyView, params);
             mWifiSsidContainer.setEnabled(false);
         } else {

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SyncConditionsActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SyncConditionsActivity.java
@@ -60,7 +60,8 @@ public class SyncConditionsActivity extends SyncthingActivity
     private SwitchCompat mSyncOnMobileData;
 
     /**
-     * Shared preferences names for custom per-folder settings.
+     * Shared preferences names for custom object settings.
+     * Object can e.g. be a folder or device.
      */
     private String mObjectPrefixAndId;
     private String mPrefSyncOnWifi;
@@ -124,7 +125,7 @@ public class SyncConditionsActivity extends SyncthingActivity
         Boolean globalRunOnMobileDataEnabled = mPreferences.getBoolean(Constants.PREF_RUN_ON_MOBILE_DATA, false);
 
         /**
-         * Load custom folder preferences. If unset, use global setting as default.
+         * Load custom object preferences. If unset, use global setting as default.
          */
         mSyncOnWifi.setChecked(globalRunOnWifiEnabled && mPreferences.getBoolean(mPrefSyncOnWifi, globalRunOnWifiEnabled));
         mSyncOnWifi.setEnabled(globalRunOnWifiEnabled);
@@ -224,7 +225,7 @@ public class SyncConditionsActivity extends SyncthingActivity
         if (mUnsavedChanges) {
             Log.v(TAG, "onPause: mUnsavedChanges == true. Saving prefs ...");
             /**
-             * Save custom folder preferences.
+             * Save custom object preferences.
              */
             SharedPreferences.Editor editor = mPreferences.edit();
             editor.putBoolean(mPrefSyncOnWifi, mSyncOnWifi.isChecked());

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
@@ -15,6 +15,7 @@ public class Constants {
     public static final String PREF_RUN_ON_MOBILE_DATA          = "run_on_mobile_data";
     public static final String PREF_RUN_ON_WIFI                 = "run_on_wifi";
     public static final String PREF_RUN_ON_METERED_WIFI         = "run_on_metered_wifi";
+    public static final String PREF_USE_WIFI_SSID_WHITELIST     = "use_wifi_whitelist";
     public static final String PREF_WIFI_SSID_WHITELIST         = "wifi_ssid_whitelist";
     public static final String PREF_POWER_SOURCE                = "power_source";
     public static final String PREF_RESPECT_BATTERY_SAVING      = "respect_battery_saving";
@@ -43,8 +44,8 @@ public class Constants {
         return objectPrefixAndId + "_" + PREF_RUN_ON_WIFI;
     }
 
-    public static String DYN_PREF_OBJECT_SYNC_ON_WHITELISTED_WIFI(String objectPrefixAndId) {
-        return objectPrefixAndId + "_" + "use_wifi_whitelist";
+    public static String DYN_PREF_OBJECT_USE_WIFI_SSID_WHITELIST(String objectPrefixAndId) {
+        return objectPrefixAndId + "_" + PREF_USE_WIFI_SSID_WHITELIST;
     }
 
     public static String DYN_PREF_OBJECT_SELECTED_WHITELIST_SSID(String objectPrefixAndId) {

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/RunConditionMonitor.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/RunConditionMonitor.java
@@ -228,11 +228,13 @@ public class RunConditionMonitor {
     /**
      * Constants.PREF_WIFI_SSID_WHITELIST
      */
-    private SyncConditionResult checkConditionSyncOnWhitelistedWifi(String prefNameSyncOnWhitelistedWifi) {
-        Set<String> whitelistedWifiSsids = mPreferences.getStringSet(prefNameSyncOnWhitelistedWifi, new HashSet<>());
-        boolean prefWifiWhitelistEnabled = !whitelistedWifiSsids.isEmpty();
+    private SyncConditionResult checkConditionSyncOnWhitelistedWifi(
+            String prefNameSyncOnWhitelistedWifi,
+            String prefNameSelectedWhitelistSsid) {
+        boolean wifiWhitelistEnabled = mPreferences.getBoolean(prefNameSyncOnWhitelistedWifi, false);
+        Set<String> whitelistedWifiSsids = mPreferences.getStringSet(prefNameSelectedWhitelistSsid, new HashSet<>());
         try {
-            if (wifiWhitelistConditionMet(prefWifiWhitelistEnabled, whitelistedWifiSsids)) {
+            if (wifiWhitelistConditionMet(wifiWhitelistEnabled, whitelistedWifiSsids)) {
                 return new SyncConditionResult(true, "\n" + res.getString(R.string.reason_on_whitelisted_wifi));
             }
             return new SyncConditionResult(false, "\n" + res.getString(R.string.reason_not_on_whitelisted_wifi));
@@ -348,7 +350,7 @@ public class RunConditionMonitor {
                 // Wifi type is allowed.
                 Log.v(TAG, "decideShouldRun: checkConditionSyncOnWifi && checkConditionSyncOnMeteredWifi");
 
-                scr = checkConditionSyncOnWhitelistedWifi(Constants.PREF_WIFI_SSID_WHITELIST);
+                scr = checkConditionSyncOnWhitelistedWifi(Constants.PREF_USE_WIFI_SSID_WHITELIST, Constants.PREF_WIFI_SSID_WHITELIST);
                 mRunDecisionExplanation += scr.explanation;
                 if (scr.conditionMet) {
                     // Wifi is whitelisted.
@@ -395,7 +397,10 @@ public class RunConditionMonitor {
                 // Wifi type is allowed.
                 Log.v(TAG, "checkObjectSyncConditions: checkConditionSyncOnWifi && checkConditionSyncOnMeteredWifi");
 
-                scr = checkConditionSyncOnWhitelistedWifi(Constants.DYN_PREF_OBJECT_SELECTED_WHITELIST_SSID(objectPrefixAndId));
+                scr = checkConditionSyncOnWhitelistedWifi(
+                    Constants.DYN_PREF_OBJECT_USE_WIFI_SSID_WHITELIST(objectPrefixAndId),
+                    Constants.DYN_PREF_OBJECT_SELECTED_WHITELIST_SSID(objectPrefixAndId)
+                );
                 if (scr.conditionMet) {
                     // Wifi is whitelisted.
                     Log.v(TAG, "checkObjectSyncConditions: checkConditionSyncOnWifi && checkConditionSyncOnMeteredWifi && checkConditionSyncOnWhitelistedWifi");

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/RunConditionMonitor.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/RunConditionMonitor.java
@@ -229,9 +229,9 @@ public class RunConditionMonitor {
      * Constants.PREF_WIFI_SSID_WHITELIST
      */
     private SyncConditionResult checkConditionSyncOnWhitelistedWifi(
-            String prefNameSyncOnWhitelistedWifi,
+            String prefNameUseWifiWhitelist,
             String prefNameSelectedWhitelistSsid) {
-        boolean wifiWhitelistEnabled = mPreferences.getBoolean(prefNameSyncOnWhitelistedWifi, false);
+        boolean wifiWhitelistEnabled = mPreferences.getBoolean(prefNameUseWifiWhitelist, false);
         Set<String> whitelistedWifiSsids = mPreferences.getStringSet(prefNameSelectedWhitelistSsid, new HashSet<>());
         try {
             if (wifiWhitelistConditionMet(wifiWhitelistEnabled, whitelistedWifiSsids)) {

--- a/app/src/main/play/en-GB/whatsnew
+++ b/app/src/main/play/en-GB/whatsnew
@@ -1,5 +1,5 @@
 Enhancements
-* Specify sync conditions differently for each folder [NEW]
+* Specify sync conditions differently for each folder, device [NEW]
 * UI explains why syncthing is running (or not)
 * Support in-app editing of folder's ignore list items
 Fixes

--- a/app/src/main/res/layout/fragment_device.xml
+++ b/app/src/main/res/layout/fragment_device.xml
@@ -122,6 +122,59 @@
                 android:drawableStart="@drawable/ic_pause_circle_outline_black_24dp"
                 android:text="@string/pause_device" />
 
+            <!-- Custom sync conditions -->
+            <LinearLayout
+                android:id="@+id/customSyncConditionsContainer"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="?selectableItemBackground"
+                android:orientation="vertical"
+                android:gravity="center_vertical">
+
+                <android.support.v7.widget.SwitchCompat
+                    android:id="@+id/customSyncConditionsSwitch"
+                    style="@style/Widget.Syncthing.TextView.Label.Details"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:checked="false"
+                    android:drawableLeft="@drawable/ic_autorenew_black_24dp"
+                    android:drawableStart="@drawable/ic_autorenew_black_24dp"
+                    android:text="@string/custom_sync_conditions_title" />
+
+                <TextView
+                    android:id="@+id/customSyncConditionsDescription"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="75dp"
+                    android:layout_marginStart="75dp"
+                    android:layout_marginTop="-20dp"
+                    android:textAppearance="@style/TextAppearance.AppCompat.Caption"
+                    android:text="@string/custom_sync_conditions_description"
+                    android:focusable="false"/>
+
+                <TextView
+                    android:id="@+id/customSyncConditionsDialog"
+                    style="@style/Widget.Syncthing.TextView.Label.Details"
+                    android:layout_marginLeft="56dp"
+                    android:layout_marginStart="56dp"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:focusable="true"
+                    android:text="@string/custom_sync_conditions_dialog"/>
+
+                <TextView
+                    android:id="@+id/customSyncConditionsCurrent"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="75dp"
+                    android:layout_marginStart="75dp"
+                    android:layout_marginTop="-20dp"
+                    android:textAppearance="@style/TextAppearance.AppCompat.Caption"
+                    android:text="@null"
+                    android:focusable="false"/>
+
+            </LinearLayout>
+
             <TextView
                 android:id="@+id/currentAddress"
                 style="@style/Widget.Syncthing.TextView.Label.Details"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -316,8 +316,10 @@ Please report any problems you encounter via Github.</string>
     <string name="run_on_metered_wifi_summary">Run when device is connected to a metered Wi-Fi network e.g. a hotspot or tethered network. Attention: This can consume large portion of your data plan if you sync a lot of data.</string>
 
     <string name="run_on_whitelisted_wifi_title">Run on specified Wi-Fi networks</string>
-    <string name="run_on_whitelisted_wifi_networks">Run only on selected Wi-Fi networks: %1$s</string>
+    <string name="specify_wifi_ssid_whitelist">Select Wi-Fi networks</string>
+    <string name="run_on_whitelisted_wifi_networks">Selected Wi-Fi networks: %1$s</string>
     <string name="run_on_all_wifi_networks">Run on all Wi-Fi networks.</string>
+    <string name="wifi_ssid_whitelist_empty">No Wi-Fi networks specified. Click to specify networks.</string>
 
     <string name="sync_only_wifi_ssids_wifi_turn_on_wifi">Please turn on Wi-Fi to select networks.</string>
 
@@ -627,7 +629,7 @@ Please report any problems you encounter via Github.</string>
 
     <!-- Sync Conditions Dialog -->
 
-    <string name="wifi_ssid_whitelist_empty">No WiFi SSID\'s whitelisted. Please specify some in the settings.</string>
+    <string name="custom_wifi_ssid_whitelist_empty">No WiFi SSID\'s whitelisted. Please specify some in the settings.</string>
 
     <!-- SyncthingService -->
 

--- a/app/src/main/res/xml/app_settings.xml
+++ b/app/src/main/res/xml/app_settings.xml
@@ -12,23 +12,34 @@
             android:title="@string/run_conditions_title"
             android:summary="@string/run_conditions_summary"/>
 
+        <!-- Sync on WiFi -->
         <CheckBoxPreference
             android:key="run_on_wifi"
             android:title="@string/run_on_wifi_title"
             android:summary="@string/run_on_wifi_summary"
             android:defaultValue="true" />
 
+        <!-- Sync on metered WiFi -->
         <CheckBoxPreference
             android:key="run_on_metered_wifi"
             android:title="@string/run_on_metered_wifi_title"
             android:summary="@string/run_on_metered_wifi_summary"
             android:defaultValue="false" />
 
+        <!-- Use WiFi Ssid whitelist -->
+        <CheckBoxPreference
+            android:key="use_wifi_whitelist"
+            android:title="@string/run_on_whitelisted_wifi_title"
+            android:summary="@string/run_on_whitelisted_wifi_summary"
+            android:defaultValue="false" />
+
+        <!-- Select whitelisted WiFi Ssid -->
         <com.nutomic.syncthingandroid.views.WifiSsidPreference
             android:key="wifi_ssid_whitelist"
-            android:title="@string/run_on_whitelisted_wifi_title"
+            android:title="@string/specify_wifi_ssid_whitelist"
             android:summary="@null" />
 
+        <!-- Sync on mobile data -->
         <CheckBoxPreference
             android:key="run_on_mobile_data"
             android:title="@string/run_on_mobile_data_title"


### PR DESCRIPTION
Purpose
Provide the ability to specify different sync conditions for each syncthing device through the wrapper UI.
Available conditions per device:
- Sync on WiFi
- Sync on specified WiFi
- Sync on metered WiFi
- Sync on mobile data

Follow-up PR, related to
#66 "Allow specifying different sync conditions per folder"

Related issues:
#57 "[FR] Feature Request: Different synchronization conditions per folder/device"
https://github.com/syncthing/syncthing-android/issues/511
https://github.com/syncthing/syncthing-android/issues/1186
https://github.com/syncthing/syncthing-android/issues/1225

Related bounty
https://www.bountysource.com/issues/28940393-enhancement-request-per-folder-sync-only-when-charging-on-wifi

Testing
Verified working on AVD with Android 9.x at commit https://github.com/Catfriend1/syncthing-android/pull/96/commits/07a22756940f10277296de90a65a209ae877fb2c .
