### PR TITLE
Fix leftover SyncthingNative instance after update in root mode (fixes #261)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/receiver/BootReceiver.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/receiver/BootReceiver.java
@@ -6,20 +6,39 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Build;
 import android.preference.PreferenceManager;
+import android.util.Log;
 
 import com.nutomic.syncthingandroid.service.Constants;
+import com.nutomic.syncthingandroid.service.SyncthingRunnable;
 import com.nutomic.syncthingandroid.service.SyncthingService;
+
+import eu.chainfire.libsuperuser.Shell;
 
 public class BootReceiver extends BroadcastReceiver {
 
+    private static final String TAG = "BootReceiver";
+
     @Override
     public void onReceive(Context context, Intent intent) {
-        if (!intent.getAction().equals(Intent.ACTION_BOOT_COMPLETED) &&
-                !intent.getAction().equals(Intent.ACTION_MY_PACKAGE_REPLACED)) {
+        Boolean bootCompleted = intent.getAction().equals(Intent.ACTION_BOOT_COMPLETED);
+        Boolean packageReplaced = intent.getAction().equals(Intent.ACTION_MY_PACKAGE_REPLACED);
+        if (!bootCompleted && !packageReplaced) {
             return;
         }
 
-        if (!startServiceOnBoot(context)) {
+        if (packageReplaced) {
+            if (getPrefUseRoot(context) && Shell.SU.available()) {
+                /**
+                 * In Root mode, there will be a SyncthingNative process left running after app update.
+                 * See https://github.com/Catfriend1/syncthing-android/issues/261
+                 */
+                Log.d(TAG, "ACTION_MY_PACKAGE_REPLACED: Killing leftover SyncthingNative instance if present ...");
+                new SyncthingRunnable(context, SyncthingRunnable.Command.main).killSyncthing();
+            }
+        }
+
+        // Check if we should (re)start now.
+        if (!getPrefStartServiceOnBoot(context)) {
             return;
         }
 
@@ -41,8 +60,13 @@ public class BootReceiver extends BroadcastReceiver {
         }
     }
 
-    private static boolean startServiceOnBoot(Context context) {
+    private static boolean getPrefStartServiceOnBoot(Context context) {
         SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(context);
         return sp.getBoolean(Constants.PREF_START_SERVICE_ON_BOOT, false);
+    }
+
+    private static boolean getPrefUseRoot(Context context) {
+        SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(context);
+        return sp.getBoolean(Constants.PREF_USE_ROOT, false);
     }
 }

--- a/app/src/main/java/com/nutomic/syncthingandroid/receiver/BootReceiver.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/receiver/BootReceiver.java
@@ -15,11 +15,13 @@ public class BootReceiver extends BroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent intent) {
         if (!intent.getAction().equals(Intent.ACTION_BOOT_COMPLETED) &&
-                !intent.getAction().equals(Intent.ACTION_MY_PACKAGE_REPLACED))
+                !intent.getAction().equals(Intent.ACTION_MY_PACKAGE_REPLACED)) {
             return;
+        }
 
-        if (!startServiceOnBoot(context))
+        if (!startServiceOnBoot(context)) {
             return;
+        }
 
         startServiceCompat(context);
     }


### PR DESCRIPTION
Purpose:
Fix leftover SyncthingNative instance after update in root mode (fixes #261)

Testing:
Verified working on AVD 8.1 at commit https://github.com/Catfriend1/syncthing-android/commit/2b71b35aa7028535732b4a2a82e5b3cc94f9d219 in cases:
a) Rooted mode
b) Non-rooted mode