### PR TITLE
Use WebViewActivity in MainActivity#previewUr (fixes #241)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -77,15 +77,11 @@
         <activity
             android:name=".activities.WebViewActivity"
             android:label="@string/report_issue_title"
-            android:parentActivityName=".activities.SettingsActivity"
             android:configChanges="keyboardHidden|orientation|screenSize">
             <intent-filter>
                 <action android:name=".activities.WebViewActivity" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
-            <meta-data
-                android:name="android.support.PARENT_ACTIVITY"
-                android:value=".activities.SettingsActivity" />
         </activity>
         <activity
             android:name=".activities.ShareActivity"

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/MainActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/MainActivity.java
@@ -43,6 +43,7 @@ import android.widget.TextView;
 import com.annimon.stream.function.Consumer;
 import com.nutomic.syncthingandroid.R;
 import com.nutomic.syncthingandroid.SyncthingApp;
+import com.nutomic.syncthingandroid.activities.WebViewActivity;
 import com.nutomic.syncthingandroid.fragments.DeviceListFragment;
 import com.nutomic.syncthingandroid.fragments.DrawerFragment;
 import com.nutomic.syncthingandroid.fragments.FolderListFragment;
@@ -84,6 +85,7 @@ public class MainActivity extends SyncthingActivity
      * See {@link #showUsageReportingDialog}
      */
     private static final long USAGE_REPORTING_DIALOG_DELAY = TimeUnit.DAYS.toMillis(3);
+    private static final Boolean DEBUG_FORCE_USAGE_REPORTING_DIALOG = false;
 
     private AlertDialog mQrCodeDialog;
     private AlertDialog mUsageReportingDialog;
@@ -131,7 +133,14 @@ public class MainActivity extends SyncthingActivity
                 // Check if the usage reporting minimum delay passed by.
                 Boolean usageReportingDelayPassed = (new Date().getTime() > getFirstStartTime() + USAGE_REPORTING_DIALOG_DELAY);
                 RestApi restApi = getApi();
-                if (usageReportingDelayPassed && restApi != null && restApi.isConfigLoaded() && !restApi.isUsageReportingDecided()) {
+                if (        (
+                                DEBUG_FORCE_USAGE_REPORTING_DIALOG
+                            ) || (
+                                usageReportingDelayPassed &&
+                                restApi != null &&
+                                restApi.isConfigLoaded() &&
+                                !restApi.isUsageReportingDecided()
+                            )) {
                     showUsageReportingDialog(restApi);
                 }
                 break;
@@ -525,8 +534,9 @@ public class MainActivity extends SyncthingActivity
                         restApi.saveConfigAndRestart();
                         break;
                     case DialogInterface.BUTTON_NEUTRAL:
-                        Uri uri = Uri.parse("https://data.syncthing.net");
-                        startActivity(new Intent(Intent.ACTION_VIEW, uri));
+                        final Intent intent = new Intent(MainActivity.this, WebViewActivity.class);
+                        intent.putExtra(WebViewActivity.EXTRA_WEB_URL, getString(R.string.syncthing_usage_stats_url));
+                        startActivity(intent);
                         break;
                 }
             } catch (Exception e) {

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
@@ -42,6 +42,7 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.Iterables;
 import com.nutomic.syncthingandroid.R;
 import com.nutomic.syncthingandroid.SyncthingApp;
+import com.nutomic.syncthingandroid.activities.WebViewActivity;
 import com.nutomic.syncthingandroid.model.Device;
 import com.nutomic.syncthingandroid.model.Gui;
 import com.nutomic.syncthingandroid.model.Options;
@@ -137,6 +138,7 @@ public class SettingsActivity extends SyncthingActivity {
         private static final String KEY_EXPORT_CONFIG = "export_config";
         private static final String KEY_IMPORT_CONFIG = "import_config";
         // Settings/Debug
+        private static final String KEY_OPEN_ISSUE_TRACKER = "open_issue_tracker";
         private static final String KEY_ST_RESET_DATABASE = "st_reset_database";
         private static final String KEY_ST_RESET_DELTAS = "st_reset_deltas";
         // Settings/About
@@ -322,17 +324,19 @@ public class SettingsActivity extends SyncthingActivity {
             importConfig.setOnPreferenceClickListener(this);
 
             /* Debugging */
+            Preference openIssueTracker             = findPreference(KEY_OPEN_ISSUE_TRACKER);
             Preference debugFacilitiesEnabled       = findPreference(Constants.PREF_DEBUG_FACILITIES_ENABLED);
             Preference environmentVariables         = findPreference("environment_variables");
             Preference stResetDatabase              = findPreference("st_reset_database");
             Preference stResetDeltas                = findPreference("st_reset_deltas");
 
+            openIssueTracker.setOnPreferenceClickListener(this);
             debugFacilitiesEnabled.setOnPreferenceChangeListener(this);
             environmentVariables.setOnPreferenceChangeListener(this);
             stResetDatabase.setOnPreferenceClickListener(this);
             stResetDeltas.setOnPreferenceClickListener(this);
 
-            screen.findPreference("open_issue_tracker").setSummary(getString(R.string.open_issue_tracker_summary, getString(R.string.issue_tracker_url)));
+            screen.findPreference(KEY_OPEN_ISSUE_TRACKER).setSummary(getString(R.string.open_issue_tracker_summary, getString(R.string.issue_tracker_url)));
 
             /* Experimental options */
             mUseTor                         = (CheckBoxPreference) findPreference(Constants.PREF_USE_TOR);
@@ -710,6 +714,11 @@ public class SettingsActivity extends SyncthingActivity {
                         new Thread(() -> Util.fixAppDataPermissions(getActivity())).start();
                         mPendingConfig = true;
                     }
+                    return true;
+                case KEY_OPEN_ISSUE_TRACKER:
+                    intent = new Intent(getActivity(), WebViewActivity.class);
+                    intent.putExtra(WebViewActivity.EXTRA_WEB_URL, getString(R.string.issue_tracker_url));
+                    startActivity(intent);
                     return true;
                 case KEY_EXPORT_CONFIG:
                     new AlertDialog.Builder(getActivity())

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/WebViewActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/WebViewActivity.java
@@ -26,6 +26,9 @@ import com.nutomic.syncthingandroid.util.Util;
  */
 public class WebViewActivity extends SyncthingActivity {
 
+    public static final String EXTRA_WEB_URL =
+            "com.github.catfriend1.syncthingandroid.activities.WebViewActivity.WEB_URL";
+
     private static final String TAG = "WebViewActivity";
 
     private AlertDialog mSecurityNoticeDialog;
@@ -91,7 +94,13 @@ public class WebViewActivity extends SyncthingActivity {
         super.onCreate(savedInstanceState);
         isRunningOnTV = Util.isRunningOnTV(WebViewActivity.this);
         setContentView(R.layout.activity_web_gui);
-        webPageUrl = getString(R.string.issue_tracker_url);
+
+        if (!getIntent().hasExtra(EXTRA_WEB_URL)) {
+            Log.e(TAG, "EXTRA_WEB_URL not set.");
+            finish();
+        }
+        webPageUrl = getIntent().getStringExtra(EXTRA_WEB_URL);
+
         mLoadingView = findViewById(R.id.loading);
         ((TextView) findViewById(R.id.loading_text)).setText(getString(R.string.web_page_loading, webPageUrl));
         mWebView = findViewById(R.id.webview);
@@ -129,6 +138,9 @@ public class WebViewActivity extends SyncthingActivity {
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
+            case android.R.id.home:
+                finish();
+                return true;
             case R.id.openBrowser:
                 // This can only be triggered on a non-TV device.
                 startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(webPageUrl)));

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -371,7 +371,7 @@ Bitte melden Sie auftretende Probleme via GitHub.</string>
     <string name="category_behaviour">Verhalten</string>
     <string name="category_syncthing_options">Syncthing-Optionen</string>
     <string name="category_backup">Import und Export</string>
-    <string name="category_debug">Fehleranalyse</string>
+    <string name="category_debug">Fehlerbehebung</string>
     <string name="category_experimental">Experimentell</string>
 
     <!-- Preference screen - Run conditions -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -374,7 +374,7 @@ Please report any problems you encounter via Github.</string>
     <string name="category_behaviour">Behaviour</string>
     <string name="category_syncthing_options">Syncthing Options</string>
     <string name="category_backup">Import and Export</string>
-    <string name="category_debug">Debug</string>
+    <string name="category_debug">Troubleshooting</string>
     <string name="category_experimental">Experimental</string>
 
     <!-- Preference screen - Run conditions -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -89,6 +89,9 @@ Please report any problems you encounter via Github.</string>
 
     <string name="open_website">Open Website</string>
 
+    <!-- URL to open when user chose to open website in usage reporting dialog -->
+    <string name="syncthing_usage_stats_url" translatable="false">https://data.syncthing.net</string>
+
     <string name="toast_write_storage_permission_required">Write storage permission is required for this app</string>
 
     <string name="device_rejected">Device \"%1$s\" wants to connect</string>

--- a/app/src/main/res/xml/app_settings.xml
+++ b/app/src/main/res/xml/app_settings.xml
@@ -196,10 +196,12 @@
 
         <Preference
             android:key="export_config"
+            android:persistent="false"
             android:title="@string/export_config" />
 
         <Preference
             android:key="import_config"
+            android:persistent="false"
             android:title="@string/import_config" />
 
     </PreferenceScreen>
@@ -211,8 +213,6 @@
             android:key="open_issue_tracker"
             android:persistent="false"
             android:title="@string/report_issue_title">
-            <intent
-                android:action=".activities.WebViewActivity" />
         </Preference>
 
         <Preference

--- a/prepare-release.bash
+++ b/prepare-release.bash
@@ -45,7 +45,10 @@ tx push -s
 # Force push/pull to make sure this is executed. Apparently tx only compares timestamps, not file
 # contents. So if a file was `touch`ed, it won't be updated by default.
 # Use multiple transifex instances for pulling to speed things up.
+#
 # tx pull -a --mode reviewed -r "syncthing-android-1.stringsxml"
+# tx pull -l de --mode reviewed -r "syncthing-android-1.stringsxml"
+#
 tx pull -a -f -r "syncthing-android-1.stringsxml" &
 tx pull -a -f -r "syncthing-android-1.description_fulltxt" &
 tx pull -a -f -r "syncthing-android-1.description_shorttxt" &


### PR DESCRIPTION
Purpose:
- Use WebViewActivity in MainActivity#previewUr (#241)
- WebViewActivity: Add intent with EXTRA_WEB_URL

Testing:
Verified working at commit https://github.com/Catfriend1/syncthing-android/pull/259/commits/0a8f9b5206c2d1a3ac1508c35c763199a32f092e on:
- AVD 8.1 (TV)
- AVD 9.x (Pixel 2)