### PR TITLE
Fix crash after sdcard was ejected (fixes #249)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderPickerActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderPickerActivity.java
@@ -108,6 +108,7 @@ public class FolderPickerActivity extends SyncthingActivity
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
             roots.addAll(Arrays.asList(getExternalFilesDirs(null)));
             roots.remove(getExternalFilesDir(null));
+            roots.remove(null);      // getExternalFilesDirs may return null for an ejected SDcard.
         }
 
         String rootDir = getIntent().getStringExtra(EXTRA_ROOT_DIRECTORY);

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/TipsAndTricksActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/TipsAndTricksActivity.java
@@ -48,6 +48,7 @@ public class TipsAndTricksActivity extends SyncthingActivity {
             ArrayList<File> externalFilesDir = new ArrayList<>();
             externalFilesDir.addAll(Arrays.asList(getExternalFilesDirs(null)));
             externalFilesDir.remove(getExternalFilesDir(null));
+            externalFilesDir.remove(null);      // getExternalFilesDirs may return null for an ejected SDcard.
             if (externalFilesDir.size() > 0) {
                 String absExternalStorageAppFilesPath = externalFilesDir.get(0).getAbsolutePath();
                 mTipListAdapter.add(getString(R.string.tip_write_to_sdcard_title),

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/FileUtils.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/FileUtils.java
@@ -167,6 +167,7 @@ public class FileUtils {
             ArrayList<File> externalFilesDir = new ArrayList<>();
             externalFilesDir.addAll(Arrays.asList(context.getExternalFilesDirs(null)));
             externalFilesDir.remove(context.getExternalFilesDir(null));
+            externalFilesDir.remove(null);      // getExternalFilesDirs may return null for an ejected SDcard.
             if (externalFilesDir.size() == 0) {
                 Log.w(TAG, "Could not determine app's private files directory on external storage.");
                 return null;


### PR DESCRIPTION
Purpose:
Fix Eject SDCARD => Crash in Tips&Tricks Activity #249

Testing:
Verified working on AVD 9.x with eject and mounted SDcard.