### PR TITLE
Make status LED un-clickable, Reduce verbose logging

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/SyncthingApp.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/SyncthingApp.java
@@ -23,11 +23,21 @@ public class SyncthingApp extends Application {
         new Languages(this).setLanguage(this);
 
         // Set VM policy to avoid crash when sending folder URI to file manager.
-        StrictMode.VmPolicy policy = new StrictMode.VmPolicy.Builder()
+        StrictMode.VmPolicy vmPolicy = new StrictMode.VmPolicy.Builder()
                 .detectAll()
                 .penaltyLog()
                 .build();
-        StrictMode.setVmPolicy(policy);
+        StrictMode.setVmPolicy(vmPolicy);
+
+        /*
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P)
+        {
+            StrictMode.ThreadPolicy threadPolicy = new StrictMode.ThreadPolicy.Builder()
+                .permitAll()
+                .build();
+            StrictMode.setThreadPolicy(threadPolicy);
+        }
+        */
     }
 
     public DaggerComponent component() {

--- a/app/src/main/java/com/nutomic/syncthingandroid/fragments/DeviceListFragment.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/fragments/DeviceListFragment.java
@@ -35,6 +35,8 @@ public class DeviceListFragment extends ListFragment implements SyncthingService
 
     private final static String TAG = "DeviceListFragment";
 
+    private static final Boolean ENABLE_VERBOSE_LOG = false;
+
     /**
      * Compares devices by name, uses the device ID as fallback if the name is empty
      */
@@ -86,13 +88,13 @@ public class DeviceListFragment extends ListFragment implements SyncthingService
     }
 
     private void startUpdateListHandler() {
-        Log.v(TAG, "startUpdateListHandler");
+        LogV("startUpdateListHandler");
         mUpdateListHandler.removeCallbacks(mUpdateListRunnable);
         mUpdateListHandler.post(mUpdateListRunnable);
     }
 
     private void stopUpdateListHandler() {
-        Log.v(TAG, "stopUpdateListHandler");
+        LogV("stopUpdateListHandler");
         mUpdateListHandler.removeCallbacks(mUpdateListRunnable);
     }
 
@@ -122,7 +124,7 @@ public class DeviceListFragment extends ListFragment implements SyncthingService
         if (mainActivity.isFinishing()) {
             return;
         }
-        Log.v(TAG, "Invoking updateList on UI thread");
+        LogV("Invoking updateList on UI thread");
         mainActivity.runOnUiThread(DeviceListFragment.this::updateList);
     }
 
@@ -193,4 +195,9 @@ public class DeviceListFragment extends ListFragment implements SyncthingService
         }
     }
 
+    private void LogV(String logMessage) {
+        if (ENABLE_VERBOSE_LOG) {
+            Log.v(TAG, logMessage);
+        }
+    }
 }

--- a/app/src/main/java/com/nutomic/syncthingandroid/fragments/FolderListFragment.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/fragments/FolderListFragment.java
@@ -30,7 +30,9 @@ import java.util.List;
 public class FolderListFragment extends ListFragment implements SyncthingService.OnServiceStateChangeListener,
         AdapterView.OnItemClickListener {
 
-    private final static String TAG = "FolderListFragment";
+    private static final String TAG = "FolderListFragment";
+
+    private static final Boolean ENABLE_VERBOSE_LOG = false;
 
     private Runnable mUpdateListRunnable = new Runnable() {
         @Override
@@ -74,13 +76,13 @@ public class FolderListFragment extends ListFragment implements SyncthingService
     }
 
     private void startUpdateListHandler() {
-        Log.v(TAG, "startUpdateListHandler");
+        LogV("startUpdateListHandler");
         mUpdateListHandler.removeCallbacks(mUpdateListRunnable);
         mUpdateListHandler.post(mUpdateListRunnable);
     }
 
     private void stopUpdateListHandler() {
-        Log.v(TAG, "stopUpdateListHandler");
+        LogV("stopUpdateListHandler");
         mUpdateListHandler.removeCallbacks(mUpdateListRunnable);
     }
 
@@ -110,7 +112,7 @@ public class FolderListFragment extends ListFragment implements SyncthingService
         if (mainActivity.isFinishing()) {
             return;
         }
-        Log.v(TAG, "Invoking updateList on UI thread");
+        LogV("Invoking updateList on UI thread");
         mainActivity.runOnUiThread(FolderListFragment.this::updateList);
     }
 
@@ -180,4 +182,9 @@ public class FolderListFragment extends ListFragment implements SyncthingService
         }
     }
 
+    private void LogV(String logMessage) {
+        if (ENABLE_VERBOSE_LOG) {
+            Log.v(TAG, logMessage);
+        }
+    }
 }

--- a/app/src/main/java/com/nutomic/syncthingandroid/fragments/StatusFragment.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/fragments/StatusFragment.java
@@ -39,6 +39,8 @@ public class StatusFragment extends ListFragment implements SyncthingService.OnS
 
     private static final String TAG = "StatusFragment";
 
+    private static final Boolean ENABLE_VERBOSE_LOG = false;
+
     private Runnable mRestApiQueryRunnable = new Runnable() {
         @Override
         public void run() {
@@ -97,13 +99,13 @@ public class StatusFragment extends ListFragment implements SyncthingService.OnS
     }
 
     private void startRestApiQueryHandler() {
-        Log.v(TAG, "startUpdateListHandler");
+        LogV("startUpdateListHandler");
         mRestApiQueryHandler.removeCallbacks(mRestApiQueryRunnable);
         mRestApiQueryHandler.post(mRestApiQueryRunnable);
     }
 
     private void stopRestApiQueryHandler() {
-        Log.v(TAG, "stopUpdateListHandler");
+        LogV("stopUpdateListHandler");
         mRestApiQueryHandler.removeCallbacks(mRestApiQueryRunnable);
     }
 
@@ -239,7 +241,7 @@ public class StatusFragment extends ListFragment implements SyncthingService.OnS
         if (restApi == null) {
             return;
         }
-        Log.v(TAG, "Invoking REST status queries");
+        LogV("Invoking REST status queries");
         restApi.getSystemStatus(this::onReceiveSystemStatus);
         restApi.getConnections(this::onReceiveConnections);
         // onReceiveSystemStatus, onReceiveConnections will call {@link #updateStatus}.
@@ -300,4 +302,9 @@ public class StatusFragment extends ListFragment implements SyncthingService.OnS
         updateStatus();
     }
 
