### PR TITLE
Fallback to http on Huawei Nova (CAN-Lxx) (fixes #262)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
@@ -180,6 +180,16 @@ public class Constants {
      * to syncthing core v0.14.53+.
      */
     public static Boolean osSupportsTLS12() {
-        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP;
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            return false;
+        }
+
+        if ("huawei".equalsIgnoreCase(Build.MANUFACTURER)) {
+            if (com.nutomic.syncthingandroid.util.Util.containsIgnoreCase(Build.MODEL, "CAN")) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
Purpose:
Fallback to http on Huawei Nova (CAN-Lxx) (fixes #262)

Review:
Detecting which tls levels are there (disabled and enabled) and enable TLS 1.2 selective would be a better fix.