### PR TITLE
Add status light to toolbar in MainActivity to indicate if syncthing is running (fixes #187)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/MainActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/MainActivity.java
@@ -36,6 +36,7 @@ import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -114,9 +115,15 @@ public class MainActivity extends SyncthingActivity
             oneTimeShot = false;
         }
 
+        // Update status light indicating if syncthing is running.
+        Button btnRunning = (Button) findViewById(R.id.btnRunning);
+        Button btnNotRunning = (Button) findViewById(R.id.btnNotRunning);
+        if (btnRunning != null && btnNotRunning != null) {
+            btnRunning.setVisibility(currentState == SyncthingService.State.ACTIVE ? View.VISIBLE : View.GONE);
+            btnNotRunning.setVisibility(currentState != SyncthingService.State.ACTIVE ? View.VISIBLE : View.GONE);
+        }
+
         switch (currentState) {
-            case STARTING:
-                break;
             case ACTIVE:
                 // Check if the usage reporting minimum delay passed by.
                 Boolean usageReportingDelayPassed = (new Date().getTime() > getFirstStartTime() + USAGE_REPORTING_DIALOG_DELAY);
@@ -127,8 +134,6 @@ public class MainActivity extends SyncthingActivity
                 break;
             case ERROR:
                 finish();
-                break;
-            case DISABLED:
                 break;
         }
     }

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/MainActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/MainActivity.java
@@ -116,11 +116,13 @@ public class MainActivity extends SyncthingActivity
         }
 
         // Update status light indicating if syncthing is running.
-        Button btnRunning = (Button) findViewById(R.id.btnRunning);
-        Button btnNotRunning = (Button) findViewById(R.id.btnNotRunning);
-        if (btnRunning != null && btnNotRunning != null) {
-            btnRunning.setVisibility(currentState == SyncthingService.State.ACTIVE ? View.VISIBLE : View.GONE);
-            btnNotRunning.setVisibility(currentState != SyncthingService.State.ACTIVE ? View.VISIBLE : View.GONE);
+        Button btnDisabled = (Button) findViewById(R.id.btnDisabled);
+        Button btnStarting = (Button) findViewById(R.id.btnStarting);
+        Button btnActive = (Button) findViewById(R.id.btnActive);
+        if (btnDisabled != null && btnStarting != null && btnActive != null) {
+            btnActive.setVisibility(currentState == SyncthingService.State.ACTIVE ? View.VISIBLE : View.GONE);
+            btnStarting.setVisibility(currentState == SyncthingService.State.STARTING ? View.VISIBLE : View.GONE);
+            btnDisabled.setVisibility(currentState != SyncthingService.State.ACTIVE && currentState != SyncthingService.State.STARTING ? View.VISIBLE : View.GONE);
         }
 
         switch (currentState) {

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SyncthingActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SyncthingActivity.java
@@ -39,8 +39,9 @@ public abstract class SyncthingActivity extends AppCompatActivity implements Ser
         super.onPostCreate(savedInstanceState);
 
         Toolbar toolbar = findViewById(R.id.toolbar);
-        if (toolbar == null)
+        if (toolbar == null) {
             return;
+        }
 
         setSupportActionBar(toolbar);
         //noinspection ConstantConditions

--- a/app/src/main/res/layout/widget_toolbar.xml
+++ b/app/src/main/res/layout/widget_toolbar.xml
@@ -10,4 +10,28 @@
     android:elevation="@dimen/toolbar_elevation"
     app:titleMarginStart="16dp"
     android:theme="@style/ThemeOverlay.Syncthing.Toolbar"
-    android:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
+    android:popupTheme="@style/ThemeOverlay.AppCompat.Light" >
+
+    <RelativeLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content">
+
+        <android.support.v7.widget.AppCompatRadioButton
+            android:id="@+id/btnRunning"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:checked="true"
+            android:visibility="gone"
+            app:buttonTint="#64f9d8"/>
+
+        <android.support.v7.widget.AppCompatRadioButton
+            android:id="@+id/btnNotRunning"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:checked="true"
+            android:visibility="gone"
+            app:buttonTint="#0000b4"/>
+
+    </RelativeLayout>
+
+</android.support.v7.widget.Toolbar>

--- a/app/src/main/res/layout/widget_toolbar.xml
+++ b/app/src/main/res/layout/widget_toolbar.xml
@@ -22,7 +22,7 @@
             android:layout_height="wrap_content"
             android:checked="true"
             android:visibility="gone"
-            app:buttonTint="#b2ff59"/>
+            app:buttonTint="#76ff03"/>
 
         <android.support.v7.widget.AppCompatRadioButton
             android:id="@+id/btnStarting"
@@ -30,7 +30,7 @@
             android:layout_height="wrap_content"
             android:checked="true"
             android:visibility="gone"
-            app:buttonTint="#fff159"/>
+            app:buttonTint="#fff103"/>
 
         <android.support.v7.widget.AppCompatRadioButton
             android:id="@+id/btnDisabled"
@@ -38,7 +38,7 @@
             android:layout_height="wrap_content"
             android:checked="true"
             android:visibility="gone"
-            app:buttonTint="#c62828"/>
+            app:buttonTint="#ffae03"/>
 
     </RelativeLayout>
 

--- a/app/src/main/res/layout/widget_toolbar.xml
+++ b/app/src/main/res/layout/widget_toolbar.xml
@@ -17,20 +17,28 @@
         android:layout_height="wrap_content">
 
         <android.support.v7.widget.AppCompatRadioButton
-            android:id="@+id/btnRunning"
+            android:id="@+id/btnActive"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:checked="true"
             android:visibility="gone"
-            app:buttonTint="#64f9d8"/>
+            app:buttonTint="#b2ff59"/>
 
         <android.support.v7.widget.AppCompatRadioButton
-            android:id="@+id/btnNotRunning"
+            android:id="@+id/btnStarting"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:checked="true"
             android:visibility="gone"
-            app:buttonTint="#0000b4"/>
+            app:buttonTint="#fff159"/>
+
+        <android.support.v7.widget.AppCompatRadioButton
+            android:id="@+id/btnDisabled"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:checked="true"
+            android:visibility="gone"
+            app:buttonTint="#c62828"/>
 
     </RelativeLayout>
 


### PR DESCRIPTION
Purpose:
Add status light to toolbar in MainActivity to indicate if syncthing is running
- green: Syncthing is running
- yellow: Syncting is starting
- orange: Syncting is not running

Related issue:
#187 - Add status light to toolbar in MainActivity to indicate if syncthing is running

Screenshot:
![image](https://user-images.githubusercontent.com/16361913/50665616-a26a1500-0fb1-11e9-9596-85d0b4ee7138.png)

Testing:
Verified working on AVD 9.x, AVD 5.x, AVD 7.1.1 at commit https://github.com/Catfriend1/syncthing-android/pull/188/commits/f21f89317ebdfb6b69b86950d8369c9035d39296 .