### PR TITLE
Welcome wizard: Disable "back" button on keygen slide (fixes #239)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FirstStartActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FirstStartActivity.java
@@ -508,6 +508,7 @@ public class FirstStartActivity extends AppCompatActivity {
      * Perform secure key generation in an AsyncTask.
      */
     private void onKeyGenerationSlideShown() {
+        mBackButton.setVisibility(View.GONE);
         mNextButton.setVisibility(View.GONE);
         KeyGenerationTask keyGenerationTask = new KeyGenerationTask(this);
         keyGenerationTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);


### PR DESCRIPTION
Purpose:
Welcome wizard: Disable "back" button on keygen slide (fixes #239)

Testing:
Verified working on AVD 7.1.1 at commit https://github.com/Catfriend1/syncthing-android/commit/602e88108aaecf0ece6448affb0a16eee5c090a8 .