### PR TITLE
Show toolbar when calling sub-pref screen (fixes #247)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
@@ -403,7 +403,6 @@ public class SettingsActivity extends SyncthingActivity {
         @SuppressWarnings("deprecation")
         @Override
         public boolean onPreferenceTreeClick(PreferenceScreen preferenceScreen, Preference preference) {
-            Log.v(TAG, "onPreferenceTreeClick");
             super.onPreferenceTreeClick(preferenceScreen, preference);
             if (preference instanceof PreferenceScreen) {
                 // User has clicked on a sub-preferences screen.
@@ -434,15 +433,12 @@ public class SettingsActivity extends SyncthingActivity {
 
         @Override
         public boolean onOptionsItemSelected(MenuItem item) {
-            Log.v(TAG, "onOptionsItemSelected ...");
             if (item.getItemId() == android.R.id.home) {
                 if (mCurrentPrefScreenDialog == null) {
                     // User is on the top preferences screen.
-                    Log.v(TAG, "onOptionsItemSelected ... getActivity().onBackPressed()");
                     getActivity().onBackPressed();
                 } else {
                     // User is on a sub-preferences screen.
-                    Log.v(TAG, "onOptionsItemSelected ... mCurrentPrefScreenDialog.dismiss()");
                     mCurrentPrefScreenDialog.dismiss();
                     mCurrentPrefScreenDialog = null;
                     SyncthingActivity syncthingActivity = (SyncthingActivity) getActivity();

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
@@ -414,11 +414,7 @@ public class SettingsActivity extends SyncthingActivity {
                     Toolbar toolbar = (Toolbar) layoutInflater.inflate(R.layout.widget_toolbar, root, false);
                     root.addView(toolbar, 0);
                     toolbar.setTitle(((PreferenceScreen) preference).getTitle());
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                        toolbar.setTouchscreenBlocksFocus(false);
-                    }
-                    syncthingActivity.setSupportActionBar(toolbar);
-                    syncthingActivity.getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+                    registerActionBar(toolbar);
                 } catch (Exception e) {
                     /**
                      * The above code has been verified working but due to known bugs in the
@@ -441,15 +437,29 @@ public class SettingsActivity extends SyncthingActivity {
                     // User is on a sub-preferences screen.
                     mCurrentPrefScreenDialog.dismiss();
                     mCurrentPrefScreenDialog = null;
-                    SyncthingActivity syncthingActivity = (SyncthingActivity) getActivity();
-                    Toolbar toolbar = (Toolbar) syncthingActivity.findViewById(R.id.toolbar);
-                    if (toolbar != null) {
-                        syncthingActivity.setSupportActionBar(toolbar);
-                    }
+
+                    // We need to re-register the action bar, see issue #247.
+                    registerActionBar(null);
                 }
                 return true;
             }
             return super.onOptionsItemSelected(item);
+        }
+
+        private void registerActionBar(Toolbar toolbar) {
+            SyncthingActivity syncthingActivity = (SyncthingActivity) getActivity();
+            if (toolbar == null) {
+                toolbar = (Toolbar) syncthingActivity.findViewById(R.id.toolbar);
+            }
+            if (toolbar == null) {
+                Log.w(TAG, "registerActionBar: toolbar == null");
+                return;
+            }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                toolbar.setTouchscreenBlocksFocus(false);
+            }
+            syncthingActivity.setSupportActionBar(toolbar);
+            syncthingActivity.getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         }
 
         public void setService(SyncthingService syncthingService) {

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
@@ -445,6 +445,11 @@ public class SettingsActivity extends SyncthingActivity {
                     Log.v(TAG, "onOptionsItemSelected ... mCurrentPrefScreenDialog.dismiss()");
                     mCurrentPrefScreenDialog.dismiss();
                     mCurrentPrefScreenDialog = null;
+                    SyncthingActivity syncthingActivity = (SyncthingActivity) getActivity();
+                    Toolbar toolbar = (Toolbar) syncthingActivity.findViewById(R.id.toolbar);
+                    if (toolbar != null) {
+                        syncthingActivity.setSupportActionBar(toolbar);
+                    }
                 }
                 return true;
             }

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
@@ -379,11 +379,11 @@ public class SettingsActivity extends SyncthingActivity {
             // Open sub preferences screen if EXTRA_OPEN_SUB_PREF_SCREEN was passed in bundle.
             if (openSubPrefScreen != null && !TextUtils.isEmpty(openSubPrefScreen)) {
                 Log.v(TAG, "Transitioning to pref screen " + openSubPrefScreen);
-                PreferenceScreen categoryRunConditions = (PreferenceScreen) findPreference(openSubPrefScreen);
+                PreferenceScreen desiredSubPrefScreen = (PreferenceScreen) findPreference(openSubPrefScreen);
                 final ListAdapter listAdapter = prefScreen.getRootAdapter();
                 final int itemsCount = listAdapter.getCount();
                 for (int itemNumber = 0; itemNumber < itemsCount; ++itemNumber) {
-                    if (listAdapter.getItem(itemNumber).equals(categoryRunConditions)) {
+                    if (listAdapter.getItem(itemNumber).equals(desiredSubPrefScreen)) {
                         // Simulates click on the sub-preference
                         prefScreen.onItemClick(null, null, itemNumber, 0);
                         break;

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
@@ -202,6 +202,7 @@ public class SettingsActivity extends SyncthingActivity {
 
         @Override
         public void onCreate(@Nullable Bundle savedInstanceState) {
+            Log.v(TAG, "onCreate");
             super.onCreate(savedInstanceState);
             ((SyncthingApp) getActivity().getApplication()).component().inject(this);
             setHasOptionsMenu(true);
@@ -213,6 +214,7 @@ public class SettingsActivity extends SyncthingActivity {
          */
         @Override
         public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+            Log.v(TAG, "onCreateView");
             View view = super.onCreateView(inflater, container, savedInstanceState);
             int horizontalMargin = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 2, getResources().getDisplayMetrics());
             int verticalMargin = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 2, getResources().getDisplayMetrics());
@@ -233,6 +235,7 @@ public class SettingsActivity extends SyncthingActivity {
          */
         @Override
         public void onActivityCreated(Bundle savedInstanceState) {
+            Log.v(TAG, "onActivityCreated");
             mContext = getActivity().getApplicationContext();
             super.onActivityCreated(savedInstanceState);
 
@@ -371,6 +374,7 @@ public class SettingsActivity extends SyncthingActivity {
         }
 
         private void openSubPrefScreen(PreferenceScreen prefScreen) {
+            Log.v(TAG, "openSubPrefScreen");
             Bundle bundle = getArguments();
             if (bundle == null) {
                 return;
@@ -395,6 +399,7 @@ public class SettingsActivity extends SyncthingActivity {
         @SuppressWarnings("deprecation")
         @Override
         public boolean onPreferenceTreeClick(PreferenceScreen preferenceScreen, Preference preference) {
+            Log.v(TAG, "onPreferenceTreeClick");
             super.onPreferenceTreeClick(preferenceScreen, preference);
             if (preference instanceof PreferenceScreen) {
                 // User has clicked on a sub-preferences screen.

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
@@ -403,6 +403,7 @@ public class SettingsActivity extends SyncthingActivity {
         @SuppressWarnings("deprecation")
         @Override
         public boolean onPreferenceTreeClick(PreferenceScreen preferenceScreen, Preference preference) {
+            Log.v(TAG, "onPreferenceTreeClick");
             super.onPreferenceTreeClick(preferenceScreen, preference);
             if (preference instanceof PreferenceScreen) {
                 // User has clicked on a sub-preferences screen.
@@ -433,12 +434,15 @@ public class SettingsActivity extends SyncthingActivity {
 
         @Override
         public boolean onOptionsItemSelected(MenuItem item) {
+            Log.v(TAG, "onOptionsItemSelected ...");
             if (item.getItemId() == android.R.id.home) {
                 if (mCurrentPrefScreenDialog == null) {
                     // User is on the top preferences screen.
+                    Log.v(TAG, "onOptionsItemSelected ... getActivity().onBackPressed()");
                     getActivity().onBackPressed();
                 } else {
                     // User is on a sub-preferences screen.
+                    Log.v(TAG, "onOptionsItemSelected ... mCurrentPrefScreenDialog.dismiss()");
                     mCurrentPrefScreenDialog.dismiss();
                     mCurrentPrefScreenDialog = null;
                 }


### PR DESCRIPTION
Purpose:
Show toolbar when calling sub-pref screen (fixes #247)

Testing:
Verified working at commit https://github.com/Catfriend1/syncthing-android/pull/251/commits/dacddd18f1de41a2f319637d8f3c39921a9ed063  on
- AVD 9.x (phone)
- AVD 8.1 (TV)