### PR TITLE
Add helper scripts to quickly enable/disable lint

### DIFF
--- a/lint_disable.cmd
+++ b/lint_disable.cmd
@@ -1,0 +1,13 @@
+@echo off
+REM 
+REM Disable lint during build
+REM 
+SET APP_BUILD_GRADLE=%~dps0app\build.gradle
+REM 
+cls
+echo [INFO] Disabling lint during build ...
+sed -e "s/\stask.dependsOn lint/ \/\/task.dependsOn lint/gI" -e "s/\stask.mustRunAfter lint/ \/\/task.mustRunAfter lint/gI" "%APP_BUILD_GRADLE%" > "%APP_BUILD_GRADLE%.tmp"
+move /y "%APP_BUILD_GRADLE%.tmp" "%APP_BUILD_GRADLE%"
+echo [INFO] Done.
+timeout 3
+goto :eof

--- a/lint_enable.cmd
+++ b/lint_enable.cmd
@@ -1,0 +1,13 @@
+@echo off
+REM 
+REM Enable lint during build
+REM 
+SET APP_BUILD_GRADLE=%~dps0app\build.gradle
+REM 
+cls
+echo [INFO] Enabling lint during build ...
+sed -e "s/\s\/\/task.dependsOn lint/ task.dependsOn lint/gI" -e "s/\s\/\/task.mustRunAfter lint/ task.mustRunAfter lint/gI" "%APP_BUILD_GRADLE%" > "%APP_BUILD_GRADLE%.tmp"
+move /y "%APP_BUILD_GRADLE%.tmp" "%APP_BUILD_GRADLE%"
+echo [INFO] Done.
+timeout 3
+goto :eof


### PR DESCRIPTION
Purpose:
- Add helper scripts to quickly enable/disable lint

Prerequisites:
- Requires UnixTools sed.exe on Windows

Source:
- PR #182 

Testing:
- Verified working under Windows 10x64.