### PR TITLE
Add helper script: postbuild_rename_apk.cmd

### DIFF
--- a/git_update_submodule.cmd
+++ b/git_update_submodule.cmd
@@ -2,7 +2,7 @@
 cls
 REM
 SET PATH=%PATH%;"%ProgramFiles%\Git\bin"
-SET DESIRED_SUBMODULE_VERSION=v0.14.54
+SET DESIRED_SUBMODULE_VERSION=v1.0.0
 REM 
 cd /d "%~dps0\syncthing\src\github.com\syncthing\syncthing"
 REM 

--- a/postbuild_rename_apk.cmd
+++ b/postbuild_rename_apk.cmd
@@ -1,4 +1,11 @@
 @echo off
+REM 
+REM Purpose:
+REM 	Rename and move built APK's to match this style:
+REM 		[APPLICATION_ID]_v[VERSION_NAME]_[COMMIT_SHORT_HASH].apk
+REM 	Example:
+REM 		com.github.catfriend1.syncthingandroid_v1.0.0.1_7d59e75.apk
+REM 
 title %~nx0
 setlocal enabledelayedexpansion
 cls
@@ -25,12 +32,13 @@ FOR /F "tokens=1" %%A IN ('git rev-parse --short --verify HEAD 2^>NUL:') DO SET 
 echo [INFO] commit="%COMMIT_SHORT_HASH%"
 REM 
 REM Rename APK to be ready for upload to the GitHub release page.
-call :renIfExist %SCRIPT_PATH%app\build\outputs\apk\debug\app-debug.apk %APPLICATION_ID%_%VERSION_NAME%_%COMMIT_SHORT_HASH%.apk
-call :renIfExist %SCRIPT_PATH%app\build\outputs\apk\release\app-release-unsigned.apk %APPLICATION_ID%_%VERSION_NAME%_%COMMIT_SHORT_HASH%.apk
+SET APK_NEW_FILENAME=%APPLICATION_ID%_v%VERSION_NAME%_%COMMIT_SHORT_HASH%.apk
+call :renIfExist %SCRIPT_PATH%app\build\outputs\apk\debug\app-debug.apk %APK_NEW_FILENAME%
+call :renIfExist %SCRIPT_PATH%app\build\outputs\apk\release\app-release-unsigned.apk %APK_NEW_FILENAME%
 echo [INFO] APK file rename step complete.
 REM 
 REM Copy debug APK to temporary storage location if the storage is available.
-IF EXIST %TEMP_OUTPUT_FOLDER% copy /y %SCRIPT_PATH%app\build\outputs\apk\debug\%APPLICATION_ID%_%VERSION_NAME%_%COMMIT_SHORT_HASH%.apk %TEMP_OUTPUT_FOLDER% 2> NUL:
+IF EXIST %TEMP_OUTPUT_FOLDER% copy /y %SCRIPT_PATH%app\build\outputs\apk\debug\%APK_NEW_FILENAME% %TEMP_OUTPUT_FOLDER% 2> NUL:
 REM 
 echo [INFO] End of Script.
 timeout 3

--- a/postbuild_rename_apk.cmd
+++ b/postbuild_rename_apk.cmd
@@ -1,0 +1,38 @@
+@echo off
+title %~x0
+setlocal enabledelayedexpansion
+cls
+SET SCRIPT_PATH=%~dps0
+REM 
+SET PATH=%PATH%;"%ProgramFiles%\Git\bin"
+REM 
+REM Get "applicationId"
+FOR /F "tokens=2 delims= " %%A IN ('type "app\build.gradle" 2^>^&1 ^| findstr "applicationId"') DO SET APPLICATION_ID=%%A
+SET APPLICATION_ID=%APPLICATION_ID:"=%
+echo applicationId="%APPLICATION_ID%"
+REM 
+REM Get "versionName"
+FOR /F "tokens=2 delims= " %%A IN ('type "app\build.gradle" 2^>^&1 ^| findstr "versionName"') DO SET VERSION_NAME=%%A
+SET VERSION_NAME=%VERSION_NAME:"=%
+echo versionName="%VERSION_NAME%"
+REM 
+REM Get short hash of last commit.
+FOR /F "tokens=1" %%A IN ('git rev-parse --short --verify HEAD 2^>NUL:') DO SET COMMIT_SHORT_HASH=%%A
+echo commit="%COMMIT_SHORT_HASH%"
+REM 
+REM Rename APK to be ready for upload to the GitHub release page.
+call :renIfExist %SCRIPT_PATH%app\build\outputs\apk\debug\app-debug.apk com.github.catfriend1.syncthingandroid_%VERSION_NAME%_%COMMIT_SHORT_HASH%.apk
+call :renIfExist %SCRIPT_PATH%app\build\outputs\apk\release\app-release-unsigned.apk com.github.catfriend1.syncthingandroid_%VERSION_NAME%_%COMMIT_SHORT_HASH%.apk
+REM 
+echo [INFO] APK files renamed.
+timeout 3
+goto :eof
+
+:renIfExist
+REM 
+REM Syntax:
+REM 	call :renIfExist [FULL_FN_ORIGINAL] [FILENAME_RENAMED]
+IF EXIST %1 REN %1 %2 & goto :eof
+echo [INFO] File not found: %1
+REM 
+goto :eof


### PR DESCRIPTION
Purpose:
 	Rename and move built APK's to match this style:
		[APPLICATION_ID]_v[VERSION_NAME]_[COMMIT_SHORT_HASH].apk
 	Example:
		com.github.catfriend1.syncthingandroid_v1.0.0.1_7d59e75.apk
