### PR TITLE
Add notice to "ignore battery optimizations" welcome slide for nVidia shield TV's (fixes #192)

### DIFF
--- a/wiki/nVidia Shield TV preparations.md
+++ b/wiki/nVidia Shield TV preparations.md
@@ -1,0 +1,24 @@
+nVidia Shield TV's Android OS seem to lack the "regular" battery optimization consent and settings dialogs as they are known from mobile phones and tablets. Because of the missing functionality, you can't setup Syncthing-Fork on those TV's without making some steps to prepare the installation of the Syncthing-Fork app first.
+
+The following instructions to solve the problem by preparing the Android TV for running the app have been contributed by @o-l-a-v :
+
+* Enable Developer options (rapidly tab build info inside Settings > About)
+* Enable "USB debugging" and then "Network debugging" inside Developer options
+* Wait for ip:port to show
+* Locate / Download Google platform-tools, navigate to folder where adb.exe resides. Open Command Prompt here
+* Type the following:
+    *adb start-server*
+    *adb connect ip:port* (example: *adb connect 192.168.1.76:5555*)
+* Enable "Allow Network debugging" on the prompt that pops up on the nVidia Shield Android TV
+* Then type the following to check weather you are successfully connected. Should state one device, and "connected"
+    *adb devices*
+* To whitelist Syncthing-Fork from doze / Android Battery Optimization, type the following
+    *adb shell dumpsys deviceidle whitelist +com.github.catfriend1.syncthingandroid*
+    *adb shell dumpsys deviceidle whitelist +com.github.catfriend1.syncthingandroid.debug*
+* If you ever want to revert this change, type the following in ADB
+    *adb shell dumpsys deviceidle whitelist -com.github.catfriend1.syncthingandroid*
+    *adb shell dumpsys deviceidle whitelist -com.github.catfriend1.syncthingandroid.debug*
+
+Related:
+- [GitHub issue](https://github.com/Catfriend1/syncthing-android/issues/192)
+- [nVidia GeForce forum topic](https://forums.geforce.com/default/topic/1092750)

--- a/wiki/nVidia Shield TV preparations.md
+++ b/wiki/nVidia Shield TV preparations.md
@@ -7,16 +7,23 @@ The following instructions to solve the problem by preparing the Android TV for 
 * Wait for ip:port to show
 * Locate / Download Google platform-tools, navigate to folder where adb.exe resides. Open Command Prompt here
 * Type the following:
+
     *adb start-server*
+
     *adb connect ip:port* (example: *adb connect 192.168.1.76:5555*)
 * Enable "Allow Network debugging" on the prompt that pops up on the nVidia Shield Android TV
 * Then type the following to check weather you are successfully connected. Should state one device, and "connected"
+
     *adb devices*
 * To whitelist Syncthing-Fork from doze / Android Battery Optimization, type the following
+
     *adb shell dumpsys deviceidle whitelist +com.github.catfriend1.syncthingandroid*
+
     *adb shell dumpsys deviceidle whitelist +com.github.catfriend1.syncthingandroid.debug*
 * If you ever want to revert this change, type the following in ADB
+
     *adb shell dumpsys deviceidle whitelist -com.github.catfriend1.syncthingandroid*
+
     *adb shell dumpsys deviceidle whitelist -com.github.catfriend1.syncthingandroid.debug*
 
 Related:


### PR DESCRIPTION
Purpose:
- Add notice to "ignore battery optimizations" welcome slide for nVidia shield TV's
- Add wiki article: nVidia Shield TV preparations

Related issue:
#192 - Syncthing-Fork v1.0.0.1 fails to open "Disable Battery Optimization" on Shield TV

Testing:
In progress ...
