### PR TITLE
Control syncthing start and stop by third-party automation apps like Tasker (fixes #161)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -147,8 +147,8 @@
         <receiver android:name=".receiver.AppConfigReceiver"
             tools:ignore="ExportedReceiver">
             <intent-filter>
-                <action android:name="com.nutomic.syncthingandroid.action.START" />
-                <action android:name="com.nutomic.syncthingandroid.action.STOP" />
+                <action android:name="com.github.catfriend1.syncthingandroid.action.START" />
+                <action android:name="com.github.catfriend1.syncthingandroid.action.STOP" />
             </intent-filter>
         </receiver>
         <activity android:name=".activities.FolderTypeDialogActivity"

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/DeviceActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/DeviceActivity.java
@@ -63,13 +63,13 @@ public class DeviceActivity extends SyncthingActivity
             SyncthingService.OnServiceStateChangeListener {
 
     public static final String EXTRA_NOTIFICATION_ID =
-            "com.nutomic.syncthingandroid.activities.DeviceActivity.NOTIFICATION_ID";
+            "com.github.catfriend1.syncthingandroid.activities.DeviceActivity.NOTIFICATION_ID";
     public static final String EXTRA_DEVICE_ID =
-            "com.nutomic.syncthingandroid.activities.DeviceActivity.DEVICE_ID";
+            "com.github.catfriend1.syncthingandroid.activities.DeviceActivity.DEVICE_ID";
     public static final String EXTRA_DEVICE_NAME =
-            "com.nutomic.syncthingandroid.activities.DeviceActivity.DEVICE_NAME";
+            "com.github.catfriend1.syncthingandroid.activities.DeviceActivity.DEVICE_NAME";
     public static final String EXTRA_IS_CREATE =
-            "com.nutomic.syncthingandroid.activities.DeviceActivity.IS_CREATE";
+            "com.github.catfriend1.syncthingandroid.activities.DeviceActivity.IS_CREATE";
 
     private static final String TAG = "DeviceActivity";
     private static final String IS_SHOWING_DISCARD_DIALOG = "DISCARD_FOLDER_DIALOG_STATE";

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
@@ -66,15 +66,15 @@ public class FolderActivity extends SyncthingActivity
         implements SyncthingService.OnServiceStateChangeListener {
 
     public static final String EXTRA_NOTIFICATION_ID =
-            "com.nutomic.syncthingandroid.activities.FolderActivity.NOTIFICATION_ID";
+            "com.github.catfriend1.syncthingandroid.activities.FolderActivity.NOTIFICATION_ID";
     public static final String EXTRA_IS_CREATE =
-            "com.nutomic.syncthingandroid.activities.FolderActivity.IS_CREATE";
+            "com.github.catfriend1.syncthingandroid.activities.FolderActivity.IS_CREATE";
     public static final String EXTRA_FOLDER_ID =
-            "com.nutomic.syncthingandroid.activities.FolderActivity.FOLDER_ID";
+            "com.github.catfriend1.syncthingandroid.activities.FolderActivity.FOLDER_ID";
     public static final String EXTRA_FOLDER_LABEL =
-            "com.nutomic.syncthingandroid.activities.FolderActivity.FOLDER_LABEL";
+            "com.github.catfriend1.syncthingandroid.activities.FolderActivity.FOLDER_LABEL";
     public static final String EXTRA_DEVICE_ID =
-            "com.nutomic.syncthingandroid.activities.FolderActivity.DEVICE_ID";
+            "com.github.catfriend1.syncthingandroid.activities.FolderActivity.DEVICE_ID";
 
     private static final String TAG = "FolderActivity";
 

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderPickerActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderPickerActivity.java
@@ -45,13 +45,13 @@ public class FolderPickerActivity extends SyncthingActivity
         implements AdapterView.OnItemClickListener {
 
     private static final String EXTRA_INITIAL_DIRECTORY =
-            "com.nutomic.syncthingandroid.activities.FolderPickerActivity.INITIAL_DIRECTORY";
+            "com.github.catfriend1.syncthingandroid.activities.FolderPickerActivity.INITIAL_DIRECTORY";
 
     private static final String EXTRA_ROOT_DIRECTORY =
-            "com.nutomic.syncthingandroid.activities.FolderPickerActivity.ROOT_DIRECTORY";
+            "com.github.catfriend1.syncthingandroid.activities.FolderPickerActivity.ROOT_DIRECTORY";
 
     public static final String EXTRA_RESULT_DIRECTORY =
-            "com.nutomic.syncthingandroid.activities.FolderPickerActivity.RESULT_DIRECTORY";
+            "com.github.catfriend1.syncthingandroid.activities.FolderPickerActivity.RESULT_DIRECTORY";
 
     public static final int DIRECTORY_REQUEST_CODE = 234;
 

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/MainActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/MainActivity.java
@@ -60,6 +60,7 @@ import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 
 import static java.lang.Math.min;
+import static com.nutomic.syncthingandroid.service.Constants.PREF_BROADCAST_SERVICE_CONTROL;
 
 /**
  * Shows {@link FolderListFragment} and
@@ -196,13 +197,19 @@ public class MainActivity extends SyncthingActivity
         mDrawerLayout.addDrawerListener(mDrawerToggle);
         setOptimalDrawerWidth(findViewById(R.id.drawer));
 
-        // SyncthingService needs to be started from this activity as the user
-        // can directly launch this activity from the recent activity switcher.
-        Intent serviceIntent = new Intent(this, SyncthingService.class);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            startForegroundService(serviceIntent);
-        } else {
-            startService(serviceIntent);
+        Boolean prefBroadcastServiceControl = mPreferences.getBoolean(PREF_BROADCAST_SERVICE_CONTROL, false);
+        if (!prefBroadcastServiceControl) {
+            /**
+             * SyncthingService needs to be started from this activity as the user
+             * can directly launch this activity from the recent activity switcher.
+             * Applies if PREF_BROADCAST_SERVICE_CONTROL is DISABLED (default).
+             */
+            Intent serviceIntent = new Intent(this, SyncthingService.class);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                startForegroundService(serviceIntent);
+            } else {
+                startService(serviceIntent);
+            }
         }
 
         onNewIntent(getIntent());

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
@@ -60,7 +60,7 @@ public class SettingsActivity extends SyncthingActivity {
     private SettingsFragment mSettingsFragment;
 
     public static final String EXTRA_OPEN_SUB_PREF_SCREEN =
-            "com.nutomic.syncthingandroid.activities.SettingsActivity.OPEN_SUB_PREF_SCREEN";
+            "com.github.catfriend1.syncthingandroid.activities.SettingsActivity.OPEN_SUB_PREF_SCREEN";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SyncConditionsActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SyncConditionsActivity.java
@@ -43,10 +43,10 @@ public class SyncConditionsActivity extends SyncthingActivity {
     private static final String TAG = "SyncConditionsActivity";
 
     private static final String EXTRA_OBJECT_PREFIX_AND_ID =
-            "com.nutomic.syncthingandroid.activities.SyncConditionsActivity.OBJECT_PREFIX_AND_ID";
+            "com.github.catfriend1.syncthingandroid.activities.SyncConditionsActivity.OBJECT_PREFIX_AND_ID";
 
     private static final String EXTRA_OBJECT_READABLE_NAME =
-            "com.nutomic.syncthingandroid.activities.SyncConditionsActivity.OBJECT_READABLE_NAME";
+            "com.github.catfriend1.syncthingandroid.activities.SyncConditionsActivity.OBJECT_READABLE_NAME";
 
     // UI elements
     private SwitchCompat mSyncOnWifi;

--- a/app/src/main/java/com/nutomic/syncthingandroid/receiver/AppConfigReceiver.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/receiver/AppConfigReceiver.java
@@ -21,14 +21,14 @@ public class AppConfigReceiver extends BroadcastReceiver {
     /**
      * Start the Syncthing-Service
      */
-    private static final String ACTION_START = "com.nutomic.syncthingandroid.action.START";
+    private static final String ACTION_START = "com.github.catfriend1.syncthingandroid.action.START";
 
     /**
      * Stop the Syncthing-Service
      * If startServiceOnBoot is enabled the service must not be stopped. Instead a
      * notification is presented to the user.
      */
-    private static final String ACTION_STOP  = "com.nutomic.syncthingandroid.action.STOP";
+    private static final String ACTION_STOP  = "com.github.catfriend1.syncthingandroid.action.STOP";
 
     @Inject NotificationHandler mNotificationHandler;
 

--- a/app/src/main/java/com/nutomic/syncthingandroid/receiver/BootReceiver.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/receiver/BootReceiver.java
@@ -29,7 +29,7 @@ public class BootReceiver extends BroadcastReceiver {
      *
      * https://stackoverflow.com/a/44505719/1837158
      */
-    static void startServiceCompat(Context context) {
+    public static void startServiceCompat(Context context) {
         Intent intent = new Intent(context, SyncthingService.class);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             context.startForegroundService(intent);

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
@@ -35,6 +35,7 @@ public class Constants {
     public static final String PREF_USE_TOR                     = "use_tor";
     public static final String PREF_SOCKS_PROXY_ADDRESS         = "socks_proxy_address";
     public static final String PREF_HTTP_PROXY_ADDRESS          = "http_proxy_address";
+    public static final String PREF_BROADCAST_SERVICE_CONTROL   = "broadcast_service_control";
 
     // Preferences - per Folder and Device Sync Conditions
     public static final String PREF_OBJECT_PREFIX_FOLDER        = "sc_folder_";

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
@@ -56,70 +56,70 @@ public class SyncthingService extends Service {
      * Intent action to perform a Syncthing restart.
      */
     public static final String ACTION_RESTART =
-            "com.nutomic.syncthingandroid.service.SyncthingService.RESTART";
+            "com.github.catfriend1.syncthingandroid.SyncthingService.RESTART";
 
     /**
      * Intent action to perform a Syncthing stop.
      */
     public static final String ACTION_STOP =
-            "com.nutomic.syncthingandroid.service.SyncthingService.STOP";
+            "com.github.catfriend1.syncthingandroid.SyncthingService.STOP";
 
     /**
      * Intent action to reset Syncthing's database.
      */
     public static final String ACTION_RESET_DATABASE =
-            "com.nutomic.syncthingandroid.service.SyncthingService.RESET_DATABASE";
+            "com.github.catfriend1.syncthingandroid.SyncthingService.RESET_DATABASE";
 
     /**
      * Intent action to reset Syncthing's delta indexes.
      */
     public static final String ACTION_RESET_DELTAS =
-            "com.nutomic.syncthingandroid.service.SyncthingService.RESET_DELTAS";
+            "com.github.catfriend1.syncthingandroid.SyncthingService.RESET_DELTAS";
 
     public static final String ACTION_REFRESH_NETWORK_INFO =
-            "com.nutomic.syncthingandroid.service.SyncthingService.REFRESH_NETWORK_INFO";
+            "com.github.catfriend1.syncthingandroid.SyncthingService.REFRESH_NETWORK_INFO";
 
     /**
      * Intent action to permanently ignore a device connection request.
      */
     public static final String ACTION_IGNORE_DEVICE =
-            "com.nutomic.syncthingandroid.service.SyncthingService.IGNORE_DEVICE";
+            "com.github.catfriend1.syncthingandroid.SyncthingService.IGNORE_DEVICE";
 
     /**
      * Intent action to permanently ignore a folder share request.
      */
     public static final String ACTION_IGNORE_FOLDER =
-            "com.nutomic.syncthingandroid.service.SyncthingService.IGNORE_FOLDER";
+            "com.github.catfriend1.syncthingandroid.SyncthingService.IGNORE_FOLDER";
 
     /**
      * Intent action to override folder changes.
      */
     public static final String ACTION_OVERRIDE_CHANGES =
-            "com.nutomic.syncthingandroid.service.SyncthingService.OVERRIDE_CHANGES";
+            "com.github.catfriend1.syncthingandroid.SyncthingService.OVERRIDE_CHANGES";
 
     /**
      * Extra used together with ACTION_IGNORE_DEVICE, ACTION_IGNORE_FOLDER.
      */
     public static final String EXTRA_NOTIFICATION_ID =
-            "com.nutomic.syncthingandroid.service.SyncthingService.EXTRA_NOTIFICATION_ID";
+            "com.github.catfriend1.syncthingandroid.SyncthingService.EXTRA_NOTIFICATION_ID";
 
     /**
      * Extra used together with ACTION_IGNORE_DEVICE
      */
     public static final String EXTRA_DEVICE_ID =
-            "com.nutomic.syncthingandroid.service.SyncthingService.EXTRA_DEVICE_ID";
+            "com.github.catfriend1.syncthingandroid.SyncthingService.EXTRA_DEVICE_ID";
 
     /**
      * Extra used together with ACTION_IGNORE_FOLDER
      */
     public static final String EXTRA_FOLDER_ID =
-            "com.nutomic.syncthingandroid.service.SyncthingService.EXTRA_FOLDER_ID";
+            "com.github.catfriend1.syncthingandroid.SyncthingService.EXTRA_FOLDER_ID";
 
     /**
      * Extra used together with ACTION_STOP.
      */
     public static final String EXTRA_STOP_AFTER_CRASHED_NATIVE =
-            "com.nutomic.syncthingandroid.service.SyncthingService.EXTRA_STOP_AFTER_CRASHED_NATIVE";
+            "com.github.catfriend1.syncthingandroid.SyncthingService.EXTRA_STOP_AFTER_CRASHED_NATIVE";
 
     public interface OnServiceStateChangeListener {
         void onServiceStateChange(State currentState);

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
@@ -334,7 +334,9 @@ public class SyncthingService extends Service {
                 shutdown(State.DISABLED);
             }
         } else if (ACTION_REFRESH_NETWORK_INFO.equals(intent.getAction())) {
-            mRunConditionMonitor.updateShouldRunDecision();
+            if (mRunConditionMonitor != null) {
+                mRunConditionMonitor.updateShouldRunDecision();
+            }
         } else if (ACTION_IGNORE_DEVICE.equals(intent.getAction()) && mCurrentState == State.ACTIVE) {
             // mRestApi is not null due to State.ACTIVE
             mRestApi.ignoreDevice(intent.getStringExtra(EXTRA_DEVICE_ID));

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
@@ -3,6 +3,7 @@ package com.nutomic.syncthingandroid.service;
 import android.app.Service;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.content.res.Resources;
 import android.content.SharedPreferences;
 import android.Manifest;
 import android.os.AsyncTask;
@@ -272,7 +273,7 @@ public class SyncthingService extends Service {
         }
 
         if (mPrefBroadcastServiceControl) {
-            Log.i(TAG, "onStartCommand: mBroadcastServiceControl == true, RunConditionMonitor is disabled.");
+            Log.i(TAG, "onStartCommand: mPrefBroadcastServiceControl == true, RunConditionMonitor is disabled.");
             /**
              * Directly use the callback which normally is invoked by RunConditionMonitor to start the
              * syncthing native unconditionally.
@@ -762,10 +763,17 @@ public class SyncthingService extends Service {
     }
 
     public String getRunDecisionExplanation() {
-        if (mRunConditionMonitor == null) {
-            return "This should not happen: mRunConditionMonitor is not instantiated.";
+        if (mRunConditionMonitor != null) {
+            return mRunConditionMonitor.getRunDecisionExplanation();
         }
-        return mRunConditionMonitor.getRunDecisionExplanation();
+
+        Resources res = getResources();
+        if (mPrefBroadcastServiceControl) {
+            return res.getString(R.string.reason_broadcast_controlled);
+        }
+
+        // mRunConditionMonitor == null
+        return res.getString(R.string.reason_run_condition_monitor_not_instantiated);
     }
 
     /**

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
@@ -212,7 +212,8 @@ public class SyncthingService extends Service {
     /**
      * True if experimental option PREF_BROADCAST_SERVICE_CONTROL is set.
      * Disables run condition monitor completely because the user chose to
-     * control the service by sending broadcasts, e.g. from "Tasker".
+     * control the service by sending broadcasts, e.g. from third-party
+     * automation apps.
      */
     private boolean mPrefBroadcastServiceControl = false;
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -57,7 +57,7 @@ Bitte melden Sie auftretende Probleme via GitHub.</string>
     <string name="dialog_exit_while_running_as_service_message">Zu Deiner Erinnerung: Du hast Syncthing eingerichtet, automatisch beim Hochfahren zu starten. Deshalb überwacht es die Laufkonditionen und synchronisiert, wenn die Bedingungen zutreffen. Du solltest nur manuell beenden, wenn Du größere Probleme feststellst. Andernfalls schalte \"Automatisch beim Hochfahren starten\" in den Einstellungen aus. Möchtest Du jetzt beenden, bis das Gerät neu gestartet wurde?</string>
 
     <!-- Title of the "add folder" menu action -->
-    <string name="add_folder">Verzeichnis hinzufügen</string>
+    <string name="add_folder">Ordner hinzufügen</string>
 
     <!-- Title of the "share device id" menu action -->
     <string name="share_device_id">Geräte-ID teilen</string>
@@ -95,7 +95,7 @@ Bitte melden Sie auftretende Probleme via GitHub.</string>
     <!-- FoldersFragment -->
 
 
-    <string name="folders_fragment_title">Verzeichnisse</string>
+    <string name="folders_fragment_title">Ordner</string>
 
     <!-- Shown if no folders exist -->
     <string name="folder_list_empty">Keine Verzeichnisse gefunden</string>
@@ -207,13 +207,13 @@ Bitte melden Sie auftretende Probleme via GitHub.</string>
     <string name="keep_versions">Versionen behalten</string>
 
     <!-- Setting title -->
-    <string name="delete_folder">Verzeichnis löschen</string>
+    <string name="delete_folder">Ordner löschen</string>
 
     <!-- Title for FolderSettingsFragment in create mode -->
-    <string name="create_folder">Verzeichnis erstellen</string>
+    <string name="create_folder">Ordner erstellen</string>
 
     <!-- Title for FolderSettingsFragment in edit mode -->
-    <string name="edit_folder">Verzeichnis bearbeiten</string>
+    <string name="edit_folder">Ordner bearbeiten</string>
 
     <!-- Menu item to confirm folder creation -->
     <string name="create">Erstellen</string>
@@ -493,6 +493,10 @@ Bitte melden Sie auftretende Probleme via GitHub.</string>
 
     <string name="use_legacy_hashing_summary">Für Abwärtskompatibilität soll Syncthing die alten Hashfunktionen verwenden</string>
 
+    <string name="broadcast_service_control_title">Dienstkontrolle über Broadcast</string>
+
+    <string name="broadcast_service_control_summary">Standard: Deaktiviert. Aktiviere diese Option, um den Dienst durch Broadcasts z. B. mit Drittanbieter Automatisierungsapps zu starten und zu stoppen. Hinweis: Nach dem Ändern dieser Option musst du die App manuell neu starten.</string>
+
     <string name="restart_on_wakeup_title">Neustart nach Aufwachen</string>
 
     <string name="restart_on_wakeup_summary">Standard: Aktiviert. Das Deaktivieren dieser Funktion kann verzögertes Ordner-Scannen und Wiederverbinden von Geräten zur Folge haben. Dafür spart es Akku.</string>
@@ -561,7 +565,7 @@ Bitte melden Sie auftretende Probleme via GitHub.</string>
 
     <!-- Title of the preference showing the REST API key -->
     <string name="syncthing_api_key">Syncthing API Key (Klicke zum Kopieren)</string>
-    
+
     <!-- Shown when the API key is copied to the clipboard -->
     <string name="api_key_copied_to_clipboard">Syncthing API Key in die Zwischenablage kopiert</string>
 
@@ -666,6 +670,8 @@ Bitte melden Sie auftretende Probleme via GitHub.</string>
     <string name="reason_not_nonmetered_wifi">Syncthing läuft nicht, weil Du verboten hast, dass es bei getakteten WLAN-Verbindungen läuft.</string>
     <string name="reason_location_unavailable">Du hast \'Starte in ausgewählten WLAN-Netzwerken\' in den Einstellungen aktiviert. Die Android-tandorterfassung ist derzeit ausgeschaltet. Aufgrund von Android-Beschränkungen kann Syncthing den aktuellen WLAN-Netzwerknamen nicht ermitteln, um zu entscheiden, ob es starten soll. Lösung: Schalte den Standort ein und verbinde WLAN erneut.</string>
     <string name="reason_on_flight_mode">Syncthing läuft, weil Du erlaubt hast, dass es bei eingeschaltetem Flugzeugmodus läuft.</string>
+    <string name="reason_broadcast_controlled">Syncthing hört auf Broadcasts, die von einer Drittanbieter-App oder über ADB gesendet werden. Du kannst zu den eingebauten Laufkonditionen zurück wechseln, indem Du unter \'Einstellungen\' > \'Experimentell\' > \'Dienstkontrolle über Broadcast\' deaktivierst.</string>
+    <string name="reason_run_condition_monitor_not_instantiated">Laufkonditionen-Überwachung ist nicht instantiiert. Bitte starte die App neu und erstelle einen Fehlerbericht, wenn das Problem nach dem Neustart nicht verschwindet.</string>
 
     <!-- Sync Conditions Dialog -->
 

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -597,7 +597,6 @@ Vänligen rapportera eventuella problem du stöter på via Github.</string>
     <string name="reason_on_whitelisted_wifi">Syncthing får köras på det aktuella Wi-Fi-nätverket.</string>
     <string name="reason_not_on_whitelisted_wifi">Syncthing körs inte eftersom det aktuella Wi-Fi-nätverkets namn inte är vitlistat.</string>
     <string name="reason_on_flight_mode">Syncthing körs som du tillät att den ska köras när flygläget är aktivt.</string>
-
     <!-- Sync Conditions Dialog -->
 
     <string name="custom_wifi_ssid_whitelist_empty">Ingen Wi-Fi-SSID är vitlistad. Ange några i inställningarna.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -495,7 +495,7 @@ Please report any problems you encounter via Github.</string>
 
     <string name="broadcast_service_control_title">Service Control by Broadcast</string>
 
-    <string name="broadcast_service_control_summary">Default: Disabled. Enable this option to start and stop the service by sending broadcasts, e.g. from tools like Tasker.</string>
+    <string name="broadcast_service_control_summary">Default: Disabled. Enable this option to start and stop the service by sending broadcasts, e.g. from third-party automation apps. Note: You have to restart the app manually after changing this option.</string>
 
     <string name="restart_on_wakeup_title">Restart on Wakeup</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -573,7 +573,7 @@ Please report any problems you encounter via Github.</string>
 
     <!-- Title of the preference showing the REST API key -->
     <string name="syncthing_api_key">Syncthing API Key (click to copy)</string>
-    
+
     <!-- Shown when the API key is copied to the clipboard -->
     <string name="api_key_copied_to_clipboard">Syncthing API key copied to clipboard</string>
 
@@ -678,6 +678,8 @@ Please report any problems you encounter via Github.</string>
     <string name="reason_not_nonmetered_wifi">Syncthing is not running as you disallowed it to run on metered WiFi connections.</string>
     <string name="reason_location_unavailable">You enabled \'Run on selected WiFi networks\' in the settings. Android location services are currently turned off. According to Android restrictions, Syncthing cannot determine the current WiFi network name to decide if it should run. Solution: Turn location on and reconnect WiFi.</string>
     <string name="reason_on_flight_mode">Syncthing is running as you allowed it to run when flight mode is active.</string>
+    <string name="reason_broadcast_controlled">Syncthing is listening to broadcasts sent by a third-party app or ADB. You can switch back to use the built-in run conditions by disabling \'Settings\' > \'Experimental\' > \'Service Control by Broadcast\'.</string>
+    <string name="reason_run_condition_monitor_not_instantiated">RunConditionMonitor is not instantiated. Please restart the app and file a bug report if this error doesn\'t disappear after the restart.</string>
 
     <!-- Sync Conditions Dialog -->
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -493,6 +493,10 @@ Please report any problems you encounter via Github.</string>
 
     <string name="use_legacy_hashing_summary">Force Syncthing to use legacy hashing package for compatibility purposes</string>
 
+    <string name="broadcast_service_control_title">Service Control by Broadcast</string>
+
+    <string name="broadcast_service_control_summary">Default: Disabled. Enable this option to start and stop the service by sending broadcasts, e.g. from tools like Tasker.</string>
+
     <string name="restart_on_wakeup_title">Restart on Wakeup</string>
 
     <string name="restart_on_wakeup_summary">Default: Enabled. Disabling this feature may result in folder scans and device reconnects being delayed to save battery.</string>

--- a/app/src/main/res/xml/app_settings.xml
+++ b/app/src/main/res/xml/app_settings.xml
@@ -255,6 +255,11 @@
             android:title="@string/use_legacy_hashing_title"
             android:summary="@string/use_legacy_hashing_summary" />
 
+        <CheckBoxPreference
+            android:key="broadcast_service_control"
+            android:title="@string/broadcast_service_control_title"
+            android:summary="@string/broadcast_service_control_summary" />
+
         <!-- Only valid for Android < 6 -->
         <CheckBoxPreference
             android:key="wakelock_while_binary_running"


### PR DESCRIPTION
Purpose:
Improve control via other apps like Tasker according to https://github.com/Catfriend1/syncthing-android/wiki/Remote-Control-by-Broadcast-Intents .
Control start and stop of syncthing via third-party automation apps like Tasker while the built-in run conditions are disabled.

Related issue:
Tasker - Support to control SyncthingService by broadcast is broken #170

Testing:
Verified working on Android 7.1.1, device Motorola Moto-X Play "lux" at commit https://github.com/Catfriend1/syncthing-android/pull/169/commits/ce390220411783dfefda6bda16466ceb7e6d51b4 .