### PR TITLE
Display syncthing's api key in Settings/About dialog (fixes #164)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
@@ -147,6 +147,7 @@ public class SettingsActivity extends SyncthingActivity {
         private EditTextPreference mHttpProxyAddress;
 
         private Preference mSyncthingVersion;
+        private Preference mSyncthingApiKey;
 
         private SyncthingService mSyncthingService;
         private RestApi mRestApi;
@@ -239,8 +240,9 @@ public class SettingsActivity extends SyncthingActivity {
             mSocksProxyAddress              = (EditTextPreference) findPreference(Constants.PREF_SOCKS_PROXY_ADDRESS);
             mHttpProxyAddress               = (EditTextPreference) findPreference(Constants.PREF_HTTP_PROXY_ADDRESS);
 
+            Preference appVersion   = findPreference("app_version");
             mSyncthingVersion       = findPreference("syncthing_version");
-            Preference appVersion   = screen.findPreference("app_version");
+            mSyncthingApiKey        = findPreference("syncthing_api_key");
 
             mRunOnMeteredWifi.setEnabled(mRunOnWifi.isChecked());
             mUseWifiWhitelist.setEnabled(mRunOnWifi.isChecked());
@@ -288,8 +290,9 @@ public class SettingsActivity extends SyncthingActivity {
             handleHttpProxyPreferenceChange(screen.findPreference(Constants.PREF_HTTP_PROXY_ADDRESS), mPreferences.getString(Constants.PREF_HTTP_PROXY_ADDRESS, ""));
 
             try {
-                appVersion.setSummary(getActivity().getPackageManager()
-                        .getPackageInfo(getActivity().getPackageName(), 0).versionName);
+                String versionName = getActivity().getPackageManager()
+                        .getPackageInfo(getActivity().getPackageName(), 0).versionName;
+                appVersion.setSummary("v" + versionName);
             } catch (PackageManager.NameNotFoundException e) {
                 Log.d(TAG, "Failed to get app version name");
             }
@@ -331,10 +334,12 @@ public class SettingsActivity extends SyncthingActivity {
                         (currentState == SyncthingService.State.ACTIVE);
             mCategorySyncthingOptions.setEnabled(isSyncthingRunning);
 
-            if (!isSyncthingRunning)
+            if (!isSyncthingRunning) {
                 return;
+            }
 
             mSyncthingVersion.setSummary(mRestApi.getVersion());
+            mSyncthingApiKey.setSummary(mRestApi.getApiKey());
             mOptions = mRestApi.getOptions();
             mGui = mRestApi.getGui();
 

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/RestApi.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/RestApi.java
@@ -776,6 +776,10 @@ public class RestApi {
         });
     }
 
+    public String getApiKey() {
+        return mApiKey;
+    }
+
     public URL getUrl() {
         return mUrl;
     }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -559,6 +559,12 @@ Bitte melden Sie auftretende Probleme via GitHub.</string>
     <!-- Title of the preference showing this app's version name -->
     <string name="app_version_title">Syncthing-Fork Wrapper Version</string>
 
+    <!-- Title of the preference showing the REST API key -->
+    <string name="syncthing_api_key">Syncthing API Key (Klicke zum Kopieren)</string>
+    
+    <!-- Shown when the API key is copied to the clipboard -->
+    <string name="api_key_copied_to_clipboard">Syncthing API Key in die Zwischenablage kopiert</string>
+
     <!-- FolderPickerAcitivity -->
 
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -567,6 +567,9 @@ Please report any problems you encounter via Github.</string>
     <!-- Title of the preference showing this app's version name -->
     <string name="app_version_title">Syncthing-Fork Wrapper Version</string>
 
+    <!-- Title of the preference showing the REST API key -->
+    <string name="syncthing_api_key">Syncthing API Key</string>
+
     <!-- FolderPickerAcitivity -->
 
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -568,7 +568,10 @@ Please report any problems you encounter via Github.</string>
     <string name="app_version_title">Syncthing-Fork Wrapper Version</string>
 
     <!-- Title of the preference showing the REST API key -->
-    <string name="syncthing_api_key">Syncthing API Key</string>
+    <string name="syncthing_api_key">Syncthing API Key (click to copy)</string>
+    
+    <!-- Shown when the API key is copied to the clipboard -->
+    <string name="api_key_copied_to_clipboard">Syncthing API key copied to clipboard</string>
 
     <!-- FolderPickerAcitivity -->
 

--- a/app/src/main/res/xml/app_settings.xml
+++ b/app/src/main/res/xml/app_settings.xml
@@ -276,12 +276,22 @@
         </Preference>
 
         <Preference
+            android:persistent="false"
+            android:selectable="false"
+            android:key="app_version"
+            android:title="@string/app_version_title" />
+
+        <Preference
+            android:persistent="false"
+            android:selectable="false"
             android:key="syncthing_version"
             android:title="@string/syncthing_version_title" />
 
         <Preference
-            android:key="app_version"
-            android:title="@string/app_version_title" />
+            android:persistent="false"
+            android:selectable="false"
+            android:key="syncthing_api_key"
+            android:title="@string/syncthing_api_key" />
 
     </PreferenceScreen>
 

--- a/app/src/main/res/xml/app_settings.xml
+++ b/app/src/main/res/xml/app_settings.xml
@@ -289,7 +289,7 @@
 
         <Preference
             android:persistent="false"
-            android:selectable="false"
+            android:selectable="true"
             android:key="syncthing_api_key"
             android:title="@string/syncthing_api_key" />
 


### PR DESCRIPTION
Purpose:
Display syncthing's api key in Settings/About dialog

Related issue:
#164 - Display syncthing's api key in Settings/About dialog

Testing:
Verified working on AVD 9.x at https://github.com/Catfriend1/syncthing-android/pull/167/commits/9ba4a88b7b8f418665784b4744e4c778adf6b46a .