### PR TITLE
Remove pref: Start directly into web gui

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FirstStartActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FirstStartActivity.java
@@ -396,16 +396,7 @@ public class FirstStartActivity extends AppCompatActivity {
      */
     private void startApp() {
         Intent mainIntent = new Intent(this, MainActivity.class);
-
-        /**
-         * In case start_into_web_gui option is enabled, start both activities
-         * so that back navigation works as expected.
-         */
-        if (mPreferences.getBoolean(Constants.PREF_START_INTO_WEB_GUI, false)) {
-            startActivities(new Intent[]{mainIntent, new Intent(this, WebGuiActivity.class)});
-        } else {
-            startActivity(mainIntent);
-        }
+        startActivity(mainIntent);
         finish();
     }
 

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
@@ -27,7 +27,6 @@ public class Constants {
     public static final String PREF_RUN_IN_FLIGHT_MODE          = "run_in_flight_mode";
 
     // Preferences - Behaviour
-    public static final String PREF_START_INTO_WEB_GUI          = "start_into_web_gui";
     public static final String PREF_USE_ROOT                    = "use_root";
     public static final String PREF_ENVIRONMENT_VARIABLES       = "environment_variables";
     public static final String PREF_DEBUG_FACILITIES_ENABLED    = "debug_facilities_enabled";

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
@@ -948,6 +948,7 @@ public class SyncthingService extends Service {
                         case "advanced_folder_picker":
                         case "notification_type":
                         case "notify_crashes":
+                        case "start_into_web_gui":
                             Log.v(TAG, "importConfig: Ignoring deprecated pref \"" + prefKey + "\".");
                             break;
                         // Cached information which is not available on SettingsActivity.

--- a/app/src/main/res/values-ca-rES/strings.xml
+++ b/app/src/main/res/values-ca-rES/strings.xml
@@ -375,10 +375,6 @@
 
     <string name="preference_language_summary">Canvieu l\'idioma de l\'aplicació</string>
 
-    <string name="start_into_web_gui_title">Inicia amb la interfície web directament</string>
-
-    <string name="start_into_web_gui_summary">Quan s\'inicia la aplicació, obre la interfície web enlloc de la pantalla principal</string>
-
     <string name="pref_language_default">Idioma per defecte</string>
 
     <string-array name="folder_types">

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -236,10 +236,6 @@
 
     <string name="preference_language_summary">Změnit jazyk aplikace</string>
 
-    <string name="start_into_web_gui_title">Spustit přímo do Syncthing GUI</string>
-
-    <string name="start_into_web_gui_summary">Při spouštění aplikace přejít přímo do Syncthing GUI</string>
-
     <string name="pref_language_default">Výchozí jazyk</string>
 
     <string-array name="versioning_types">

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -232,10 +232,6 @@
 
     <string name="preference_language_summary">Ændr app sproget</string>
 
-    <string name="start_into_web_gui_title">Start direkte i webinterfacet</string>
-
-    <string name="start_into_web_gui_summary">Når app\'en starter, åben webinterfacet i stedet for hovedskærmen</string>
-
     <string name="pref_language_default">Default Sprog</string>
 
     <string-array name="versioning_types">

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -428,10 +428,6 @@ Bitte melden Sie auftretende Probleme via GitHub.</string>
 
     <string name="preference_language_summary">Anwendungssprache ändern</string>
 
-    <string name="start_into_web_gui_title">Starte direkt in die Weboberfläche</string>
-
-    <string name="start_into_web_gui_summary">Beim Start der App die Weboberfläche anstelle des Hauptfensters öffnen</string>
-
     <string name="pref_language_default">Standardsprache</string>
 
     <string-array name="folder_types">

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -232,10 +232,6 @@
 
     <string name="preference_language_summary">Αλλαγή γλώσσας της εφαρμογής</string>
 
-    <string name="start_into_web_gui_title">Άνοιγμα απευθείας στο web GUI</string>
-
-    <string name="start_into_web_gui_summary">Κατά την εκκίνηση της εφαρμογής, να ανοίγει το web GUI αντί της κεντρικής οθόνης</string>
-
     <string name="pref_language_default">Προεπιλεγμένη γλώσσα</string>
 
     <string-array name="versioning_types">

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -258,10 +258,6 @@
 
     <string name="preference_language_summary">Changer la langue de l\'application</string>
 
-    <string name="start_into_web_gui_title">Démarrer directement dans l\'interface WEB</string>
-
-    <string name="start_into_web_gui_summary">Au lancement de l\'application, ouvre l\'interface WEB au lieu de l\'écran d\'accueil.</string>
-
     <string name="pref_language_default">Langue par défaut</string>
 
     <string-array name="versioning_types">

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -254,10 +254,6 @@ Az összesített statisztika nyilvánosan elérhető a https://data.syncthing.ne
 
     <string name="preference_language_summary">Alkalmazás nyelvének megváltoztatása</string>
 
-    <string name="start_into_web_gui_title">A webes felület legyen a kezdőképernyő</string>
-
-    <string name="start_into_web_gui_summary">Az app indításakor a főképernyő helyett a webes felület jelenjen meg</string>
-
     <string name="pref_language_default">Alapértelmezett nyelv</string>
 
     <string-array name="versioning_types">

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -226,10 +226,6 @@
 
     <string name="preference_language_summary">Ganti bahasa dalam aplikasi</string>
 
-    <string name="start_into_web_gui_title">Mulai dengan web GUI</string>
-
-    <string name="start_into_web_gui_summary">Saat memulai aplikasi, buka web GUI saja, bukannya layar utama</string>
-
     <string name="pref_language_default">Bahasa Standar</string>
 
     <string name="device_name">Nama Perangkat</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -255,10 +255,6 @@
 
     <string name="preference_language_summary">Cambia la lingua dell\'app</string>
 
-    <string name="start_into_web_gui_title">Avvia direttamente nell\'Interfaccia Web</string>
-
-    <string name="start_into_web_gui_summary">Quando si avvia l\'applicazione, apre l\'Interfaccia Web invece che la schermata principale</string>
-
     <string name="pref_language_default">Lingua di default</string>
 
     <string-array name="versioning_types">

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -234,10 +234,6 @@
 
     <string name="preference_language_summary">アプリの言語を変更します</string>
 
-    <string name="start_into_web_gui_title">Web GUI に直接起動する</string>
-
-    <string name="start_into_web_gui_summary">アプリを起動するとき、メイン画面ではなく Web GUI を開きます</string>
-
     <string name="pref_language_default">デフォルトの言語</string>
 
     <string-array name="versioning_types">

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -231,10 +231,6 @@
 
     <string name="preference_language_summary">언어 변경하기</string>
 
-    <string name="start_into_web_gui_title">웹 GUI로 바로 시작하기</string>
-
-    <string name="start_into_web_gui_summary">앱을 시작할 때 기본 화면 대신 웹 GUI로 엽니다.</string>
-
     <string name="pref_language_default">기본 언어</string>
 
     <string-array name="versioning_types">

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -277,10 +277,6 @@
 
     <string name="preference_language_summary">Wijzig de taal van de app</string>
 
-    <string name="start_into_web_gui_title">Rechtstreeks opstarten in webinterface</string>
-
-    <string name="start_into_web_gui_summary">Open de webinterface in plaats van het hoofdvenster bij het opstarten van de app</string>
-
     <string name="pref_language_default">Standaardtaal</string>
 
     <string-array name="versioning_types">

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -236,10 +236,6 @@
 
     <string name="preference_language_summary">Zmień język aplikacji</string>
 
-    <string name="start_into_web_gui_title">Startuj bezpośrednio do trybu web GUI</string>
-
-    <string name="start_into_web_gui_summary">Uruchamiając aplikację, otwórz web GUI zamiast głównego ekranu</string>
-
     <string name="pref_language_default">Domyślny język</string>
 
     <string-array name="versioning_types">

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -254,10 +254,6 @@
 
     <string name="preference_language_summary">Alterar o idioma do aplicativo</string>
 
-    <string name="start_into_web_gui_title">Iniciar diretamente na interface web</string>
-
-    <string name="start_into_web_gui_summary">Quando o app for iniciado, abrir a interface web em vez da tela principal</string>
-
     <string name="pref_language_default">Idioma padrão</string>
 
     <string-array name="versioning_types">

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -273,10 +273,6 @@
 
     <string name="preference_language_summary">Alegeți limba de afișat în aplicație</string>
 
-    <string name="start_into_web_gui_title">Pornire direct în interfața web</string>
-
-    <string name="start_into_web_gui_summary">Când aplicația pornește se deschide direct interfața web în loc de ecranul principal</string>
-
     <string name="pref_language_default">Limba implicită</string>
 
     <string-array name="pull_order_types">

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -316,10 +316,6 @@
 
     <string name="preference_language_summary">Изменить язык приложения</string>
 
-    <string name="start_into_web_gui_title">Использовать веб-интерфейс при старте</string>
-
-    <string name="start_into_web_gui_summary">Во время запуска приложения открывать веб-интерфейс вместо главного экрана</string>
-
     <string name="pref_language_default">Язык по умолчанию</string>
 
     <string-array name="versioning_types">

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -352,10 +352,6 @@
 
     <string name="preference_language_summary">Ändra appens språk</string>
 
-    <string name="start_into_web_gui_title">Starta direkt i webbgränssnittet</string>
-
-    <string name="start_into_web_gui_summary">När du startar appen öppnar du webbgränssnittet istället för huvudskärmen</string>
-
     <string name="pref_language_default">Standardspråk</string>
 
     <string-array name="folder_types">

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -183,10 +183,6 @@
 
     <string name="preference_language_summary">Змінити мову пристрою</string>
 
-    <string name="start_into_web_gui_title">Перехід одразу до веб-інтерфейсу</string>
-
-    <string name="start_into_web_gui_summary">При запуску додатка, відкривати веб-інтерфейс замість головного меню</string>
-
     <string name="pref_language_default">Мова по замовчанню</string>
 
     <string name="device_name">Назва пристрою</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -332,10 +332,6 @@
 
     <string name="preference_language_summary">更改应用语言</string>
 
-    <string name="start_into_web_gui_title">启动直接进入 Web GUI</string>
-
-    <string name="start_into_web_gui_summary">启动应用时，打开网页图形用户界面而不是打开主屏幕</string>
-
     <string name="pref_language_default">默认语言</string>
 
     <string-array name="folder_types">

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -232,10 +232,6 @@
 
     <string name="preference_language_summary">選擇應用程式語言</string>
 
-    <string name="start_into_web_gui_title">直接開啟網頁介面</string>
-
-    <string name="start_into_web_gui_summary">當開啟應用程式時，打開網頁介面，而不是主螢幕</string>
-
     <string name="pref_language_default">預設語言</string>
 
     <string-array name="versioning_types">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -428,10 +428,6 @@ Please report any problems you encounter via Github.</string>
 
     <string name="preference_language_summary">Change the app language</string>
 
-    <string name="start_into_web_gui_title">Start directly into web GUI</string>
-
-    <string name="start_into_web_gui_summary">When starting the app, open web GUI instead of the main screen</string>
-
     <string name="pref_language_default">Default Language</string>
 
     <string-array name="folder_types">

--- a/app/src/main/res/xml/app_settings.xml
+++ b/app/src/main/res/xml/app_settings.xml
@@ -95,12 +95,6 @@
             android:title="@string/preference_language_title"
             android:summary="@string/preference_language_summary" />
 
-        <CheckBoxPreference
-            android:key="start_into_web_gui"
-            android:title="@string/start_into_web_gui_title"
-            android:summary="@string/start_into_web_gui_summary"
-            android:defaultValue="false"/>
-
     </PreferenceScreen>
 
     <PreferenceScreen


### PR DESCRIPTION
Purpose:
Remove pref: Start directly into web gui

Testing:
Verified working on AVD 9.x at commit https://github.com/Catfriend1/syncthing-android/commit/97fcb709cf3c137f842bf272adc6c3985dad01da .