+    private void LogV(String logMessage) {
+        if (ENABLE_VERBOSE_LOG) {
+            Log.v(TAG, logMessage);
+        }
+    }
 }

--- a/app/src/main/java/com/nutomic/syncthingandroid/model/Folder.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/model/Folder.java
@@ -15,7 +15,7 @@ public class Folder {
 
     // Folder Configuration
     public String id;
-    public String label;
+    public String label = "";
     public String filesystemType = "basic";
     public String path;
     public String type = Constants.FOLDER_TYPE_SEND_RECEIVE;

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/EventProcessor.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/EventProcessor.java
@@ -84,7 +84,7 @@ public class EventProcessor implements  Runnable, RestApi.OnReceiveEventListener
             public void onDone(long lastId) {
                 if (lastId < mLastEventId) mLastEventId = 0;
 
-                Log.d(TAG, "Reading events starting with id " + mLastEventId);
+                LogV("Reading events starting with id " + mLastEventId);
 
                 mRestApi.getEvents(mLastEventId, 0, EventProcessor.this);
             }
@@ -99,7 +99,7 @@ public class EventProcessor implements  Runnable, RestApi.OnReceiveEventListener
         switch (event.type) {
             case "ConfigSaved":
                 if (mRestApi != null) {
-                    Log.d(TAG, "Forwarding ConfigSaved event to RestApi to get the updated config.");
+                    LogV("Forwarding ConfigSaved event to RestApi to get the updated config.");
                     mRestApi.reloadConfig();
                 }
                 break;
@@ -157,6 +157,7 @@ public class EventProcessor implements  Runnable, RestApi.OnReceiveEventListener
             case "DeviceDiscovered":
             case "DownloadProgress":
             case "FolderPaused":
+            case "FolderResumed":
             case "FolderScanProgress":
             case "FolderSummary":
             case "FolderWatchStateChanged":
@@ -169,7 +170,7 @@ public class EventProcessor implements  Runnable, RestApi.OnReceiveEventListener
             case "StartupComplete":
             case "StateChanged":
                 if (ENABLE_VERBOSE_LOG) {
-                    Log.v(TAG, "Ignored event " + event.type + ", data " + event.data);
+                    LogV("Ignored event " + event.type + ", data " + event.data);
                 }
                 break;
             default:
@@ -337,6 +338,12 @@ public class EventProcessor implements  Runnable, RestApi.OnReceiveEventListener
             if (result == 1 && cookie != null) {
                 // ToDo Log.v(TAG, "onItemFinished: onDeleteComplete: [ok] file=" + cookie.toString() + ", token=" + Integer.toString(token));
             }
+        }
+    }
+
+    private void LogV(String logMessage) {
+        if (ENABLE_VERBOSE_LOG) {
+            Log.v(TAG, logMessage);
         }
     }
 }

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/ReceiverManager.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/ReceiverManager.java
@@ -13,12 +13,14 @@ public class ReceiverManager {
 
     private static final String TAG = "ReceiverManager";
 
+    private static final Boolean ENABLE_VERBOSE_LOG = false;
+
     private static List<BroadcastReceiver> mReceivers = new ArrayList<BroadcastReceiver>();
 
     public static synchronized void registerReceiver(Context context, BroadcastReceiver receiver, IntentFilter intentFilter) {
         mReceivers.add(receiver);
         context.registerReceiver(receiver, intentFilter);
-        Log.v(TAG, "Registered receiver: " + receiver + " with filter: " + intentFilter);
+        LogV("Registered receiver: " + receiver + " with filter: " + intentFilter);
     }
 
     public static synchronized boolean isReceiverRegistered(BroadcastReceiver receiver) {
@@ -36,7 +38,7 @@ public class ReceiverManager {
             if (isReceiverRegistered(receiver)) {
                 try {
                     context.unregisterReceiver(receiver);
-                    Log.v(TAG, "Unregistered receiver: " + receiver);
+                    LogV("Unregistered receiver: " + receiver);
                 } catch(IllegalArgumentException e) {
                     // We have to catch the race condition a registration is still pending in android
                     // according to https://stackoverflow.com/a/3568906
@@ -44,6 +46,12 @@ public class ReceiverManager {
                 }
                 iter.remove();
             }
+        }
+    }
+
+    private static void LogV(String logMessage) {
+        if (ENABLE_VERBOSE_LOG) {
+            Log.v(TAG, logMessage);
         }
     }
 }

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/RestApi.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/RestApi.java
@@ -815,14 +815,13 @@ public class RestApi {
      * Event triggered by {@link RunConditionMonitor} routed here through {@link SyncthingService}.
      */
     public void applyCustomRunConditions(RunConditionMonitor runConditionMonitor) {
-        Log.v(TAG, "applyCustomRunConditions: Event fired.");
         SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(mContext);
         synchronized (mConfigLock) {
             Boolean configChanged = false;
 
             // Check if the config has been loaded.
             if (mConfig == null) {
-                Log.d(TAG, "applyCustomRunConditions: mConfig is not ready yet.");
+                Log.w(TAG, "applyCustomRunConditions: mConfig is not ready yet.");
                 return;
             }
 
@@ -877,6 +876,8 @@ public class RestApi {
             if (configChanged) {
                 LogV("applyCustomRunConditions: Sending changed config ...");
                 sendConfig();
+            } else {
+                LogV("applyCustomRunConditions: No action was necessary.");
             }
         }
     }

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/RestApi.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/RestApi.java
@@ -177,7 +177,6 @@ public class RestApi {
         new GetRequest(mContext, mUrl, GetRequest.URI_VERSION, mApiKey, null, result -> {
             JsonObject json = new JsonParser().parse(result).getAsJsonObject();
             mVersion = json.get("version").getAsString();
-            Log.i(TAG, "Syncthing version is " + mVersion);
             updateDebugFacilitiesCache();
             synchronized (mAsyncQueryCompleteLock) {
                 asyncQueryVersionComplete = true;
@@ -203,7 +202,8 @@ public class RestApi {
 
     private void checkReadConfigFromRestApiCompleted() {
         if (asyncQueryVersionComplete && asyncQueryConfigComplete && asyncQuerySystemStatusComplete) {
-            Log.d(TAG, "Reading config from REST completed.");
+            LogV("Reading config from REST completed. Syncthing version is " + mVersion);
+            // Tell SyncthingService it can transition to State.ACTIVE.
             mOnApiAvailableListener.onApiAvailable();
         }
     }

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/RestApi.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/RestApi.java
@@ -816,21 +816,22 @@ public class RestApi {
     /**
      * Event triggered by {@link RunConditionMonitor} routed here through {@link SyncthingService}.
      */
-    public void onSyncPreconditionChanged(RunConditionMonitor runConditionMonitor) {
-        Log.v(TAG, "onSyncPreconditionChanged: Event fired.");
+    public void applyCustomRunConditions(RunConditionMonitor runConditionMonitor) {
+        Log.v(TAG, "applyCustomRunConditions: Event fired.");
         SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(mContext);
         synchronized (mConfigLock) {
             Boolean configChanged = false;
 
             // Check if the config has been loaded.
             if (mConfig == null) {
-                Log.d(TAG, "onSyncPreconditionChanged: mConfig is not ready yet.");
+                Log.d(TAG, "applyCustomRunConditions: mConfig is not ready yet.");
                 return;
             }
 
             // Check if the folders are available from config.
             if (mConfig.folders != null) {
                 for (Folder folder : mConfig.folders) {
+                    // Log.v(TAG, "applyCustomRunConditions: Processing config of folder(" + folder.label + ")");
                     Boolean folderCustomSyncConditionsEnabled = sharedPreferences.getBoolean(
                         Constants.DYN_PREF_OBJECT_CUSTOM_SYNC_CONDITIONS(Constants.PREF_OBJECT_PREFIX_FOLDER + folder.id), false
                     );
@@ -838,22 +839,23 @@ public class RestApi {
                         Boolean syncConditionsMet = runConditionMonitor.checkObjectSyncConditions(
                             Constants.PREF_OBJECT_PREFIX_FOLDER + folder.id
                         );
-                        Log.v(TAG, "onSyncPreconditionChanged: syncFolder(" + folder.id + ")=" + (syncConditionsMet ? "1" : "0"));
+                        Log.v(TAG, "applyCustomRunConditions: f(" + folder.label + ")=" + (syncConditionsMet ? "1" : "0"));
                         if (folder.paused != !syncConditionsMet) {
                             folder.paused = !syncConditionsMet;
-                            Log.d(TAG, "onSyncPreconditionChanged: syncFolder(" + folder.id + ")=" + (syncConditionsMet ? ">1" : ">0"));
+                            Log.d(TAG, "applyCustomRunConditions: f(" + folder.label + ")=" + (syncConditionsMet ? ">1" : ">0"));
                             configChanged = true;
                         }
                     }
                 }
             } else {
-                Log.d(TAG, "onSyncPreconditionChanged: mConfig.folders is not ready yet.");
+                Log.d(TAG, "applyCustomRunConditions: mConfig.folders is not ready yet.");
                 return;
             }
 
             // Check if the devices are available from config.
             if (mConfig.devices != null) {
                 for (Device device : mConfig.devices) {
+                    // Log.v(TAG, "applyCustomRunConditions: Processing config of device(" + device.name + ")");
                     Boolean deviceCustomSyncConditionsEnabled = sharedPreferences.getBoolean(
                         Constants.DYN_PREF_OBJECT_CUSTOM_SYNC_CONDITIONS(Constants.PREF_OBJECT_PREFIX_DEVICE + device.deviceID), false
                     );
@@ -861,21 +863,21 @@ public class RestApi {
                         Boolean syncConditionsMet = runConditionMonitor.checkObjectSyncConditions(
                             Constants.PREF_OBJECT_PREFIX_DEVICE + device.deviceID
                         );
-                        Log.v(TAG, "onSyncPreconditionChanged: syncDevice(" + device.deviceID + ")=" + (syncConditionsMet ? "1" : "0"));
+                        Log.v(TAG, "applyCustomRunConditions: d(" + device.name + ")=" + (syncConditionsMet ? "1" : "0"));
                         if (device.paused != !syncConditionsMet) {
                             device.paused = !syncConditionsMet;
-                            Log.d(TAG, "onSyncPreconditionChanged: syncDevice(" + device.deviceID + ")=" + (syncConditionsMet ? ">1" : ">0"));
+                            Log.d(TAG, "applyCustomRunConditions: d(" + device.name + ")=" + (syncConditionsMet ? ">1" : ">0"));
                             configChanged = true;
                         }
                     }
                 }
             } else {
-                Log.d(TAG, "onSyncPreconditionChanged: mConfig.devices is not ready yet.");
+                Log.d(TAG, "applyCustomRunConditions: mConfig.devices is not ready yet.");
                 return;
             }
 
             if (configChanged) {
-                Log.v(TAG, "onSyncPreconditionChanged: Sending changed config ...");
+                Log.v(TAG, "applyCustomRunConditions: Sending changed config ...");
                 sendConfig();
             }
         }

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/RestApi.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/RestApi.java
@@ -829,7 +829,7 @@ public class RestApi {
             // Check if the folders are available from config.
             if (mConfig.folders != null) {
                 for (Folder folder : mConfig.folders) {
-                    // Log.v(TAG, "applyCustomRunConditions: Processing config of folder(" + folder.label + ")");
+                    // LogV("applyCustomRunConditions: Processing config of folder(" + folder.label + ")");
                     Boolean folderCustomSyncConditionsEnabled = sharedPreferences.getBoolean(
                         Constants.DYN_PREF_OBJECT_CUSTOM_SYNC_CONDITIONS(Constants.PREF_OBJECT_PREFIX_FOLDER + folder.id), false
                     );
@@ -837,7 +837,7 @@ public class RestApi {
                         Boolean syncConditionsMet = runConditionMonitor.checkObjectSyncConditions(
                             Constants.PREF_OBJECT_PREFIX_FOLDER + folder.id
                         );
-                        Log.v(TAG, "applyCustomRunConditions: f(" + folder.label + ")=" + (syncConditionsMet ? "1" : "0"));
+                        LogV("applyCustomRunConditions: f(" + folder.label + ")=" + (syncConditionsMet ? "1" : "0"));
                         if (folder.paused != !syncConditionsMet) {
                             folder.paused = !syncConditionsMet;
                             Log.d(TAG, "applyCustomRunConditions: f(" + folder.label + ")=" + (syncConditionsMet ? ">1" : ">0"));
@@ -853,7 +853,7 @@ public class RestApi {
             // Check if the devices are available from config.
             if (mConfig.devices != null) {
                 for (Device device : mConfig.devices) {
-                    // Log.v(TAG, "applyCustomRunConditions: Processing config of device(" + device.name + ")");
+                    // LogV("applyCustomRunConditions: Processing config of device(" + device.name + ")");
                     Boolean deviceCustomSyncConditionsEnabled = sharedPreferences.getBoolean(
                         Constants.DYN_PREF_OBJECT_CUSTOM_SYNC_CONDITIONS(Constants.PREF_OBJECT_PREFIX_DEVICE + device.deviceID), false
                     );
@@ -861,7 +861,7 @@ public class RestApi {
                         Boolean syncConditionsMet = runConditionMonitor.checkObjectSyncConditions(
                             Constants.PREF_OBJECT_PREFIX_DEVICE + device.deviceID
                         );
-                        Log.v(TAG, "applyCustomRunConditions: d(" + device.name + ")=" + (syncConditionsMet ? "1" : "0"));
+                        LogV("applyCustomRunConditions: d(" + device.name + ")=" + (syncConditionsMet ? "1" : "0"));
                         if (device.paused != !syncConditionsMet) {
                             device.paused = !syncConditionsMet;
                             Log.d(TAG, "applyCustomRunConditions: d(" + device.name + ")=" + (syncConditionsMet ? ">1" : ">0"));
@@ -875,7 +875,7 @@ public class RestApi {
             }
 
             if (configChanged) {
-                Log.v(TAG, "applyCustomRunConditions: Sending changed config ...");
+                LogV("applyCustomRunConditions: Sending changed config ...");
                 sendConfig();
             }
         }

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/RestApi.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/RestApi.java
@@ -64,6 +64,8 @@ public class RestApi {
 
     private static final String TAG = "RestApi";
 
+    private static final Boolean ENABLE_VERBOSE_LOG = false;
+
     /**
      * Compares folders by labels, uses the folder ID as fallback if the label is empty
      */
@@ -166,7 +168,7 @@ public class RestApi {
      * Gets local device ID, syncthing version and config, then calls all OnApiAvailableListeners.
      */
     public void readConfigFromRestApi() {
-        Log.v(TAG, "Reading config from REST ...");
+        Log.d(TAG, "Reading config from REST ...");
         synchronized (mAsyncQueryCompleteLock) {
             asyncQueryVersionComplete = false;
             asyncQueryConfigComplete = false;
@@ -201,7 +203,7 @@ public class RestApi {
 
     private void checkReadConfigFromRestApiCompleted() {
         if (asyncQueryVersionComplete && asyncQueryConfigComplete && asyncQuerySystemStatusComplete) {
-            Log.v(TAG, "Reading config from REST completed.");
+            Log.d(TAG, "Reading config from REST completed.");
             mOnApiAvailableListener.onApiAvailable();
         }
     }
@@ -219,11 +221,9 @@ public class RestApi {
         if (!configParseSuccess) {
             throw new RuntimeException("config is null: " + result);
         }
-        Log.v(TAG, "onReloadConfigComplete: Successfully parsed configuration.");
-        if (BuildConfig.DEBUG) {
-            Log.v(TAG, "mConfig.pendingDevices = " + new Gson().toJson(mConfig.pendingDevices));
-            Log.v(TAG, "mConfig.remoteIgnoredDevices = " + new Gson().toJson(mConfig.remoteIgnoredDevices));
-        }
+        Log.d(TAG, "onReloadConfigComplete: Successfully parsed configuration.");
+        LogV("mConfig.pendingDevices = " + new Gson().toJson(mConfig.pendingDevices));
+        LogV("mConfig.remoteIgnoredDevices = " + new Gson().toJson(mConfig.remoteIgnoredDevices));
 
         // Update cached device and folder information stored in the mCompletion model.
         mCompletion.updateFromConfig(getDevices(true), getFolders());
@@ -340,10 +340,8 @@ public class RestApi {
                         }
                     }
                     device.ignoredFolders.add(ignoredFolder);
-                    if (BuildConfig.DEBUG) {
-                        Log.v(TAG, "device.pendingFolders = " + new Gson().toJson(device.pendingFolders));
-                        Log.v(TAG, "device.ignoredFolders = " + new Gson().toJson(device.ignoredFolders));
-                    }
+                    LogV("device.pendingFolders = " + new Gson().toJson(device.pendingFolders));
+                    LogV("device.ignoredFolders = " + new Gson().toJson(device.ignoredFolders));
                     sendConfig();
                     Log.d(TAG, "Ignored folder [" + folderId + "] announced by device [" + deviceId + "]");
 
@@ -521,7 +519,7 @@ public class RestApi {
         if (devices.isEmpty()) {
             throw new RuntimeException("RestApi.getLocalDevice: devices is empty.");
         }
-        Log.v(TAG, "getLocalDevice: Looking for local device ID " + mLocalDeviceId);
+        LogV("getLocalDevice: Looking for local device ID " + mLocalDeviceId);
         for (Device d : devices) {
             if (d.deviceID.equals(mLocalDeviceId)) {
                 return deepCopy(d, Device.class);
@@ -880,6 +878,12 @@ public class RestApi {
                 Log.v(TAG, "applyCustomRunConditions: Sending changed config ...");
                 sendConfig();
             }
+        }
+    }
+
+    private void LogV(String logMessage) {
+        if (ENABLE_VERBOSE_LOG) {
+            Log.v(TAG, logMessage);
         }
     }
 }

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/RestApi.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/RestApi.java
@@ -168,7 +168,7 @@ public class RestApi {
      * Gets local device ID, syncthing version and config, then calls all OnApiAvailableListeners.
      */
     public void readConfigFromRestApi() {
-        Log.d(TAG, "Reading config from REST ...");
+        LogV("Querying config from REST ...");
         synchronized (mAsyncQueryCompleteLock) {
             asyncQueryVersionComplete = false;
             asyncQueryConfigComplete = false;

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/RunConditionMonitor.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/RunConditionMonitor.java
@@ -39,6 +39,8 @@ public class RunConditionMonitor {
 
     private static final String TAG = "RunConditionMonitor";
 
+    private static final Boolean ENABLE_VERBOSE_LOG = false;
+
     private static final String POWER_SOURCE_CHARGER_BATTERY = "ac_and_battery_power";
     private static final String POWER_SOURCE_CHARGER = "ac_power";
     private static final String POWER_SOURCE_BATTERY = "battery_power";
@@ -109,7 +111,7 @@ public class RunConditionMonitor {
     public RunConditionMonitor(Context context,
             OnShouldRunChangedListener onShouldRunChangedListener,
             OnSyncPreconditionChangedListener onSyncPreconditionChangedListener) {
-        Log.v(TAG, "Created new instance");
+        LogV("Created new instance");
         ((SyncthingApp) context.getApplicationContext()).component().inject(this);
         mContext = context;
         res = mContext.getResources();
@@ -144,7 +146,7 @@ public class RunConditionMonitor {
     }
 
     public void shutdown() {
-        Log.v(TAG, "Shutting down");
+        LogV("Shutting down");
         if (mSyncStatusObserverHandle != null) {
             ContentResolver.removeStatusChangeListener(mSyncStatusObserverHandle);
             mSyncStatusObserverHandle = null;
@@ -303,14 +305,14 @@ public class RunConditionMonitor {
         switch (prefPowerSource) {
             case POWER_SOURCE_CHARGER:
                 if (!isCharging()) {
-                    Log.v(TAG, "decideShouldRun: POWER_SOURCE_AC && !isCharging");
+                    LogV("decideShouldRun: POWER_SOURCE_AC && !isCharging");
                     mRunDecisionExplanation = res.getString(R.string.reason_not_charging);
                     return false;
                 }
                 break;
             case POWER_SOURCE_BATTERY:
                 if (isCharging()) {
-                    Log.v(TAG, "decideShouldRun: POWER_SOURCE_BATTERY && isCharging");
+                    LogV("decideShouldRun: POWER_SOURCE_BATTERY && isCharging");
                     mRunDecisionExplanation = res.getString(R.string.reason_not_on_battery_power);
                     return false;
                 }
@@ -323,7 +325,7 @@ public class RunConditionMonitor {
         // Power saving
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             if (prefRespectPowerSaving && isPowerSaving()) {
-                Log.v(TAG, "decideShouldRun: prefRespectPowerSaving && isPowerSaving");
+                LogV("decideShouldRun: prefRespectPowerSaving && isPowerSaving");
                 mRunDecisionExplanation = res.getString(R.string.reason_not_while_power_saving);
                 return false;
             }
@@ -331,7 +333,7 @@ public class RunConditionMonitor {
 
         // Android global AutoSync setting.
         if (prefRespectMasterSync && !ContentResolver.getMasterSyncAutomatically()) {
-            Log.v(TAG, "decideShouldRun: prefRespectMasterSync && !getMasterSyncAutomatically");
+            LogV("decideShouldRun: prefRespectMasterSync && !getMasterSyncAutomatically");
             mRunDecisionExplanation = res.getString(R.string.reason_not_while_auto_sync_data_disabled);
             return false;
         }
@@ -341,7 +343,7 @@ public class RunConditionMonitor {
         mRunDecisionExplanation += scr.explanation;
         if (scr.conditionMet) {
             // Mobile data is connected.
-            Log.v(TAG, "decideShouldRun: checkConditionSyncOnMobileData");
+            LogV("decideShouldRun: checkConditionSyncOnMobileData");
             return true;
         }
 
@@ -350,19 +352,19 @@ public class RunConditionMonitor {
         mRunDecisionExplanation += scr.explanation;
         if (scr.conditionMet) {
             // Wifi is connected.
-            Log.v(TAG, "decideShouldRun: checkConditionSyncOnWifi");
+            LogV("decideShouldRun: checkConditionSyncOnWifi");
 
             scr = checkConditionSyncOnMeteredWifi(Constants.PREF_RUN_ON_METERED_WIFI);
             mRunDecisionExplanation += scr.explanation;
             if (scr.conditionMet) {
                 // Wifi type is allowed.
-                Log.v(TAG, "decideShouldRun: checkConditionSyncOnWifi && checkConditionSyncOnMeteredWifi");
+                LogV("decideShouldRun: checkConditionSyncOnWifi && checkConditionSyncOnMeteredWifi");
 
                 scr = checkConditionSyncOnWhitelistedWifi(Constants.PREF_USE_WIFI_SSID_WHITELIST, Constants.PREF_WIFI_SSID_WHITELIST);
                 mRunDecisionExplanation += scr.explanation;
                 if (scr.conditionMet) {
                     // Wifi is whitelisted.
-                    Log.v(TAG, "decideShouldRun: checkConditionSyncOnWifi && checkConditionSyncOnMeteredWifi && checkConditionSyncOnWhitelistedWifi");
+                    LogV("decideShouldRun: checkConditionSyncOnWifi && checkConditionSyncOnMeteredWifi && checkConditionSyncOnWhitelistedWifi");
                     return true;
                 }
             }
@@ -370,7 +372,7 @@ public class RunConditionMonitor {
 
         // Run in flight mode.
         if (prefRunInFlightMode && isFlightMode()) {
-            Log.v(TAG, "decideShouldRun: prefRunInFlightMode && isFlightMode");
+            LogV("decideShouldRun: prefRunInFlightMode && isFlightMode");
             mRunDecisionExplanation += "\n" + res.getString(R.string.reason_on_flight_mode);
             return true;
         }
@@ -378,7 +380,7 @@ public class RunConditionMonitor {
         /**
          * If none of the above run conditions matched, don't run.
          */
-        Log.v(TAG, "decideShouldRun: return false");
+        LogV("decideShouldRun: return false");
         return false;
     }
 
@@ -390,7 +392,7 @@ public class RunConditionMonitor {
         SyncConditionResult scr = checkConditionSyncOnMobileData(Constants.DYN_PREF_OBJECT_SYNC_ON_MOBILE_DATA(objectPrefixAndId));
         if (scr.conditionMet) {
             // Mobile data is connected.
-            Log.v(TAG, "checkObjectSyncConditions(" + objectPrefixAndId + "): checkConditionSyncOnMobileData");
+            LogV("checkObjectSyncConditions(" + objectPrefixAndId + "): checkConditionSyncOnMobileData");
             return true;
         }
 
@@ -398,12 +400,12 @@ public class RunConditionMonitor {
         scr = checkConditionSyncOnWifi(Constants.DYN_PREF_OBJECT_SYNC_ON_WIFI(objectPrefixAndId));
         if (scr.conditionMet) {
             // Wifi is connected.
-            Log.v(TAG, "checkObjectSyncConditions(" + objectPrefixAndId + "): checkConditionSyncOnWifi");
+            LogV("checkObjectSyncConditions(" + objectPrefixAndId + "): checkConditionSyncOnWifi");
 
             scr = checkConditionSyncOnMeteredWifi(Constants.DYN_PREF_OBJECT_SYNC_ON_METERED_WIFI(objectPrefixAndId));
             if (scr.conditionMet) {
                 // Wifi type is allowed.
-                Log.v(TAG, "checkObjectSyncConditions(" + objectPrefixAndId + "): checkConditionSyncOnWifi && checkConditionSyncOnMeteredWifi");
+                LogV("checkObjectSyncConditions(" + objectPrefixAndId + "): checkConditionSyncOnWifi && checkConditionSyncOnMeteredWifi");
 
                 scr = checkConditionSyncOnWhitelistedWifi(
                     Constants.DYN_PREF_OBJECT_USE_WIFI_SSID_WHITELIST(objectPrefixAndId),
@@ -411,7 +413,7 @@ public class RunConditionMonitor {
                 );
                 if (scr.conditionMet) {
                     // Wifi is whitelisted.
-                    Log.v(TAG, "checkObjectSyncConditions(" + objectPrefixAndId + "): checkConditionSyncOnWifi && checkConditionSyncOnMeteredWifi && checkConditionSyncOnWhitelistedWifi");
+                    LogV("checkObjectSyncConditions(" + objectPrefixAndId + "): checkConditionSyncOnWifi && checkConditionSyncOnMeteredWifi && checkConditionSyncOnWhitelistedWifi");
                     return true;
                 }
             }
@@ -426,11 +428,11 @@ public class RunConditionMonitor {
     private boolean wifiWhitelistConditionMet (boolean prefWifiWhitelistEnabled,
             Set<String> whitelistedWifiSsids) throws LocationUnavailableException {
         if (!prefWifiWhitelistEnabled) {
-            Log.v(TAG, "handleWifiWhitelist: !prefWifiWhitelistEnabled");
+            LogV("handleWifiWhitelist: !prefWifiWhitelistEnabled");
             return true;
         }
         if (isWifiConnectionWhitelisted(whitelistedWifiSsids)) {
-            Log.v(TAG, "handleWifiWhitelist: isWifiConnectionWhitelisted");
+            LogV("handleWifiWhitelist: isWifiConnectionWhitelisted");
             return true;
         }
         return false;
@@ -572,4 +574,9 @@ public class RunConditionMonitor {
 
     }
 
+    private void LogV(String logMessage) {
+        if (ENABLE_VERBOSE_LOG) {
+            Log.v(TAG, logMessage);
+        }
+    }
 }

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
@@ -52,6 +52,8 @@ public class SyncthingRunnable implements Runnable {
     private static final String TAG = "SyncthingRunnable";
     private static final String TAG_NATIVE = "SyncthingNativeCode";
     private static final String TAG_NICE = "SyncthingRunnableIoNice";
+
+    private static final Boolean ENABLE_VERBOSE_LOG = false;
     private static final int LOG_FILE_MAX_LINES = 10;
 
     private static final AtomicReference<Process> mSyncthing = new AtomicReference<>();
@@ -178,7 +180,7 @@ public class SyncthingRunnable implements Runnable {
                     br = new BufferedReader(new InputStreamReader(process.getInputStream(), Charsets.UTF_8));
                     String line;
                     while ((line = br.readLine()) != null) {
-                        Log.println(Log.INFO, TAG_NATIVE, line);
+                        Log.i(TAG_NATIVE, line);
                         capturedStdOut = capturedStdOut + line + "\n";
                     }
                 } catch (IOException e) {
@@ -195,7 +197,7 @@ public class SyncthingRunnable implements Runnable {
             niceSyncthing();
 
             exitCode = process.waitFor();
-            Log.i(TAG, "Syncthing exited with code " + exitCode);
+            LogV("Syncthing exited with code " + exitCode);
             mSyncthing.set(null);
             if (lInfo != null) {
                 lInfo.join();
@@ -381,13 +383,13 @@ public class SyncthingRunnable implements Runnable {
         int exitCode;
         List<String> syncthingPIDs = getSyncthingPIDs(true);
         if (syncthingPIDs.isEmpty()) {
-            Log.d(TAG, "killSyncthing: Found no running instances of " + Constants.FILENAME_SYNCTHING_BINARY);
+            LogV("killSyncthing: Found no running instances of " + Constants.FILENAME_SYNCTHING_BINARY);
             return;
         }
         for (String syncthingPID : syncthingPIDs) {
             exitCode = Util.runShellCommand("kill -SIGINT " + syncthingPID + "\n", mUseRoot);
             if (exitCode == 0) {
-                Log.d(TAG, "Sent kill SIGINT to process " + syncthingPID);
+                LogV("Sent kill SIGINT to process " + syncthingPID);
             } else {
                 Log.w(TAG, "Failed to send kill SIGINT to process " + syncthingPID +
                         " exit code " + Integer.toString(exitCode));
@@ -397,11 +399,11 @@ public class SyncthingRunnable implements Runnable {
         /**
          * Wait for the syncthing instance to end.
          */
-        Log.v(TAG, "Waiting for all syncthing instances to end ...");
+        LogV("Waiting for all syncthing instances to end ...");
         while (!getSyncthingPIDs(false).isEmpty()) {
             SystemClock.sleep(50);
         }
-        Log.v(TAG, "killSyncthing: Complete.");
+        Log.d(TAG, "killSyncthing: Complete.");
     }
 
     /**
@@ -555,5 +557,11 @@ public class SyncthingRunnable implements Runnable {
             super(message, throwable);
         }
 
+    }
+
+    private void LogV(String logMessage) {
+        if (ENABLE_VERBOSE_LOG) {
+            Log.v(TAG, logMessage);
+        }
     }
 }

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
@@ -420,7 +420,6 @@ public class SyncthingService extends Service {
             }
         }
 
-        Log.v(TAG, "applyCustomRunConditions: Event fired while syncthing is not running.");
         Boolean configChanged = false;
         ConfigXml configXml;
 
@@ -487,8 +486,10 @@ public class SyncthingService extends Service {
         }
 
         if (configChanged) {
-            LogV("applyCustomRunConditions: Saving changed config to disk ...");
+            LogV("applyCustomRunConditions: Saving changed config ...");
             configXml.saveChanges();
+        } else {
+            LogV("applyCustomRunConditions: No action was necessary.");
         }
     }
 

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
@@ -286,7 +286,7 @@ public class SyncthingService extends Service {
                  */
                 mRunConditionMonitor = new RunConditionMonitor(SyncthingService.this,
                     this::onShouldRunDecisionChanged,
-                    this::onSyncPreconditionChanged
+                    this::applyCustomRunConditions
                 );
             }
         }
@@ -410,16 +410,16 @@ public class SyncthingService extends Service {
      * After sync preconditions changed, we need to inform {@link RestApi} to pause or
      * unpause devices and folders as defined in per-object sync preferences.
      */
-    private void onSyncPreconditionChanged(RunConditionMonitor runConditionMonitor) {
+    private void applyCustomRunConditions(RunConditionMonitor runConditionMonitor) {
         synchronized (mStateLock) {
             if (mRestApi != null && mCurrentState == State.ACTIVE) {
                 // Forward event because syncthing is running.
-                mRestApi.onSyncPreconditionChanged(runConditionMonitor);
+                mRestApi.applyCustomRunConditions(runConditionMonitor);
                 return;
             }
         }
 
-        Log.v(TAG, "onSyncPreconditionChanged: Event fired while syncthing is not running.");
+        Log.v(TAG, "applyCustomRunConditions: Event fired while syncthing is not running.");
         Boolean configChanged = false;
         ConfigXml configXml;
 
@@ -428,7 +428,7 @@ public class SyncthingService extends Service {
         try {
             configXml.loadConfig();
         } catch (ConfigXml.OpenConfigException e) {
-            mNotificationHandler.showCrashedNotification(R.string.config_read_failed, "onSyncPreconditionChanged:ConfigXml.OpenConfigException");
+            mNotificationHandler.showCrashedNotification(R.string.config_read_failed, "applyCustomRunConditions:ConfigXml.OpenConfigException");
             synchronized (mStateLock) {
                 onServiceStateChange(State.ERROR);
             }
@@ -439,7 +439,7 @@ public class SyncthingService extends Service {
         List<Folder> folders = configXml.getFolders();
         if (folders != null) {
             for (Folder folder : folders) {
-                // Log.v(TAG, "onSyncPreconditionChanged: Processing config of folder.id=" + folder.id);
+                // Log.v(TAG, "applyCustomRunConditions: Processing config of folder(" + folder.label + ")");
                 Boolean folderCustomSyncConditionsEnabled = mPreferences.getBoolean(
                     Constants.DYN_PREF_OBJECT_CUSTOM_SYNC_CONDITIONS(Constants.PREF_OBJECT_PREFIX_FOLDER + folder.id), false
                 );
@@ -447,16 +447,16 @@ public class SyncthingService extends Service {
                     Boolean syncConditionsMet = runConditionMonitor.checkObjectSyncConditions(
                         Constants.PREF_OBJECT_PREFIX_FOLDER + folder.id
                     );
-                    Log.v(TAG, "onSyncPreconditionChanged: syncFolder(" + folder.id + ")=" + (syncConditionsMet ? "1" : "0"));
+                    Log.v(TAG, "applyCustomRunConditions: f(" + folder.label + ")=" + (syncConditionsMet ? "1" : "0"));
                     if (folder.paused != !syncConditionsMet) {
                         configXml.setFolderPause(folder.id, !syncConditionsMet);
-                        Log.d(TAG, "onSyncPreconditionChanged: syncFolder(" + folder.id + ")=" + (syncConditionsMet ? ">1" : ">0"));
+                        Log.d(TAG, "applyCustomRunConditions: f(" + folder.label + ")=" + (syncConditionsMet ? ">1" : ">0"));
                         configChanged = true;
                     }
                 }
             }
         } else {
-            Log.d(TAG, "onSyncPreconditionChanged: folders == null");
+            Log.d(TAG, "applyCustomRunConditions: folders == null");
             return;
         }
 
@@ -464,7 +464,7 @@ public class SyncthingService extends Service {
         List<Device> devices = configXml.getDevices(false);
         if (devices != null) {
             for (Device device : devices) {
-                // Log.v(TAG, "onSyncPreconditionChanged: Processing config of device.id=" + device.deviceID);
+                // Log.v(TAG, "applyCustomRunConditions: Processing config of device(" + device.name + ")");
                 Boolean deviceCustomSyncConditionsEnabled = mPreferences.getBoolean(
                     Constants.DYN_PREF_OBJECT_CUSTOM_SYNC_CONDITIONS(Constants.PREF_OBJECT_PREFIX_DEVICE + device.deviceID), false
                 );
@@ -472,21 +472,21 @@ public class SyncthingService extends Service {
                     Boolean syncConditionsMet = runConditionMonitor.checkObjectSyncConditions(
                         Constants.PREF_OBJECT_PREFIX_DEVICE + device.deviceID
                     );
-                    Log.v(TAG, "onSyncPreconditionChanged: syncDevice(" + device.deviceID + ")=" + (syncConditionsMet ? "1" : "0"));
+                    Log.v(TAG, "applyCustomRunConditions: d(" + device.name + ")=" + (syncConditionsMet ? "1" : "0"));
                     if (device.paused != !syncConditionsMet) {
                         configXml.setDevicePause(device.deviceID, !syncConditionsMet);
-                        Log.d(TAG, "onSyncPreconditionChanged: syncDevice(" + device.deviceID + ")=" + (syncConditionsMet ? ">1" : ">0"));
+                        Log.d(TAG, "applyCustomRunConditions: d(" + device.name + ")=" + (syncConditionsMet ? ">1" : ">0"));
                         configChanged = true;
                     }
                 }
             }
         } else {
-            Log.d(TAG, "onSyncPreconditionChanged: devices == null");
+            Log.d(TAG, "applyCustomRunConditions: devices == null");
             return;
         }
 
         if (configChanged) {
-            Log.v(TAG, "onSyncPreconditionChanged: Saving changed config to disk ...");
+            Log.v(TAG, "applyCustomRunConditions: Saving changed config to disk ...");
             configXml.saveChanges();
         }
     }
@@ -587,7 +587,7 @@ public class SyncthingService extends Service {
             onServiceStateChange(State.ACTIVE);
         }
         if (mRestApi != null && mRunConditionMonitor != null) {
-            mRestApi.onSyncPreconditionChanged(mRunConditionMonitor);
+            mRestApi.applyCustomRunConditions(mRunConditionMonitor);
         }
 
         /**

--- a/app/src/main/res/layout/widget_toolbar.xml
+++ b/app/src/main/res/layout/widget_toolbar.xml
@@ -22,6 +22,7 @@
             android:layout_height="wrap_content"
             android:checked="true"
             android:focusable="false"
+            android:clickable="false"
             android:visibility="gone"
             app:buttonTint="#76ff03"/>
 
@@ -31,6 +32,7 @@
             android:layout_height="wrap_content"
             android:checked="true"
             android:focusable="false"
+            android:clickable="false"
             android:visibility="gone"
             app:buttonTint="#fff103"/>
 
@@ -40,6 +42,7 @@
             android:layout_height="wrap_content"
             android:checked="true"
             android:focusable="false"
+            android:clickable="false"
             android:visibility="gone"
             app:buttonTint="#ffae03"/>
 


### PR DESCRIPTION
Purpose:
- Early merge "safe changes" to logging, model, UI

Change summary:
- Make status light un-clickable
- Add configurable verbose logging
- Reduce verbose logging
- Initialize model#Folder.label
- EventProcessor: Ignore event "FolderResumed"

Related PR:
- #182 Rework custom run conditions

Testing:
Verified working on AVD 9.x at commit https://github.com/Catfriend1/syncthing-android/pull/254/commits/32aef4b9d6f1c683ef6fe0d83301b25c395d9c67 .