### PR TITLE
Detect if another app/process is blocking the tcp port (fixes #193)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
@@ -489,8 +489,8 @@ public class SettingsActivity extends SyncthingActivity {
                         webUITcpPort = Integer.parseInt((String) o);
                     } catch (Exception e) {
                     }
-                    if (webUITcpPort < 1 || webUITcpPort > 65535) {
-                        Toast.makeText(getActivity(), getResources().getString(R.string.invalid_port_number, 1, 65535), Toast.LENGTH_LONG)
+                    if (webUITcpPort < 1024 || webUITcpPort > 65535) {
+                        Toast.makeText(getActivity(), getResources().getString(R.string.invalid_port_number, 1024, 65535), Toast.LENGTH_LONG)
                                 .show();
                         return false;
                     }

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
@@ -34,6 +34,7 @@ import com.nutomic.syncthingandroid.R;
 import com.nutomic.syncthingandroid.SyncthingApp;
 import com.nutomic.syncthingandroid.model.Config;
 import com.nutomic.syncthingandroid.model.Device;
+import com.nutomic.syncthingandroid.model.Gui;
 import com.nutomic.syncthingandroid.model.Options;
 import com.nutomic.syncthingandroid.service.Constants;
 import com.nutomic.syncthingandroid.service.NotificationHandler;
@@ -169,7 +170,7 @@ public class SettingsActivity extends SyncthingActivity {
         private RestApi mRestApi;
 
         private Options mOptions;
-        private Config.Gui mGui;
+        private Gui mGui;
 
         private Boolean mPendingConfig = false;
 

--- a/app/src/main/java/com/nutomic/syncthingandroid/model/Config.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/model/Config.java
@@ -10,31 +10,4 @@ public class Config {
     public Options options;
     public List<PendingDevice> pendingDevices;
     public List<RemoteIgnoredDevice> remoteIgnoredDevices;
-
-    public class Gui {
-        public boolean enabled;
-        public String address;
-        public String user;
-        public String password;
-        public boolean useTLS;
-        public String apiKey;
-        public boolean insecureAdminAccess;
-        public String theme;
-
-        public String getBindAddress() {
-            if (address == null) {
-                return "";
-            }
-            String[] split = address.split(":");
-            return split.length < 1 ? "" : split[0];
-        }
-
-        public String getBindPort() {
-            if (address == null) {
-                return "";
-            }
-            String[] split = address.split(":");
-            return split.length < 2 ? "" : split[1];
-        }
-    }
 }

--- a/app/src/main/java/com/nutomic/syncthingandroid/model/Gui.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/model/Gui.java
@@ -1,0 +1,28 @@
+package com.nutomic.syncthingandroid.model;
+
+public class Gui {
+    public boolean enabled;
+    public String address;
+    public String user;
+    public String password;
+    public boolean useTLS;
+    public String apiKey;
+    public boolean insecureAdminAccess;
+    public String theme;
+
+    public String getBindAddress() {
+        if (address == null) {
+            return "";
+        }
+        String[] split = address.split(":");
+        return split.length < 1 ? "" : split[0];
+    }
+
+    public String getBindPort() {
+        if (address == null) {
+            return "";
+        }
+        String[] split = address.split(":");
+        return split.length < 2 ? "" : split[1];
+    }
+}

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
@@ -90,6 +90,12 @@ public class Constants {
     public static final String FOLDER_TYPE_RECEIVE_ONLY         = "receiveonly";
 
     /**
+     * Default listening ports.
+     */
+    public static final Integer DEFAULT_WEBGUI_TCP_PORT         = 8384;
+    public static final Integer DEFAULT_DATA_TCP_PORT           = 22000;
+
+    /**
      * On Android 8.1, ACCESS_COARSE_LOCATION is required to access WiFi SSID.
      * This is the request code used when requesting the permission.
      */

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/RestApi.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/RestApi.java
@@ -32,6 +32,7 @@ import com.nutomic.syncthingandroid.model.Event;
 import com.nutomic.syncthingandroid.model.Folder;
 import com.nutomic.syncthingandroid.model.FolderIgnoreList;
 import com.nutomic.syncthingandroid.model.FolderStatus;
+import com.nutomic.syncthingandroid.model.Gui;
 import com.nutomic.syncthingandroid.model.IgnoredFolder;
 import com.nutomic.syncthingandroid.model.Options;
 import com.nutomic.syncthingandroid.model.PendingDevice;
@@ -573,13 +574,13 @@ public class RestApi {
         }
     }
 
-    public Config.Gui getGui() {
+    public Gui getGui() {
         synchronized (mConfigLock) {
-            return deepCopy(mConfig.gui, Config.Gui.class);
+            return deepCopy(mConfig.gui, Gui.class);
         }
     }
 
-    public void editSettings(Config.Gui newGui, Options newOptions) {
+    public void editSettings(Gui newGui, Options newOptions) {
         synchronized (mConfigLock) {
             mConfig.gui = newGui;
             mConfig.options = newOptions;

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/ConfigXml.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/ConfigXml.java
@@ -10,6 +10,7 @@ import android.util.Log;
 import com.nutomic.syncthingandroid.model.Device;
 import com.nutomic.syncthingandroid.model.Folder;
 import com.nutomic.syncthingandroid.model.FolderIgnoreList;
+import com.nutomic.syncthingandroid.model.Gui;
 import com.nutomic.syncthingandroid.R;
 import com.nutomic.syncthingandroid.service.Constants;
 import com.nutomic.syncthingandroid.service.SyncthingRunnable;
@@ -201,6 +202,17 @@ public class ConfigXml {
             return new URL(urlProtocol + "://" + getGuiElement().getElementsByTagName("address").item(0).getTextContent());
         } catch (MalformedURLException e) {
             throw new RuntimeException("Failed to parse web interface URL", e);
+        }
+    }
+
+    public Integer getWebGuiBindPort() {
+        try {
+            Gui gui = new Gui();
+            gui.address = getGuiElement().getElementsByTagName("address").item(0).getTextContent();
+            return Integer.parseInt(gui.getBindPort());
+        } catch (Exception e) {
+            Log.w(TAG, "getWebGuiBindPort: Failed with exception: ", e);
+            return Constants.DEFAULT_WEBGUI_TCP_PORT;
         }
     }
 

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/Util.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/Util.java
@@ -274,9 +274,13 @@ public class Util {
                 continue;
             }
             String[] words = line.split("\\s+");
-            if (words.length > 4) {
-                if (words[0].equals("tcp")) {
-                    if (words[3].endsWith(":" + Integer.toString(port))) {
+            if (words.length > 5) {
+                String protocol = words[0];
+                String localAddress = words[3];
+                String connState = words[5];
+                if (protocol.equals("tcp") || protocol.equals("tcp6")) {
+                    if (localAddress.endsWith(":" + Integer.toString(port)) &&
+                            connState.equalsIgnoreCase("LISTEN")) {
                         // Port is listening.
                         return true;
                     }

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/Util.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/Util.java
@@ -9,6 +9,7 @@ import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.os.Build;
 import android.preference.PreferenceManager;
+import android.text.TextUtils;
 import android.util.Log;
 import android.widget.Toast;
 
@@ -255,6 +256,34 @@ public class Util {
 
         // Return captured command line output.
         return capturedStdOut;
+    }
+
+    /**
+     * Check if a TCP is listening on the local device on a specific port.
+     */
+    public static Boolean isTcpPortListening(Integer port) {
+        // t: tcp, l: listening, n: numeric
+        String output = runShellCommandGetOutput("netstat -t -l -n", false);
+        if (TextUtils.isEmpty(output)) {
+            Log.w(TAG, "isTcpPortListening: Failed to run netstat. Returning false.");
+            return false;
+        }
+        String[] results  = output.split("\n");
+        for (String line : results) {
+            if (TextUtils.isEmpty(output)) {
+                continue;
+            }
+            String[] words = line.split("\\s+");
+            if (words.length > 4) {
+                if (words[0].equals("tcp")) {
+                    if (words[3].endsWith(":" + Integer.toString(port))) {
+                        // Port is listening.
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
     }
 
     /**

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -711,6 +711,9 @@ Bitte melden Sie auftretende Probleme via GitHub.</string>
     <!-- Toast shown if a config file crucial to operation is missing -->
     <string name="config_file_missing">Eine für den Betrieb wichtige Konfigurationsdatei fehlt</string>
 
+    <!-- Toast shown if a listening tcp port is unavailable -->
+    <string name="webui_tcp_port_unavailable">WebGUI TCP-Port %s belegt. Zweite Instanz?</string>
+
     <!-- Label of the default folder created of first start (camera folder). -->
     <string name="default_folder_label">Kamera</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -720,6 +720,9 @@ Please report any problems you encounter via Github.</string>
     <!-- Toast shown if a config file crucial to operation is missing -->
     <string name="config_file_missing">A config file crucial to operation is missing</string>
 
+    <!-- Toast shown if a listening tcp port is unavailable -->
+    <string name="webui_tcp_port_unavailable">WebUI tcp port %s busy. Second instance?</string>
+
     <!-- Label of the default folder created of first start (camera folder). -->
     <string name="default_folder_label">Camera</string>
 


### PR DESCRIPTION
Purpose:
- Detect another app blocking the configured webui port of SyncthingNative
- Detect another Syncthing instance blocking the configured webui port of SyncthingNative

Related issue:
- #193 - Syncthing-Fork crashes during startup if Syncthing-Android is already running
- #211 - Settings UI allows to set a listening port which Android denies to bind

Screenshot:
![image](https://user-images.githubusercontent.com/16361913/50786923-34756480-12b5-11e9-807c-7ec08a72033d.png)

Testing:
- Verified working on AVD 7.1.1 (Nexus one) at commit https://github.com/Catfriend1/syncthing-android/pull/209/commits/02822808e413ceff3f9892f1c113613a31e2291a .
- Verified working on AVD 9.x (Pixel 2) at commit https://github.com/Catfriend1/syncthing-android/pull/209/commits/02822808e413ceff3f9892f1c113613a31e2291a .