### PR TITLE
Device overview: Show status "Syncing" in case of data throughput (fixes #240)

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -778,6 +778,7 @@ Bitte melden Sie auftretende Probleme via GitHub.</string>
     <!-- Possible folder states -->
     <string name="state_idle">Untätig</string>
     <string name="state_scanning">Scannen</string>
+    <string name="state_syncing_general">Synchronisiere</string>
     <string name="state_syncing">Synchronisiere (%1$d%%)</string>
     <string name="state_error">Fehler</string>
     <string name="state_unknown">Unbekannt</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -794,6 +794,7 @@ Please report any problems you encounter via Github.</string>
     <!-- Possible folder states -->
     <string name="state_idle">Idle</string>
     <string name="state_scanning">Scanning</string>
+    <string name="state_syncing_general">Syncing</string>
     <string name="state_syncing">Syncing (%1$d%%)</string>
     <string name="state_error">Error</string>
     <string name="state_unknown">Unknown</string>


### PR DESCRIPTION
Purpose:
- Device overview: Show status "Syncing" in case of data throughput (fixes #240)
- If (incoming_bits_per_second + outgoing_bits_per_second) top the threshold, we'll assume syncing state for the device reporting that data throughput.

Related FR:
- Device overview: Show status "Syncing" in case of data throughput (#240)

Testing:
Verified working on AVD 9.x at commit https://github.com/Catfriend1/syncthing-android/commit/695e5598f38eb5fe95f5417df4145974e5e26325 .