### PR TITLE
Add dialog if no compatible file manager was found (fixes #97)

### DIFF
--- a/app/src/main/res/values-ca-rES/strings.xml
+++ b/app/src/main/res/values-ca-rES/strings.xml
@@ -66,8 +66,6 @@ Ens podeu informar dels problemes que trobeu a través de Github.</string>
 
     <string name="open_file_manager">Obre l\'administrador d\'arxius</string>
 
-    <string name="toast_no_file_manager">No s\'ha trobat cap gestor de fitxers compatible</string>
-
     <!-- DevicesFragment -->
 
 

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -67,8 +67,6 @@ Všechny zaznamenané chyby prosím hlašte přes Github.</string>
         <item quantity="other">%1$d / %2$d souborů</item>
     </plurals>
 
-    <string name="toast_no_file_manager">Nenalezen žádný kompatibilní manažer souborů</string>
-
     <!-- DevicesFragment -->
 
 

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -63,8 +63,6 @@ Vær venlig at rapportere ethvert problem, du støder på, via Github. </string>
         <item quantity="other">%1$d/%2$d Filer</item>
     </plurals>
 
-    <string name="toast_no_file_manager">Ingen kompatibel file manager fundet</string>
-
     <!-- DevicesFragment -->
 
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -106,7 +106,9 @@ Bitte melden Sie auftretende Probleme via GitHub.</string>
 
     <string name="open_file_manager">Dateimanager öffnen</string>
 
-    <string name="toast_no_file_manager">Kein kompatibler Dateimanager gefunden</string>
+    <!-- Suggest File Manager App Dialog -->
+    <string name="suggest_file_manager_app_dialog_title">Kein kompatibler Dateimanager gefunden</string>
+    <string name="suggest_file_manager_app_dialog_text">Wir empfehlen Dir, die Open-Source App \"Simple File Manager\" aus F-Droid zu installieren. Möchtest Du ihre Seite im App-Store aufrufen?</string>
 
     <!-- DevicesFragment -->
 

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -63,8 +63,6 @@
         <item quantity="other">%1$d / %2$d αρχεία</item>
     </plurals>
 
-    <string name="toast_no_file_manager">Δεν βρέθηκε συμβατός διαχειριστής αρχείων</string>
-
     <!-- DevicesFragment -->
 
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -53,8 +53,6 @@
     <!-- Shown if no folders exist -->
     <string name="folder_list_empty">No se encontraron carpetas</string>
 
-    <string name="toast_no_file_manager">No se ha encontrado un gestor de ficheros compatible</string>
-
     <!-- DevicesFragment -->
 
 

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -66,8 +66,6 @@ Ilmoitathan ystävällisesti kaikista havaitsemistasi ongelmista Githubin kautta
 
     <string name="open_file_manager">Avaa tiedostonhallinta</string>
 
-    <string name="toast_no_file_manager">Yhteensopivaa tiedostonhallintaa ei löydy</string>
-
     <!-- DevicesFragment -->
 
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -68,8 +68,6 @@ S\'il vous plaît, soumettez les problèmes que vous rencontrez via Github.</str
 
     <string name="open_file_manager">Ouvrir le gestionnaire de fichiers</string>
 
-    <string name="toast_no_file_manager">Aucun gestionnaire de fichiers compatible n\'a été trouvé</string>
-
     <!-- DevicesFragment -->
 
 

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -72,8 +72,6 @@ Néhány eszközön extra alkalmazás-leállító alkalmazást telepített fel a
 
     <string name="open_file_manager">Fájlkezelő megnyitása</string>
 
-    <string name="toast_no_file_manager">Nem található kompatibilis fájlkezelő</string>
-
     <!-- DevicesFragment -->
 
 

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -60,8 +60,6 @@ Jika ada masalah silakan laporkan lewat Github.</string>
         <item quantity="other">%1$d / %2$d Berkas</item>
     </plurals>
 
-    <string name="toast_no_file_manager">Tidak ada file manager yang kompatibel yang ditemukan</string>
-
     <!-- DevicesFragment -->
 
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -68,8 +68,6 @@ Si prega di segnalare eventuali problemi che si incontrano via Github.</string>
 
     <string name="open_file_manager">Apri il file manager</string>
 
-    <string name="toast_no_file_manager">Nessun gestore file compatibile rilevato</string>
-
     <!-- DevicesFragment -->
 
 

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -64,8 +64,6 @@
         <item quantity="other">%1$d / %2$d ファイル</item>
     </plurals>
 
-    <string name="toast_no_file_manager">互換性のあるファイルマネージャーが見つかりません</string>
-
     <!-- DevicesFragment -->
 
 

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -62,8 +62,6 @@
         <item quantity="other">%1$d / %2$d 파일</item>
     </plurals>
 
-    <string name="toast_no_file_manager">호환되는 파일 매니저를 찾을 수 없습니다</string>
-
     <!-- DevicesFragment -->
 
 

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -68,8 +68,6 @@ Als je problemen tegenkomt, meld ze dan via GitHub.</string>
 
     <string name="open_file_manager">Bestandsbeheerder openen</string>
 
-    <string name="toast_no_file_manager">Geen compatibele bestandsbeheerder gevonden</string>
-
     <!-- DevicesFragment -->
 
 

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -67,8 +67,6 @@ Proszę zgłaszać napotkane błędy programu za pośrednictwem serwisu Github.<
         <item quantity="other">%1$d / %2$d</item>
     </plurals>
 
-    <string name="toast_no_file_manager">Nie znaleziono kompatybilnego menadżera plików</string>
-
     <!-- DevicesFragment -->
 
 

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -68,8 +68,6 @@ Por favor, nos avise sobre quaisquer problemas que você encontrar via Github.</
 
     <string name="open_file_manager">Abrir gerenciador de arquivos</string>
 
-    <string name="toast_no_file_manager">Nenhum gerenciador de arquivos compatível foi encontrado</string>
-
     <!-- DevicesFragment -->
 
 

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -55,8 +55,6 @@ Reporte, através do Github, quaisquer problemas que encontre, por favor.</strin
     <!-- Shown if no folders exist -->
     <string name="folder_list_empty">Não foram encontradas quaisquer pastas</string>
 
-    <string name="toast_no_file_manager">Não foi encontrado um gestor de ficheiros compatível</string>
-
     <!-- DevicesFragment -->
 
 

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -77,8 +77,6 @@ Vă rugăm să raportați orice problemă întâlniți, prin intermediul GitHub.
 
     <string name="open_file_manager">Deschide managerul de fișiere</string>
 
-    <string name="toast_no_file_manager">Nici un manager de fișiere compatibil găsit</string>
-
     <!-- DevicesFragment -->
 
 

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -70,8 +70,6 @@
 
     <string name="open_file_manager">Открыть файловый менеджер</string>
 
-    <string name="toast_no_file_manager">Не найдено совместимого файлового менеджера</string>
-
     <!-- DevicesFragment -->
 
 

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -76,8 +76,6 @@ Vänligen rapportera eventuella problem du stöter på via Github.</string>
 
     <string name="open_file_manager">Öppna filhanteraren</string>
 
-    <string name="toast_no_file_manager">Ingen kompatibel filhanterare hittad</string>
-
     <!-- DevicesFragment -->
 
 

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -55,8 +55,6 @@ Eğer herhangi bir sorunla karşılaşırsan Github aracılığıyla bildir.</st
     <!-- Shown if no folders exist -->
     <string name="folder_list_empty">Klasör bulunamadı</string>
 
-    <string name="toast_no_file_manager">Uyumlu dosya yöneticisi bulunamadı</string>
-
     <!-- DevicesFragment -->
 
 

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -66,8 +66,6 @@
         <item quantity="other">%1$d / %2$d 个文件</item>
     </plurals>
 
-    <string name="toast_no_file_manager">未找到兼容的文件管理器</string>
-
     <!-- DevicesFragment -->
 
 

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -62,8 +62,6 @@
         <item quantity="other">%1$d / %2$d 檔案</item>
     </plurals>
 
-    <string name="toast_no_file_manager">沒有找到相容的檔案管理員。</string>
-
     <!-- DevicesFragment -->
 
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -106,7 +106,9 @@ Please report any problems you encounter via Github.</string>
 
     <string name="open_file_manager">Open file manager</string>
 
-    <string name="toast_no_file_manager">No compatible file manager found</string>
+    <!-- Suggest File Manager App Dialog -->
+    <string name="suggest_file_manager_app_dialog_title">No compatible file manager app found</string>
+    <string name="suggest_file_manager_app_dialog_text">We recommend you to install the open-source file manager app \'Simple File Manager\' from F-Droid. Would you like to open its app store page?</string>
 
     <!-- DevicesFragment -->
 


### PR DESCRIPTION
Purpose
Add recommendation dialog if no compatible file manager was found.

Related issue
#97 "[FR] Recommend Simple File Manager app if no compatible file manager app was found."

Testing
Verified working on AVD (Android 9.x) and Android 8.1.0 (Xiaomi MI8).