### PR TITLE
Treat ethernet connection "like un-metered Wi-Fi" (fixes #280)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/service/RunConditionMonitor.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/RunConditionMonitor.java
@@ -499,6 +499,14 @@ public class RunConditionMonitor {
             // No network connection.
             return false;
         }
+        if (ni.getType() == ConnectivityManager.TYPE_ETHERNET) {
+            /**
+             * We treat Wi-Fi and ETHERNET as "Wi-Fi" connection.
+             * Assume ETHERNET connection is un-metered to allow syncing on
+             * Android TV or VirtualBox ETHERNET connection.
+             */
+             return false;
+        }
         return cm.isActiveNetworkMetered();
     }
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -385,7 +385,7 @@ Bitte melden Sie auftretende Probleme via GitHub.</string>
     <string name="run_on_mobile_data_summary">Starte, wenn das Gerät über das mobile Datennetzwerk verbunden ist. Warnung: Wenn Du große Datenmengen synchronisierst, kann dies einen hohen Verbrauch deines mobilen Datentarifs verursachen.</string>
 
     <string name="run_on_wifi_title">Starte bei WLAN-Verbindung</string>
-    <string name="run_on_wifi_summary">Starte, wenn das Gerät mit einem WLAN-Netzwerk verbunden ist.</string>
+    <string name="run_on_wifi_summary">Starte, wenn das Gerät mit einem WLAN- oder Kabel-Netzwerk verbunden ist.</string>
 
     <string name="run_on_metered_wifi_title">Starte bei getakteter WLAN-Verbindung</string>
     <string name="run_on_metered_wifi_summary">Starte, wenn das Gerät mit einem getakteten WLAN-Netzwerk wie z. B. einem Hotspot- oder Tethering-Netzwerk verbunden ist. Achtung: Dies kann einen großen Anteil des mobilen Datenvolumens verbrauchen, wenn Du viele Dateien synchronisierst.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -388,7 +388,7 @@ Please report any problems you encounter via Github.</string>
     <string name="run_on_mobile_data_summary">Run when device is connected via the mobile data network. Warning: This can consume a lot of data from your mobile operator data plan if you sync large amounts of data.</string>
 
     <string name="run_on_wifi_title">Run on Wi-Fi</string>
-    <string name="run_on_wifi_summary">Run when device is connected to a Wi-Fi network.</string>
+    <string name="run_on_wifi_summary">Run when device is connected to a Wi-Fi or ethernet network.</string>
 
     <string name="run_on_metered_wifi_title">Run on metered Wi-Fi</string>
     <string name="run_on_metered_wifi_summary">Run when device is connected to a metered Wi-Fi network e.g. a hotspot or tethered network. Attention: This can consume large portion of your data plan if you sync a lot of data.</string>


### PR DESCRIPTION
Purpose:
Treat ethernet connection "like un-metered Wi-Fi" (fixes #280)

Testing:
Verified working on Android x86 8.1 virtual device at commit https://github.com/Catfriend1/syncthing-android/commit/75db7193644bdca9e8eedcfedf0b5aa9d09180eb .