### PR TITLE
Preserve syncthing running/not running after a database or delta index reset (fixes #154)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/model/Completion.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/model/Completion.java
@@ -17,6 +17,8 @@ public class Completion {
 
     private static final String TAG = "Completion";
 
+    private static final Boolean ENABLE_VERBOSE_LOG = false;
+
     HashMap<String, HashMap<String, CompletionInfo>> deviceFolderMap =
         new HashMap<String, HashMap<String, CompletionInfo>>();
 
@@ -55,14 +57,18 @@ public class Completion {
             }
         }
         for (String deviceId : removedDevices) {
-            Log.v(TAG, "updateFromConfig: Remove device '" + deviceId + "' from cache model");
+            if (ENABLE_VERBOSE_LOG) {
+                Log.v(TAG, "updateFromConfig: Remove device '" + deviceId + "' from cache model");
+            }
             deviceFolderMap.remove(deviceId);
         }
 
         // Handle devices that were added to the config.
         for (Device device : newDevices) {
             if (!deviceFolderMap.containsKey(device.deviceID)) {
-                Log.v(TAG, "updateFromConfig: Add device '" + device.deviceID + "' to cache model");
+                if (ENABLE_VERBOSE_LOG) {
+                    Log.v(TAG, "updateFromConfig: Add device '" + device.deviceID + "' to cache model");
+                }
                 deviceFolderMap.put(device.deviceID, new HashMap<String, CompletionInfo>());
             }
         }
@@ -85,7 +91,9 @@ public class Completion {
             }
         }
         for (String folderId : removedFolders) {
-            Log.v(TAG, "updateFromConfig: Remove folder '" + folderId + "' from cache model");
+            if (ENABLE_VERBOSE_LOG) {
+                Log.v(TAG, "updateFromConfig: Remove folder '" + folderId + "' from cache model");
+            }
             removeFolder(folderId);
         }
 
@@ -96,8 +104,10 @@ public class Completion {
                     // folder is shared with device.
                     folderMap = deviceFolderMap.get(device.deviceID);
                     if (!folderMap.containsKey(folder.id)) {
-                        Log.v(TAG, "updateFromConfig: Add folder '" + folder.id +
-                                    "' shared with device '" + device.deviceID + "' to cache model.");
+                        if (ENABLE_VERBOSE_LOG) {
+                            Log.v(TAG, "updateFromConfig: Add folder '" + folder.id +
+                                        "' shared with device '" + device.deviceID + "' to cache model.");
+                        }
                         folderMap.put(folder.id, new CompletionInfo());
                     }
                 }

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/EventProcessor.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/EventProcessor.java
@@ -37,6 +37,8 @@ public class EventProcessor implements  Runnable, RestApi.OnReceiveEventListener
 
     private static final String TAG = "EventProcessor";
 
+    private static final Boolean ENABLE_VERBOSE_LOG = false;
+
     /**
      * Minimum interval in seconds at which the events are polled from syncthing and processed.
      * This intervall will not wake up the device to save battery power.
@@ -96,7 +98,7 @@ public class EventProcessor implements  Runnable, RestApi.OnReceiveEventListener
         switch (event.type) {
             case "ConfigSaved":
                 if (mRestApi != null) {
-                    Log.v(TAG, "Forwarding ConfigSaved event to RestApi to get the updated config.");
+                    Log.d(TAG, "Forwarding ConfigSaved event to RestApi to get the updated config.");
                     mRestApi.reloadConfig();
                 }
                 break;
@@ -162,12 +164,12 @@ public class EventProcessor implements  Runnable, RestApi.OnReceiveEventListener
             case "Starting":
             case "StartupComplete":
             case "StateChanged":
-                if (BuildConfig.DEBUG) {
+                if (ENABLE_VERBOSE_LOG) {
                     Log.v(TAG, "Ignored event " + event.type + ", data " + event.data);
                 }
                 break;
             default:
-                Log.v(TAG, "Unhandled event " + event.type);
+                Log.d(TAG, "Unhandled event " + event.type);
         }
     }
 


### PR DESCRIPTION
Purpose
Preserve syncthing running/not running after a database or delta index reset (fixes #154)

Related issue
#154 - "After resetting DB, syncthing runs unconditionally"

Testing
Verified working on AVD 9.x at commit https://github.com/Catfriend1/syncthing-android/commit/e31b0a644f7996e81a440c9cb896ed955cd7a6bb .