### PR TITLE
Add debug option to fallback to http (fixes #137) (fixes #139)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: MPLv2](https://img.shields.io/badge/License-MPLv2-blue.svg)](https://opensource.org/licenses/MPL-2.0)
 <a href="https://github.com/Catfriend1/syncthing-android/releases" alt="GitHub release"><img src="https://img.shields.io/github/release/Catfriend1/syncthing-android/all.svg" /></a>
-<a href="https://f-droid.org/de/packages/com.github.catfriend1.syncthingandroid" alt="F-Droid release"><img src="https://img.shields.io/badge/f--droid-4180-brightgreen.svg" /></a>
+<a href="https://f-droid.org/de/packages/com.github.catfriend1.syncthingandroid" alt="F-Droid release"><img src="https://img.shields.io/f-droid/v/com.github.catfriend1.syncthingandroid.svg" /></a>
 
 # Major enhancements in this fork are:
 - Individual sync conditions can be applied per device and per folder (for expert users).

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,8 +37,8 @@ android {
         applicationId "com.github.catfriend1.syncthingandroid"
         minSdkVersion 16
         targetSdkVersion 26
-        versionCode 4180
-        versionName "0.14.54.1"
+        versionCode 4181
+        versionName "0.14.54.2"
         testApplicationId 'com.github.catfriend1.syncthingandroid.test'
         testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
         playAccountConfig = playAccountConfigs.defaultAccountConfig

--- a/app/src/main/java/com/nutomic/syncthingandroid/http/ApiRequest.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/http/ApiRequest.java
@@ -157,9 +157,12 @@ public abstract class ApiRequest {
         }
         @Override
         protected HttpURLConnection createConnection(URL url) throws IOException {
-            HttpsURLConnection connection = (HttpsURLConnection) super.createConnection(url);
-            connection.setHostnameVerifier((hostname, session) -> true);
-            return connection;
+            if (mUrl.toString().startsWith("https://")) {
+                HttpsURLConnection connection = (HttpsURLConnection) super.createConnection(url);
+                connection.setHostnameVerifier((hostname, session) -> true);
+                return connection;
+            }
+            return super.createConnection(url);
         }
     }
 

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
@@ -1,6 +1,7 @@
 package com.nutomic.syncthingandroid.service;
 
 import android.content.Context;
+import android.os.Build;
 import android.os.Environment;
 
 import java.io.File;
@@ -163,5 +164,15 @@ public class Constants {
 
     static File getLogFile(Context context) {
         return new File(context.getExternalFilesDir(null), "syncthing.log");
+    }
+
+    /**
+     * Decide if we should enforce HTTPS when accessing the Web UI and REST API.
+     * Android 4.4 and earlier don't have support for TLS 1.2 requiring us to
+     * fall back to an unencrypted HTTP connection to localhost. This applies
+     * to syncthing core v0.14.53+.
+     */
+    public static final Boolean osSupportsTLS12() {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP;
     }
 }

--- a/app/src/main/play/en-GB/whatsnew
+++ b/app/src/main/play/en-GB/whatsnew
@@ -1,5 +1,6 @@
 Maintenance
 * Updated syncthing core to v0.14.54
+* Fallback to http if https tls 1.2 is unavailable on Android 4.x
 Enhancements
 * Added "Recent changes" UI, click files to open [NEW]
 * Specify sync conditions differently for each folder, device [NEW]

--- a/build_submodule.cmd
+++ b/build_submodule.cmd
@@ -1,0 +1,7 @@
+@echo off
+cls
+cd /d "%~dps0"
+REM 
+gradlew buildNative
+REM 
+pause

--- a/git_update_submodule.cmd
+++ b/git_update_submodule.cmd
@@ -1,0 +1,12 @@
+@echo off
+cls
+REM
+SET PATH=%PATH%;"%ProgramFiles%\Git\bin"
+SET DESIRED_SUBMODULE_VERSION=v0.14.54
+REM 
+cd /d "%~dps0\syncthing\src\github.com\syncthing\syncthing"
+REM 
+git fetch --all
+git checkout %DESIRED_SUBMODULE_VERSION%
+REM 
+pause

--- a/publish-release.sh
+++ b/publish-release.sh
@@ -43,4 +43,4 @@ Release published!
 #"
 #ACCESS_TOKEN=""
 #api_json=$(printf '{"tag_name": "v%s","target_commitish": "master","name": "v%s","body": "%s","draft": false,"prerelease": false}' $version $version $changelog)
-#curl --data "$api_json" https://api.github.com/repos/syncthing/syncthing-android/releases?access_token=$ACCESS_TOKEN
+#curl --data "$api_json" https://api.github.com/repos/Catfriend1/syncthing-android/releases?access_token=$ACCESS_TOKEN


### PR DESCRIPTION
Purpose
Fix issue #137
Fix issue #139

Related issues
#137 "[FR] Add debug option to fallback to http"
#1255 "TLS 1.2 not utilized using Android 4.4"

Testing
Verified working at commit https://github.com/Catfriend1/syncthing-android/pull/138/commits/5567bc05b48a3ace3dc482beeb30986aac4e958b using Android AVD 9.x by making osSupportsTLS12() return true (1) and false (2) to run the tests.
Verified working by @phuyuk on Android 4.4.2.