### PR TITLE
Device create/edit dialog: Check address input, fix losing changes on screen rotation

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/DeviceActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/DeviceActivity.java
@@ -214,7 +214,7 @@ public class DeviceActivity extends SyncthingActivity {
             mDeviceNeedsToUpdate = savedInstanceState.getBoolean("deviceNeedsToUpdate");
             restoreDialogStates(savedInstanceState);
         } else {
-            // Fresh initialiation of the edit or create mode.
+            // Fresh init of the edit or create mode.
             if (mIsCreateMode) {
                 Log.d(TAG, "Initializing create mode ...");
                 initDevice();

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/DeviceActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/DeviceActivity.java
@@ -391,6 +391,7 @@ public class DeviceActivity extends SyncthingActivity {
 
     @Override
     public boolean onPrepareOptionsMenu(Menu menu) {
+        menu.findItem(R.id.save).setTitle(mIsCreateMode ? R.string.create : R.string.save_title);
         menu.findItem(R.id.share_device_id).setVisible(!mIsCreateMode);
         menu.findItem(R.id.remove).setVisible(!mIsCreateMode);
         return true;

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/DeviceActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/DeviceActivity.java
@@ -430,6 +430,11 @@ public class DeviceActivity extends SyncthingActivity
                             .show();
                     return true;
                 }
+                if (!mDevice.checkDeviceAddresses()) {
+                    Toast.makeText(this, R.string.device_addresses_invalid, Toast.LENGTH_LONG)
+                            .show();
+                    return true;
+                }
                 mConfig.addDevice(getApi(), mDevice);
                 finish();
                 return true;

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/DeviceActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/DeviceActivity.java
@@ -462,6 +462,11 @@ public class DeviceActivity extends SyncthingActivity {
     }
 
     private void onSave() {
+        if (mDevice == null) {
+            Log.e(TAG, "onSave: mDevice == null");
+            return;
+        }
+
         // Validate fields.
         if (isEmpty(mDevice.deviceID)) {
             Toast.makeText(this, R.string.device_id_required, Toast.LENGTH_LONG)
@@ -495,11 +500,6 @@ public class DeviceActivity extends SyncthingActivity {
         if (!mDeviceNeedsToUpdate) {
             // We've got nothing to save.
             finish();
-            return;
-        }
-
-        if (mDevice == null) {
-            Log.e(TAG, "onSave: mDevice == null");
             return;
         }
         // Log.v(TAG, "deviceID=" + mDevice.deviceID + ", introducedBy=" + mDevice.introducedBy);

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/DeviceActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/DeviceActivity.java
@@ -520,7 +520,7 @@ public class DeviceActivity extends SyncthingActivity {
     }
 
     /**
-     * Convert text line to addresses array.
+     * Converts text line to addresses array.
      */
     private List<String> persistableAddresses(CharSequence userInput) {
         if (isEmpty(userInput)) {

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/DeviceActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/DeviceActivity.java
@@ -519,6 +519,9 @@ public class DeviceActivity extends SyncthingActivity
         mConfig.updateDevice(getApi(), mDevice);
     }
 
+    /**
+     * Convert text line to addresses array.
+     */
     private List<String> persistableAddresses(CharSequence userInput) {
         if (isEmpty(userInput)) {
             return DYNAMIC_ADDRESS;
@@ -543,6 +546,9 @@ public class DeviceActivity extends SyncthingActivity
         return Arrays.asList(input.split(", "));
     }
 
+    /**
+     * Converts addresses array to a text line.
+     */
     private String displayableAddresses() {
         if (mDevice.addresses == null) {
             return "";

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/DeviceActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/DeviceActivity.java
@@ -53,9 +53,7 @@ import static com.nutomic.syncthingandroid.util.Compression.METADATA;
 /**
  * Shows device details and allows changing them.
  */
-public class DeviceActivity extends SyncthingActivity
-        implements
-            SyncthingService.OnServiceStateChangeListener {
+public class DeviceActivity extends SyncthingActivity {
 
     public static final String EXTRA_NOTIFICATION_ID =
             "com.github.catfriend1.syncthingandroid.activities.DeviceActivity.NOTIFICATION_ID";
@@ -207,25 +205,51 @@ public class DeviceActivity extends SyncthingActivity
         mCompressionContainer.setOnClickListener(view -> onCompressionContainerClick());
         mCustomSyncConditionsDialog.setOnClickListener(view -> onCustomSyncConditionsDialogClick());
 
-        if (savedInstanceState != null){
-            if (mDevice == null) {
-                mDevice = new Gson().fromJson(savedInstanceState.getString("device"), Device.class);
-            }
-            restoreDialogStates(savedInstanceState);
-        }
-
         findViewById(R.id.editDeviceIdContainer).setVisibility(mIsCreateMode ? View.VISIBLE : View.GONE);
         mShowDeviceIdContainer.setVisibility(!mIsCreateMode ? View.VISIBLE : View.GONE);
-        if (mIsCreateMode) {
-            if (mDevice == null) {
+
+        if (savedInstanceState != null) {
+            Log.d(TAG, "Retrieving state from savedInstanceState ...");
+            mDevice = new Gson().fromJson(savedInstanceState.getString("device"), Device.class);
+            mDeviceNeedsToUpdate = savedInstanceState.getBoolean("deviceNeedsToUpdate");
+            restoreDialogStates(savedInstanceState);
+        } else {
+            // Fresh initialiation of the edit or create mode.
+            if (mIsCreateMode) {
+                Log.d(TAG, "Initializing create mode ...");
                 initDevice();
+                mDeviceNeedsToUpdate = true;
+            } else {
+                // Edit mode.
+                String passedId = getIntent().getStringExtra(EXTRA_DEVICE_ID);
+                Log.d(TAG, "Initializing edit mode: deviceID=" + passedId);
+                RestApi restApi = getApi();
+                List<Device> devices = mConfig.getDevices(restApi, false);
+                mDevice = null;
+                for (Device currentDevice : devices) {
+                    if (currentDevice.deviceID.equals(passedId)) {
+                        mDevice = currentDevice;
+                        break;
+                    }
+                }
+                if (mDevice == null) {
+                    Log.w(TAG, "Device not found in API update, maybe it was deleted?");
+                    finish();
+                    return;
+                }
+                if (restApi != null) {
+                    restApi.getConnections(this::onReceiveConnections);
+                }
+                mDeviceNeedsToUpdate = false;
             }
+        }
+        updateViewsAndSetListeners();
+
+        if (mIsCreateMode) {
             mEditDeviceId.requestFocus();
-            mDeviceNeedsToUpdate = true;
         } else {
             getWindow().setSoftInputMode(SOFT_INPUT_STATE_ALWAYS_HIDDEN);
             mNameView.requestFocus();
-            mDeviceNeedsToUpdate = false;
         }
     }
 
@@ -252,32 +276,6 @@ public class DeviceActivity extends SyncthingActivity
         SyncthingServiceBinder syncthingServiceBinder = (SyncthingServiceBinder) iBinder;
         SyncthingService syncthingService = (SyncthingService) syncthingServiceBinder.getService();
         syncthingService.getNotificationHandler().cancelConsentNotification(getIntent().getIntExtra(EXTRA_NOTIFICATION_ID, 0));
-        syncthingService.registerOnServiceStateChangeListener(DeviceActivity.this);
-    }
-
-    @Override
-    public void onServiceStateChange(SyncthingService.State currentState) {
-        if (!mIsCreateMode) {
-            RestApi restApi = getApi();
-            List<Device> devices = mConfig.getDevices(restApi, false);
-            String passedId = getIntent().getStringExtra(EXTRA_DEVICE_ID);
-            mDevice = null;
-            for (Device currentDevice : devices) {
-                if (currentDevice.deviceID.equals(passedId)) {
-                    mDevice = currentDevice;
-                    break;
-                }
-            }
-            if (mDevice == null) {
-                Log.w(TAG, "Device not found in API update, maybe it was deleted?");
-                finish();
-                return;
-            }
-            if (restApi != null) {
-                restApi.getConnections(this::onReceiveConnections);
-            }
-        }
-        updateViewsAndSetListeners();
     }
 
     @Override
@@ -296,7 +294,6 @@ public class DeviceActivity extends SyncthingActivity
         SyncthingService syncthingService = getService();
         if (syncthingService != null) {
             syncthingService.getNotificationHandler().cancelConsentNotification(getIntent().getIntExtra(EXTRA_NOTIFICATION_ID, 0));
-            syncthingService.unregisterOnServiceStateChangeListener(DeviceActivity.this);
         }
         mEditDeviceId.removeTextChangedListener(mIdTextWatcher);
         mNameView.removeTextChangedListener(mNameTextWatcher);
@@ -310,6 +307,7 @@ public class DeviceActivity extends SyncthingActivity
     public void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putString("device", new Gson().toJson(mDevice));
+        outState.putBoolean("deviceNeedsToUpdate", mDeviceNeedsToUpdate);
 
         outState.putBoolean(IS_SHOWING_DISCARD_DIALOG, mDiscardDialog != null && mDiscardDialog.isShowing());
         Util.dismissDialogSafe(mDiscardDialog, this);

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
@@ -511,6 +511,7 @@ public class FolderActivity extends SyncthingActivity {
 
     @Override
     public boolean onPrepareOptionsMenu(Menu menu) {
+        menu.findItem(R.id.save).setTitle(mIsCreateMode ? R.string.create : R.string.save_title);
         menu.findItem(R.id.remove).setVisible(!mIsCreateMode);
         return true;
     }

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
@@ -601,8 +601,12 @@ public class FolderActivity extends SyncthingActivity {
                  * because the user most probably intentionally chose a special folder like
                  * "[storage]/Android/data/com.nutomic.syncthingandroid/files"
                  * or enabled root mode thus having write access.
+                 * Default from {@link #initFolder} was already set in {@link #onCreate}.
+                 *      mFolder.type = Constants.FOLDER_TYPE_SEND_RECEIVE;
+                 * We won't set it again here as this would cause user selection to be reset on
+                 * screen rotation - as we don't know if we restored the activity or created
+                 * a fresh one.
                  */
-                mFolder.type = Constants.FOLDER_TYPE_SEND_RECEIVE;
                 updateFolderTypeDescription();
             } else {
                 mEditIgnoreListTitle.setEnabled(true);
@@ -633,6 +637,9 @@ public class FolderActivity extends SyncthingActivity {
         return sb.toString();
     }
 
+    /**
+     * Init a new folder in mIsCreateMode, used in {@link #onCreate}.
+     */
     private void initFolder() {
         mFolder = new Folder();
         mFolder.id = (getIntent().hasExtra(EXTRA_FOLDER_ID))
@@ -647,7 +654,7 @@ public class FolderActivity extends SyncthingActivity {
          */
         mFolder.rescanIntervalS = 3600;
         mFolder.paused = false;
-        mFolder.type = Constants.FOLDER_TYPE_SEND_RECEIVE;
+        mFolder.type = Constants.FOLDER_TYPE_SEND_RECEIVE;      // Default for {@link #checkWriteAndUpdateUI}.
         mFolder.versioning = new Folder.Versioning();
     }
 

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
@@ -682,6 +682,11 @@ public class FolderActivity extends SyncthingActivity {
     }
 
     private void onSave() {
+        if (mFolder == null) {
+            Log.e(TAG, "onSave: mFolder == null");
+            return;
+        }
+
         // Validate fields.
         if (TextUtils.isEmpty(mFolder.id)) {
             Toast.makeText(this, R.string.folder_id_required, Toast.LENGTH_LONG)
@@ -725,11 +730,6 @@ public class FolderActivity extends SyncthingActivity {
         if (!mFolderNeedsToUpdate) {
             // We've got nothing to save.
             finish();
-            return;
-        }
-
-        if (mFolder == null) {
-            Log.e(TAG, "onSave: mFolder == null");
             return;
         }
 

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
@@ -773,16 +773,12 @@ public class FolderActivity extends SyncthingActivity
     }
 
     private void showDiscardDialog(){
-        mDiscardDialog = createDiscardDialog();
-        mDiscardDialog.show();
-    }
-
-    private Dialog createDiscardDialog() {
-        return new AlertDialog.Builder(this)
+        mDiscardDialog = new AlertDialog.Builder(this)
                 .setMessage(R.string.dialog_discard_changes)
                 .setPositiveButton(android.R.string.ok, (dialog, which) -> finish())
                 .setNegativeButton(android.R.string.cancel, null)
                 .create();
+        mDiscardDialog.show();
     }
 
     private void updateVersioning(Bundle arguments) {

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
@@ -251,14 +251,14 @@ public class FolderActivity extends SyncthingActivity {
                 }
                 mConfig.getFolderIgnoreList(restApi, mFolder, this::onReceiveFolderIgnoreList);
                 mFolderNeedsToUpdate = false;
+            }
 
-                // If the extra is set, we should automatically share the current folder with the given device.
-                if (getIntent().hasExtra(EXTRA_DEVICE_ID)) {
-                    Device device = new Device();
-                    device.deviceID = getIntent().getStringExtra(EXTRA_DEVICE_ID);
-                    mFolder.addDevice(device);
-                    mFolderNeedsToUpdate = true;
-                }
+            // If the extra is set, we should automatically share the current folder with the given device.
+            if (getIntent().hasExtra(EXTRA_DEVICE_ID)) {
+                Device device = new Device();
+                device.deviceID = getIntent().getStringExtra(EXTRA_DEVICE_ID);
+                mFolder.addDevice(device);
+                mFolderNeedsToUpdate = true;
             }
         }
 

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
@@ -226,7 +226,7 @@ public class FolderActivity extends SyncthingActivity {
             mFolderUri = savedInstanceState.getParcelable("mFolderUri");
             restoreDialogStates(savedInstanceState);
         } else {
-            // Fresh initialiation of the edit or create mode.
+            // Fresh init of the edit or create mode.
             if (mIsCreateMode) {
                 Log.d(TAG, "Initializing create mode ...");
                 initFolder();

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/EventProcessor.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/EventProcessor.java
@@ -162,6 +162,7 @@ public class EventProcessor implements  Runnable, RestApi.OnReceiveEventListener
             case "FolderSummary":
             case "FolderWatchStateChanged":
             case "ItemStarted":
+            case "ListenAddressesChanged":
             case "LocalIndexUpdated":
             case "LoginAttempt":
             case "RemoteDownloadProgress":

--- a/app/src/main/res/menu/device_settings.xml
+++ b/app/src/main/res/menu/device_settings.xml
@@ -4,7 +4,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
-        android:id="@+id/create"
+        android:id="@+id/save"
         android:title="@string/add"
         android:icon="@drawable/ic_done_white_24dp"
         app:showAsAction="always|withText" />

--- a/app/src/main/res/menu/folder_settings.xml
+++ b/app/src/main/res/menu/folder_settings.xml
@@ -4,7 +4,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
-        android:id="@+id/create"
+        android:id="@+id/save"
         android:icon="@drawable/ic_done_white_24dp"
         android:title="@string/create"
         app:showAsAction="always|withText" />

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -305,6 +305,9 @@ Bitte melden Sie auftretende Probleme via GitHub.</string>
     <!-- Toast shown when trying to create a device with an empty name -->
     <string name="device_name_required">Der Gerätename darf nicht leer sein</string>
 
+    <!-- Toast shown when trying to create a device with invalid addresses -->
+    <string name="device_addresses_invalid">Die Geräteadressen sind nicht im richtigen Format. Bitte versuche es erneut. Sieh Dir die Syncthing Doku für weitere Hilfe an.</string>
+
     <!-- Content description for device ID qr code icon -->
     <string name="scan_qr_code_description">QR Code scannen</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -308,6 +308,9 @@ Please report any problems you encounter via Github.</string>
     <!-- Toast shown when trying to create a device with an empty name -->
     <string name="device_name_required">The device name must not be empty</string>
 
+    <!-- Toast shown when trying to create a device with invalid addresses -->
+    <string name="device_addresses_invalid">The device addresses are not formatted correctly. Please retry. Look at the Syncthing docs for more info.</string>
+
     <!-- Content description for device ID qr code icon -->
     <string name="scan_qr_code_description">Scan QR Code</string>
 


### PR DESCRIPTION
Purpose:
- Validate device addresses better (fixes #264)
- Device dialog: Fix losing changes on screen rotation (fixes #271)
- Fix device ID validation doesn't take place when editing device (fixes #272)
- Fix folder settings validation doesn't take place when editing folder (fixes #273)
- Fix screen rotation during versioning dialog crashes next time opening it (fixes #265)
- Fix folder.type is reset from SendOnly to Send&Receive on recreation of FolderActivity while creating a new folder (fixes #274)

Related issue:
#264 - Validate device addresses better
#265 - Screen rotation during versioning dialog crashes next time opening it
#271 - Screen rotation resets unsaved changes in device edit dialog 
#272 - Device ID validation doesn't take place when editing device 
#273 - Folder settings validation doesn't take place when editing folder
#274 - On recreation of FolderActivity while creating a new folder: folder.type is reset from SendOnly to Send&Receive

Testing:
Verified working on AVD 7.0 at commit https://github.com/Catfriend1/syncthing-android/pull/270/commits/6e919c0fde91c94753fcc5830d5ee665a8ebebfe .
