### PR TITLE
Incorporate feedback from issue #110 (1) + (3)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -116,7 +116,8 @@
                 android:value=".activities.MainActivity" />
         </activity>
         <activity android:name=".activities.FolderActivity"
-            android:parentActivityName=".activities.MainActivity">
+            android:parentActivityName=".activities.MainActivity"
+            android:windowSoftInputMode="stateHidden">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".activities.MainActivity" />

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SyncConditionsActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SyncConditionsActivity.java
@@ -60,6 +60,11 @@ public class SyncConditionsActivity extends SyncthingActivity
     private SwitchCompat mSyncOnMobileData;
 
     /**
+     * Shared preferences contents for global conditions.
+     */
+    private Boolean mGlobalWhitelistEnabled;
+
+    /**
      * Shared preferences names for custom object settings.
      * Object can e.g. be a folder or device.
      */
@@ -119,7 +124,7 @@ public class SyncConditionsActivity extends SyncthingActivity
          */
         Boolean globalRunOnWifiEnabled = mPreferences.getBoolean(Constants.PREF_RUN_ON_WIFI, true);
         Set<String> globalWhitelistedSsid = mPreferences.getStringSet(Constants.PREF_WIFI_SSID_WHITELIST, new HashSet<>());
-        Boolean globalWhitelistEnabled = mPreferences.getBoolean(Constants.PREF_USE_WIFI_SSID_WHITELIST, false);
+        mGlobalWhitelistEnabled = mPreferences.getBoolean(Constants.PREF_USE_WIFI_SSID_WHITELIST, false);
         Boolean globalRunOnMeteredWifiEnabled = mPreferences.getBoolean(Constants.PREF_RUN_ON_METERED_WIFI, false);
         Boolean globalRunOnMobileDataEnabled = mPreferences.getBoolean(Constants.PREF_RUN_ON_MOBILE_DATA, false);
 
@@ -130,8 +135,8 @@ public class SyncConditionsActivity extends SyncthingActivity
         mSyncOnWifi.setEnabled(globalRunOnWifiEnabled);
         mSyncOnWifi.setOnCheckedChangeListener(mCheckedListener);
 
-        mSyncOnWhitelistedWifi.setChecked(globalWhitelistEnabled && mPreferences.getBoolean(mPrefSyncOnWhitelistedWifi, globalWhitelistEnabled));
-        mSyncOnWhitelistedWifi.setEnabled(globalWhitelistEnabled && mSyncOnWifi.isChecked());
+        mSyncOnWhitelistedWifi.setChecked(mGlobalWhitelistEnabled && mPreferences.getBoolean(mPrefSyncOnWhitelistedWifi, mGlobalWhitelistEnabled));
+        mSyncOnWhitelistedWifi.setEnabled(mGlobalWhitelistEnabled && mSyncOnWifi.isChecked());
         mSyncOnWhitelistedWifi.setOnCheckedChangeListener(mCheckedListener);
 
         mSyncOnMeteredWifi.setChecked(globalRunOnMeteredWifiEnabled && mPreferences.getBoolean(mPrefSyncOnMeteredWifi, globalRunOnMeteredWifiEnabled));
@@ -152,7 +157,7 @@ public class SyncConditionsActivity extends SyncthingActivity
         // from JavaDoc: Note that you must not modify the set instance returned by this call.
         // therefore required to make a defensive copy of the elements
         globalWhitelistedSsid = new HashSet<>(globalWhitelistedSsid);
-        if (!globalWhitelistEnabled) {
+        if (!mGlobalWhitelistEnabled) {
             // Add empty WiFi Ssid ListView.
             int height = (int) TypedValue.applyDimension(COMPLEX_UNIT_DIP, 48, getResources().getDisplayMetrics());
             LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(WRAP_CONTENT, height);
@@ -163,6 +168,7 @@ public class SyncConditionsActivity extends SyncthingActivity
             TextView emptyView = new TextView(mWifiSsidContainer.getContext());
             emptyView.setGravity(CENTER_VERTICAL);
             emptyView.setText(R.string.custom_wifi_ssid_whitelist_empty);
+            emptyView.setEnabled(false);
             mWifiSsidContainer.addView(emptyView, params);
             mWifiSsidContainer.setEnabled(false);
         } else {
@@ -173,7 +179,7 @@ public class SyncConditionsActivity extends SyncthingActivity
                 SwitchCompat wifiSsidView = (SwitchCompat) mWifiSsidContainer.getChildAt(mWifiSsidContainer.getChildCount()-1);
                 wifiSsidView.setOnCheckedChangeListener(null);
                 wifiSsidView.setChecked(selectedWhitelistedSsid.contains(wifiSsid));
-                wifiSsidView.setEnabled(mSyncOnWhitelistedWifi.isChecked());
+                wifiSsidView.setEnabled(mSyncOnWifi.isChecked() && mSyncOnWhitelistedWifi.isChecked());
                 wifiSsidView.setText(wifiSsid.replaceFirst("^\"", "").replaceFirst("\"$", ""));
                 wifiSsidView.setTag(wifiSsid);
                 wifiSsidView.setOnCheckedChangeListener(mCheckedListener);
@@ -187,12 +193,12 @@ public class SyncConditionsActivity extends SyncthingActivity
         public void onCheckedChanged(CompoundButton view, boolean isChecked) {
             switch (view.getId()) {
                 case R.id.sync_on_wifi_title:
-                    mSyncOnWhitelistedWifi.setEnabled(isChecked);
+                    mSyncOnWhitelistedWifi.setEnabled(mGlobalWhitelistEnabled && isChecked);
                     // Fall-through to dependent options.
                 case R.id.sync_on_whitelisted_wifi_title:
                     // Enable or disable WiFi Ssid switches according to parent switch.
                     for (int i = 0; i < mWifiSsidContainer.getChildCount(); i++) {
-                        mWifiSsidContainer.getChildAt(i).setEnabled(isChecked);
+                        mWifiSsidContainer.getChildAt(i).setEnabled(mGlobalWhitelistEnabled && isChecked);
                     }
                     break;
                 default:

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SyncConditionsActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SyncConditionsActivity.java
@@ -252,22 +252,9 @@ public class SyncConditionsActivity extends SyncthingActivity
     }
 
     @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
-        getMenuInflater().inflate(R.menu.sync_conditions_settings, menu);
-        return super.onCreateOptionsMenu(menu);
-    }
-
-    @Override
-    public boolean onPrepareOptionsMenu(Menu menu) {
-        menu.findItem(R.id.done).setVisible(true);
-        return true;
-    }
-
-    @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case android.R.id.home:
-            case R.id.done:
                 onBackPressed();
                 return true;
             default:

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SyncConditionsActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SyncConditionsActivity.java
@@ -185,6 +185,13 @@ public class SyncConditionsActivity extends SyncthingActivity
                 wifiSsidView.setOnCheckedChangeListener(mCheckedListener);
             }
         }
