### PR TITLE
Update syncthing submodule to 0.14.52-release

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,8 +37,8 @@ android {
         applicationId "com.github.catfriend1.syncthingandroid"
         minSdkVersion 16
         targetSdkVersion 26
-        versionCode 4176
-        versionName "0.14.51.13"
+        versionCode 4177
+        versionName "0.14.52.1"
         testApplicationId 'com.github.catfriend1.syncthingandroid.test'
         testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
         playAccountConfig = playAccountConfigs.defaultAccountConfig

--- a/app/src/main/play/en-GB/whatsnew
+++ b/app/src/main/play/en-GB/whatsnew
@@ -7,4 +7,4 @@ Fixes
 * Fixed the "battery eater"
 * Android 8 and 9 support
 Maintenance
-* Updated syncthing to v0.14.51 (receiveOnly folders)
+* Updated syncthing to v0.14.52


### PR DESCRIPTION
Purpose
Update syncthing submodule to 0.14.52-release

Testing
QA will be done in issue #122 .