### PR TITLE
Fallback to localhost:http on Elephone P8 (fixes #266)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
@@ -184,9 +184,18 @@ public class Constants {
             return false;
         }
 
-        if ("huawei".equalsIgnoreCase(Build.MANUFACTURER)) {
-            if (com.nutomic.syncthingandroid.util.Util.containsIgnoreCase(Build.MODEL, "CAN")) {
-                return false;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N &&
+                Build.VERSION.SDK_INT <= Build.VERSION_CODES.N_MR1) {
+            if ("huawei".equalsIgnoreCase(Build.MANUFACTURER)) {
+                if (com.nutomic.syncthingandroid.util.Util.containsIgnoreCase(Build.MODEL, "CAN")) {
+                    // See issue #262: Android 7 / Huawei / Nova (CAN-L01\L11)
+                    return false;
+                }
+            } else if ("elephone".equalsIgnoreCase(Build.MANUFACTURER)) {
+                if (com.nutomic.syncthingandroid.util.Util.containsIgnoreCase(Build.MODEL, "P8")) {
+                    // See issue #266: Android 7.0 / P8_Mini / Elephone_P8_Mini_20171104
+                    return false;
+                }
             }
         }
 


### PR DESCRIPTION
Purpose:
Fallback to localhost:http on Elephone P8 as TLS 1.2 is not available on Android 7 (#266)

First attempt to fix it, "better" fix will come later when collecting information about the make and models affected is done.