+
+        /**
+         * We should always save until we abandoned the global sync conditions
+         * as changes to the global run conditions resulting in force-disabling
+         * the switches here would else not be saved back to the prefs.
+         */
+        mUnsavedChanges = true;
     }
 
     private final CompoundButton.OnCheckedChangeListener mCheckedListener =

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/RunConditionMonitor.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/RunConditionMonitor.java
@@ -382,7 +382,7 @@ public class RunConditionMonitor {
         SyncConditionResult scr = checkConditionSyncOnMobileData(Constants.DYN_PREF_OBJECT_SYNC_ON_MOBILE_DATA(objectPrefixAndId));
         if (scr.conditionMet) {
             // Mobile data is connected.
-            Log.v(TAG, "checkObjectSyncConditions: checkConditionSyncOnMobileData");
+            Log.v(TAG, "checkObjectSyncConditions(" + objectPrefixAndId + "): checkConditionSyncOnMobileData");
             return true;
         }
 
@@ -390,12 +390,12 @@ public class RunConditionMonitor {
         scr = checkConditionSyncOnWifi(Constants.DYN_PREF_OBJECT_SYNC_ON_WIFI(objectPrefixAndId));
         if (scr.conditionMet) {
             // Wifi is connected.
-            Log.v(TAG, "checkObjectSyncConditions: checkConditionSyncOnWifi");
+            Log.v(TAG, "checkObjectSyncConditions(" + objectPrefixAndId + "): checkConditionSyncOnWifi");
 
             scr = checkConditionSyncOnMeteredWifi(Constants.DYN_PREF_OBJECT_SYNC_ON_METERED_WIFI(objectPrefixAndId));
             if (scr.conditionMet) {
                 // Wifi type is allowed.
-                Log.v(TAG, "checkObjectSyncConditions: checkConditionSyncOnWifi && checkConditionSyncOnMeteredWifi");
+                Log.v(TAG, "checkObjectSyncConditions(" + objectPrefixAndId + "): checkConditionSyncOnWifi && checkConditionSyncOnMeteredWifi");
 
                 scr = checkConditionSyncOnWhitelistedWifi(
                     Constants.DYN_PREF_OBJECT_USE_WIFI_SSID_WHITELIST(objectPrefixAndId),
@@ -403,7 +403,7 @@ public class RunConditionMonitor {
                 );
                 if (scr.conditionMet) {
                     // Wifi is whitelisted.
-                    Log.v(TAG, "checkObjectSyncConditions: checkConditionSyncOnWifi && checkConditionSyncOnMeteredWifi && checkConditionSyncOnWhitelistedWifi");
+                    Log.v(TAG, "checkObjectSyncConditions(" + objectPrefixAndId + "): checkConditionSyncOnWifi && checkConditionSyncOnMeteredWifi && checkConditionSyncOnWhitelistedWifi");
                     return true;
                 }
             }

--- a/app/src/main/res/menu/sync_conditions_settings.xml
+++ b/app/src/main/res/menu/sync_conditions_settings.xml
@@ -3,10 +3,4 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <item
-        android:id="@+id/done"
-        android:title="@string/add"
-        android:icon="@drawable/ic_done_white_24dp"
-        app:showAsAction="always|withText" />
-
 </menu>


### PR DESCRIPTION
Purpose
- Fix issue #110 (3) - Remove checkmark in the per-object sync conditions dialog on the upper right

Testing
Verified working on AVD Android 9.x at commit https://github.com/Catfriend1/syncthing-android/pull/114/commits/e1f070231f03a8756a64c4e42e148844268f40be .