### PR TITLE
 Save welcome wizard button state on screen rotation (fixes #281)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FirstStartActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FirstStartActivity.java
@@ -198,6 +198,27 @@ public class FirstStartActivity extends AppCompatActivity {
                 onBtnNextClick();
             }
         });
+
+        if (savedInstanceState != null) {
+            mBackButton.setVisibility(savedInstanceState.getBoolean("mBackButton") ? View.VISIBLE : View.GONE);
+            mNextButton.setVisibility(savedInstanceState.getBoolean("mNextButton") ? View.VISIBLE : View.GONE);
+        }
+        if (mNextButton.getVisibility() == View.VISIBLE) {
+            mNextButton.requestFocus();
+        } else if (mBackButton.getVisibility() == View.VISIBLE) {
+            mBackButton.requestFocus();
+        }
+    }
+
+    /**
+     * Saves current tab index and fragment states.
+     */
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+
+        outState.putBoolean("mBackButton", mBackButton.getVisibility() == View.VISIBLE);
+        outState.putBoolean("mNextButton", mNextButton.getVisibility() == View.VISIBLE);
     }
 
     public void onBtnBackClick() {
@@ -207,6 +228,7 @@ public class FirstStartActivity extends AppCompatActivity {
             mViewPager.setCurrentItem(current);
             if (current == 0) {
                 mBackButton.setVisibility(View.GONE);
+                mNextButton.requestFocus();
             }
         }
     }

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FirstStartActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FirstStartActivity.java
@@ -199,6 +199,9 @@ public class FirstStartActivity extends AppCompatActivity {
             }
         });
 
+        if (mRunningOnTV) {
+            mNextButton.setFocusableInTouchMode(true);
+        }
         if (savedInstanceState != null) {
             mBackButton.setVisibility(savedInstanceState.getBoolean("mBackButton") ? View.VISIBLE : View.GONE);
             mNextButton.setVisibility(savedInstanceState.getBoolean("mNextButton") ? View.VISIBLE : View.GONE);

--- a/app/src/main/res/layout/activity_first_start.xml
+++ b/app/src/main/res/layout/activity_first_start.xml
@@ -10,7 +10,9 @@
         <com.nutomic.syncthingandroid.views.CustomViewPager
                 android:id="@+id/view_pager"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent" />
+                android:layout_height="match_parent"
+                android:nextFocusLeft="@+id/btn_back"
+                android:nextFocusRight="@+id/btn_next" />
 
         <LinearLayout
                 android:id="@+id/layoutDots"

--- a/app/src/main/res/layout/activity_first_start.xml
+++ b/app/src/main/res/layout/activity_first_start.xml
@@ -14,6 +14,7 @@
 
         <LinearLayout
                 android:id="@+id/layoutDots"
+                android:focusable="false"
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/dots_height"
                 android:layout_alignParentBottom="true"
@@ -25,6 +26,7 @@
         </LinearLayout>
 
         <View
+                android:focusable="false"
                 android:layout_width="match_parent"
                 android:layout_height="1dp"
                 android:alpha=".5"
@@ -33,6 +35,7 @@
 
         <Button
                 android:id="@+id/btn_back"
+                android:focusable="true"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_alignParentBottom="true"
@@ -45,7 +48,6 @@
         <Button
                 android:id="@+id/btn_next"
                 android:focusable="true"
-                android:focusableInTouchMode="true"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_alignParentBottom="true"
@@ -53,7 +55,6 @@
                 android:layout_alignParentEnd="true"
                 android:text="@string/cont"
                 style="@style/Theme.Syncthing.GreyButton" >
-                <requestFocus />
         </Button>
 
 </RelativeLayout>


### PR DESCRIPTION
Purpose:
Save welcome wizard button state on screen rotation (fixes #281)

Testing:
Verified working at commit https://github.com/Catfriend1/syncthing-android/commit/f7d5c295084826f3462aa3c85eac0691dfee1d4e on:
- AVD 9.x phone
- AVD 9.0 TV