### PR TITLE
User selections are lost if screen rotation changes during folder edit (fixes #200) (fixes #202) (fixes #203)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/DeviceActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/DeviceActivity.java
@@ -596,17 +596,13 @@ public class DeviceActivity extends SyncthingActivity
     }
 
     private void showCompressionDialog(){
-        mCompressionDialog = createCompressionDialog();
-        mCompressionDialog.show();
-    }
-
-    private Dialog createCompressionDialog(){
-        return new AlertDialog.Builder(this)
+        mCompressionDialog = new AlertDialog.Builder(this)
                 .setTitle(R.string.compression)
                 .setSingleChoiceItems(R.array.compress_entries,
                         Compression.fromValue(this, mDevice.compression).getIndex(),
                         mCompressionEntrySelectedListener)
                 .create();
+        mCompressionDialog.show();
     }
 
     /**

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
@@ -587,12 +587,7 @@ public class FolderActivity extends SyncthingActivity
     }
 
     private void showDeleteDialog(){
-        mDeleteDialog = createDeleteDialog();
-        mDeleteDialog.show();
-    }
-
-    private Dialog createDeleteDialog(){
-        return new AlertDialog.Builder(this)
+        mDeleteDialog = new AlertDialog.Builder(this)
                 .setMessage(R.string.remove_folder_confirm)
                 .setPositiveButton(android.R.string.yes, (dialogInterface, i) -> {
                     mConfig.removeFolder(getApi(), mFolder.id);
@@ -601,6 +596,7 @@ public class FolderActivity extends SyncthingActivity
                 })
                 .setNegativeButton(android.R.string.no, null)
                 .create();
+        mDeleteDialog.show();
     }
 
     @Override

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
@@ -225,9 +225,6 @@ public class FolderActivity extends SyncthingActivity
             if (savedInstanceState != null) {
                 mFolder = new Gson().fromJson(savedInstanceState.getString("mFolder"), Folder.class);
                 mFolderUri = savedInstanceState.getParcelable("mFolderUri");
-                if (savedInstanceState.getBoolean(IS_SHOW_DISCARD_DIALOG)){
-                    showDiscardDialog();
-                }
             }
             if (mFolder == null) {
                 initFolder();
@@ -245,15 +242,11 @@ public class FolderActivity extends SyncthingActivity
             mPathView.setEnabled(false);
         }
 
-        if (savedInstanceState != null){
-            if (savedInstanceState.getBoolean(IS_SHOWING_DELETE_DIALOG)){
+        if (savedInstanceState != null) {
+            if (savedInstanceState.getBoolean(IS_SHOWING_DELETE_DIALOG)) {
                 showDeleteDialog();
-            }
-        }
-
-        if (savedInstanceState != null){
-            if (savedInstanceState.getBoolean(IS_SHOWING_DELETE_DIALOG)){
-                showDeleteDialog();
+            } else if (savedInstanceState.getBoolean(IS_SHOW_DISCARD_DIALOG)) {
+                showDiscardDialog();
             }
         }
     }
@@ -388,13 +381,14 @@ public class FolderActivity extends SyncthingActivity
     @Override
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
+
         outState.putBoolean(IS_SHOWING_DELETE_DIALOG, mDeleteDialog != null && mDeleteDialog.isShowing());
         Util.dismissDialogSafe(mDeleteDialog, this);
 
-        if (mIsCreateMode){
-            outState.putBoolean(IS_SHOW_DISCARD_DIALOG, mDiscardDialog != null && mDiscardDialog.isShowing());
-            Util.dismissDialogSafe(mDiscardDialog, this);
+        outState.putBoolean(IS_SHOW_DISCARD_DIALOG, mDiscardDialog != null && mDiscardDialog.isShowing());
+        Util.dismissDialogSafe(mDiscardDialog, this);
 
+        if (mIsCreateMode) {
             outState.putString("mFolder", new Gson().toJson(mFolder));
             outState.putParcelable("mFolderUri", mFolderUri);
         }

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderTypeDialogActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderTypeDialogActivity.java
@@ -16,8 +16,8 @@ import java.util.List;
 
 public class FolderTypeDialogActivity extends AppCompatActivity {
 
-    public static final String EXTRA_FOLDER_TYPE = "com.nutomic.syncthinandroid.activities.FolderTypeDialogActivity.FOLDER_TYPE";
-    public static final String EXTRA_RESULT_FOLDER_TYPE = "com.nutomic.syncthinandroid.activities.FolderTypeDialogActivity.EXTRA_RESULT_FOLDER_TYPE";
+    public static final String EXTRA_FOLDER_TYPE = "com.github.catfriend1.syncthingandroid.activities.FolderTypeDialogActivity.FOLDER_TYPE";
+    public static final String EXTRA_RESULT_FOLDER_TYPE = "com.github.catfriend1.syncthingandroid.activities.FolderTypeDialogActivity.EXTRA_RESULT_FOLDER_TYPE";
 
     private String selectedType;
 

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/PullOrderDialogActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/PullOrderDialogActivity.java
@@ -15,8 +15,8 @@ import java.util.List;
 
 public class PullOrderDialogActivity extends AppCompatActivity {
 
-    public static final String EXTRA_PULL_ORDER = "com.nutomic.syncthinandroid.activities.PullOrderDialogActivity.PULL_ORDER";
-    public static final String EXTRA_RESULT_PULL_ORDER = "com.nutomic.syncthinandroid.activities.PullOrderDialogActivity.EXTRA_RESULT_PULL_ORDER";
+    public static final String EXTRA_PULL_ORDER = "com.github.catfriend1.syncthingandroid.activities.PullOrderDialogActivity.PULL_ORDER";
+    public static final String EXTRA_RESULT_PULL_ORDER = "com.github.catfriend1.syncthingandroid.activities.PullOrderDialogActivity.EXTRA_RESULT_PULL_ORDER";
 
     private String selectedType;
 


### PR DESCRIPTION
Purpose:
Fix changing folder type or pull order in wrapper UI

Related issues:
#200 - Cannot change folder type or pull order in wrapper UI
#202 - User selections are lost if screen rotation changes during folder edit
#203 - Edit folder dialog - AlertDialogs leak on screen rotation

Testing:
Verified working on AVD 9.x at commit https://github.com/Catfriend1/syncthing-android/pull/201/commits/960ee97f8cf749623fc2c8bd7a20c1a4a8cef031 .
