### PR TITLE
Update filemanager recommendation (fixes #125)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/util/FileUtils.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/FileUtils.java
@@ -921,7 +921,7 @@ public class FileUtils {
                 .setTitle(R.string.suggest_file_manager_app_dialog_title)
                 .setMessage(R.string.suggest_file_manager_app_dialog_text)
                 .setPositiveButton(R.string.yes, (d, i) -> {
-                    final String appPackageName = "com.simplemobiletools.filemanager";
+                    final String appPackageName = "com.simplemobiletools.filemanager.pro";
                     try {
                         context.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("market://details?id=" + appPackageName)));
                     } catch (android.content.ActivityNotFoundException anfe) {


### PR DESCRIPTION
Purpose
Update filemanager recommendation package name. The recommended app is still free on F-Droid at time of writing this.

Related issues
#125 

Testing
Verified working at commit https://github.com/Catfriend1/syncthing-android/pull/134/commits/c61fa5e6c2a1d3753b5acb85db6d06c6e24199fd using Android 9.x AVD.