### PR TITLE
Improve usage reporting question dialog implementation (fixes #184)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/MainActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/MainActivity.java
@@ -83,8 +83,8 @@ public class MainActivity extends SyncthingActivity
      */
     private static final long USAGE_REPORTING_DIALOG_DELAY = TimeUnit.DAYS.toMillis(3);
 
-    private AlertDialog mBatteryOptimizationsDialog;
     private AlertDialog mQrCodeDialog;
+    private AlertDialog mUsageReportingDialog;
     private Dialog mRestartDialog;
 
     private SyncthingService.State mSyncthingServiceState = SyncthingService.State.INIT;
@@ -350,6 +350,7 @@ public class MainActivity extends SyncthingActivity
             outState.putString(DEVICEID_KEY, deviceID.getText().toString());
         }
         Util.dismissDialogSafe(mRestartDialog, this);
+        Util.dismissDialogSafe(mUsageReportingDialog, this);
     }
 
     @Override
@@ -371,17 +372,13 @@ public class MainActivity extends SyncthingActivity
     }
 
     public void showRestartDialog(){
-        mRestartDialog = createRestartDialog();
-        mRestartDialog.show();
-    }
-
-    private Dialog createRestartDialog(){
-        return  new AlertDialog.Builder(this)
+        mRestartDialog = new AlertDialog.Builder(this)
                 .setMessage(R.string.dialog_confirm_restart)
                 .setPositiveButton(android.R.string.yes, (dialogInterface, i1) -> this.startService(new Intent(this, SyncthingService.class)
                         .setAction(SyncthingService.ACTION_RESTART)))
                 .setNegativeButton(android.R.string.no, null)
                 .create();
+        mRestartDialog.show();
     }
 
     public void showQrCodeDialog(String deviceId, Bitmap qrCode) {
@@ -520,7 +517,8 @@ public class MainActivity extends SyncthingActivity
                     .inflate(R.layout.dialog_usage_reporting, null);
             TextView tv = v.findViewById(R.id.example);
             tv.setText(report);
-            new AlertDialog.Builder(MainActivity.this)
+            Util.dismissDialogSafe(mUsageReportingDialog, MainActivity.this);
+            mUsageReportingDialog = new AlertDialog.Builder(MainActivity.this)
                     .setTitle(R.string.usage_reporting_dialog_title)
                     .setView(v)
                     .setPositiveButton(R.string.yes, listener)

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/MainActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/MainActivity.java
@@ -121,7 +121,7 @@ public class MainActivity extends SyncthingActivity
                 // Check if the usage reporting minimum delay passed by.
                 Boolean usageReportingDelayPassed = (new Date().getTime() > getFirstStartTime() + USAGE_REPORTING_DIALOG_DELAY);
                 RestApi restApi = getApi();
-                if (usageReportingDelayPassed && restApi != null && !restApi.isUsageReportingDecided()) {
+                if (usageReportingDelayPassed && restApi != null && restApi.isConfigLoaded() && !restApi.isUsageReportingDecided()) {
                     showUsageReportingDialog(restApi);
                 }
                 break;

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/MainActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/MainActivity.java
@@ -492,6 +492,7 @@ public class MainActivity extends SyncthingActivity
      * Displays dialog asking user to accept/deny usage reporting.
      */
     private void showUsageReportingDialog(RestApi restApi) {
+        Log.v(TAG, "showUsageReportingDialog triggered.");
         final DialogInterface.OnClickListener listener = (dialog, which) -> {
             try {
                 switch (which) {

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
@@ -388,8 +388,7 @@ public class SettingsActivity extends SyncthingActivity {
             }
 
             mRestartOnWakeup.setChecked(mOptions.restartOnWakeup);
-            mRestApi.getSystemStatus(systemStatus ->
-                    mUrAccepted.setChecked(mOptions.isUsageReportingAccepted(systemStatus.urVersionMax)));
+            mUrAccepted.setChecked(mRestApi.isUsageReportingAccepted());
         }
 
         @Override
@@ -504,11 +503,8 @@ public class SettingsActivity extends SyncthingActivity {
                     mOptions.restartOnWakeup = (boolean) o;
                     break;
                 case "urAccepted":
-                    mRestApi.getSystemStatus(systemStatus -> {
-                        mOptions.urAccepted = ((boolean) o)
-                                ? systemStatus.urVersionMax
-                                : Options.USAGE_REPORTING_DENIED;
-                    });
+                    mRestApi.setUsageReporting((boolean) o);
+                    mOptions = mRestApi.getOptions();
                     break;
                 default: throw new InvalidParameterException();
             }

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/RestApi.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/RestApi.java
@@ -784,6 +784,15 @@ public class RestApi {
         return mUrl;
     }
 
+    public Boolean isUsageReportingAccepted() {
+        Options options = getOptions();
+        if (options == null) {
+            Log.e(TAG, "isUsageReportingAccepted called while options == null");
+            return false;
+        }
+        return options.isUsageReportingAccepted(mUrVersionMax);
+    }
+
     public Boolean isUsageReportingDecided() {
         Options options = getOptions();
         if (options == null) {


### PR DESCRIPTION
Purpose:
- Improve usage reporting question dialog implementation (fixes #184)
- Add verbose log when usage report question dialog triggers
- Add RestApi#isUsageReportingAccepted to centralise detection if the user opted-out or opted-in to usage reporting (this is more bullet-proof in the future than the old implementation, but currently does the same as before the PR)

Testing:
Verified working on AVD 7.1.1 at commit https://github.com/Catfriend1/syncthing-android/pull/186/commits/98c21fdfdde7b0d332fecf74c1dc338d330db487 .