### PR TITLE
Fix Binder failed - cannot create handler inside thread that has not called looper.prepare (fixes #149)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,8 +37,8 @@ android {
         applicationId "com.github.catfriend1.syncthingandroid"
         minSdkVersion 16
         targetSdkVersion 26
-        versionCode 4182
-        versionName "0.14.54.3"
+        versionCode 4183
+        versionName "0.14.54.4"
         testApplicationId 'com.github.catfriend1.syncthingandroid.test'
         testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
         playAccountConfig = playAccountConfigs.defaultAccountConfig

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/RunConditionMonitor.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/RunConditionMonitor.java
@@ -15,6 +15,8 @@ import android.net.wifi.WifiInfo;
 import android.net.wifi.WifiManager;
 import android.os.BatteryManager;
 import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
 import android.os.PowerManager;
 import android.support.annotation.Nullable;
 import android.support.v4.content.LocalBroadcastManager;
@@ -49,7 +51,17 @@ public class RunConditionMonitor {
     private final SyncStatusObserver mSyncStatusObserver = new SyncStatusObserver() {
         @Override
         public void onStatusChanged(int which) {
-            updateShouldRunDecision();
+            /**
+             * We need a Looper here, see issue https://github.com/Catfriend1/syncthing-android/issues/149
+             */
+            Handler mainLooper = new Handler(Looper.getMainLooper());
+            Runnable updateShouldRunDecisionRunnable = new Runnable() {
+                @Override
+                public void run() {
+                    updateShouldRunDecision();
+                }
+            };
+            mainLooper.post(updateShouldRunDecisionRunnable);
         }
     };
 


### PR DESCRIPTION
Related issue
#149 

Testing
Verified working on AVD 9.x at commit 