### PR TITLE
Add Database Size status label to Settings/About (fixes #155)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
@@ -119,6 +119,7 @@ public class SettingsActivity extends SyncthingActivity {
         private static final String KEY_ST_RESET_DELTAS = "st_reset_deltas";
         // Settings/About
         private static final String KEY_SYNCTHING_API_KEY = "syncthing_api_key";
+        private static final String KEY_SYNCTHING_DATABASE_SIZE = "syncthing_database_size";
 
         @Inject NotificationHandler mNotificationHandler;
         @Inject SharedPreferences mPreferences;
@@ -310,6 +311,7 @@ public class SettingsActivity extends SyncthingActivity {
                 Log.d(TAG, "Failed to get app version name");
             }
             mSyncthingApiKey.setOnPreferenceClickListener(this);
+            screen.findPreference(KEY_SYNCTHING_DATABASE_SIZE).setSummary(getDatabaseSize());
 
             openSubPrefScreen(screen);
         }
@@ -818,6 +820,22 @@ public class SettingsActivity extends SyncthingActivity {
                         .show();
                 return false;
             }
+        }
+
+        /**
+         * Calculates the size of the syncthing database on disk.
+         */
+        private String getDatabaseSize() {
+            String dbPath = getContext().getFilesDir() + "/" + Constants.INDEX_DB_FOLDER;
+            String result = Util.runShellCommandGetOutput("/system/bin/du -sh " + dbPath, false);
+            if (TextUtils.isEmpty(result)) {
+                return "N/A";
+            }
+            String resultParts[] = result.split("\\s+");
+            if (resultParts.length == 0) {
+                return "N/A";
+            }
+            return resultParts[0];
         }
     }
 }

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
@@ -158,6 +158,7 @@ public class SettingsActivity extends SyncthingActivity {
         private Preference mSyncthingVersion;
         private Preference mSyncthingApiKey;
 
+        private Context mContext;
         private SyncthingService mSyncthingService;
         private RestApi mRestApi;
 
@@ -185,6 +186,7 @@ public class SettingsActivity extends SyncthingActivity {
          */
         @Override
         public void onActivityCreated(Bundle savedInstanceState) {
+            mContext = getActivity().getApplicationContext();
             super.onActivityCreated(savedInstanceState);
 
             addPreferencesFromResource(R.xml.app_settings);
@@ -641,7 +643,7 @@ public class SettingsActivity extends SyncthingActivity {
                     return true;
                 case KEY_SYNCTHING_API_KEY:
                     // Copy syncthing's API key to clipboard.
-                    ClipboardManager clipboard = (ClipboardManager) getActivity().getApplicationContext().getSystemService(Context.CLIPBOARD_SERVICE);
+                    ClipboardManager clipboard = (ClipboardManager) mContext.getSystemService(Context.CLIPBOARD_SERVICE);
                     ClipData clip = ClipData.newPlainText(getString(R.string.syncthing_api_key), mSyncthingApiKey.getSummary());
                     clipboard.setPrimaryClip(clip);
                     Toast.makeText(getActivity(), R.string.api_key_copied_to_clipboard, Toast.LENGTH_SHORT)
@@ -826,7 +828,7 @@ public class SettingsActivity extends SyncthingActivity {
          * Calculates the size of the syncthing database on disk.
          */
         private String getDatabaseSize() {
-            String dbPath = getContext().getFilesDir() + "/" + Constants.INDEX_DB_FOLDER;
+            String dbPath = mContext.getFilesDir() + "/" + Constants.INDEX_DB_FOLDER;
             String result = Util.runShellCommandGetOutput("/system/bin/du -sh " + dbPath, false);
             if (TextUtils.isEmpty(result)) {
                 return "N/A";

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
@@ -146,7 +146,7 @@ public class Constants {
     /**
      * Name of the folder containing the index database.
      */
-    static final String INDEX_DB_FOLDER = "index-v0.14.0.db";
+    public static final String INDEX_DB_FOLDER = "index-v0.14.0.db";
 
     /**
      * Name of the public HTTPS CA file in the data directory.

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -569,6 +569,9 @@ Bitte melden Sie auftretende Probleme via GitHub.</string>
     <!-- Shown when the API key is copied to the clipboard -->
     <string name="api_key_copied_to_clipboard">Syncthing API Key in die Zwischenablage kopiert</string>
 
+    <!-- Title of the preference showing database size -->
+    <string name="syncthing_database_size">Syncthing Datenbankgröße</string>
+
     <!-- FolderPickerAcitivity -->
 
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -577,6 +577,9 @@ Please report any problems you encounter via Github.</string>
     <!-- Shown when the API key is copied to the clipboard -->
     <string name="api_key_copied_to_clipboard">Syncthing API key copied to clipboard</string>
 
+    <!-- Title of the preference showing database size -->
+    <string name="syncthing_database_size">Syncthing Database Size</string>
+
     <!-- FolderPickerAcitivity -->
 
 

--- a/app/src/main/res/xml/app_settings.xml
+++ b/app/src/main/res/xml/app_settings.xml
@@ -298,6 +298,12 @@
             android:key="syncthing_api_key"
             android:title="@string/syncthing_api_key" />
 
+        <Preference
+            android:persistent="false"
+            android:selectable="false"
+            android:key="syncthing_database_size"
+            android:title="@string/syncthing_database_size" />
+
     </PreferenceScreen>
 
 </PreferenceScreen>


### PR DESCRIPTION
Purpose:
Add Database Size status label to Settings/About

Related Issue:
Show database size in SettingsActivity (#155)

Testing:
Verified working on AVD 9.x at commit https://github.com/Catfriend1/syncthing-android/commit/e3b8ab80ae7c44aa37049e25286b995949b6d516 .
![image](https://user-images.githubusercontent.com/16361913/50563437-16d85600-0d1d-11e9-8bd2-d909be749e2d.png)
