### PR TITLE
Don't crash if config got corrupted and inform the user

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FirstStartActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FirstStartActivity.java
@@ -98,28 +98,13 @@ public class FirstStartActivity extends AppCompatActivity {
         Log.d(TAG, mRunningOnTV ? "Running on a TV Device" : "Running on a non-TV Device");
 
         /**
-         * Check if a valid config exists that can be read and parsed.
-         */
-        Boolean configParseable = false;
-        Boolean configExists = Constants.getConfigFile(this).exists();
-        if (configExists) {
-            ConfigXml configParseTest = new ConfigXml(this);
-            try {
-                configParseTest.loadConfig();
-                configParseable = true;
-            } catch (ConfigXml.OpenConfigException e) {
-                Log.d(TAG, "Failed to parse existing config. Will show key generation slide ...");
-            }
-        }
-
-        /**
          * Check if prerequisites to run the app are still in place.
          * If anything mandatory is missing, the according welcome slide(s) will be shown.
          */
         Boolean showSlideStoragePermission = !haveStoragePermission();
         Boolean showSlideIgnoreDozePermission = !haveIgnoreDozePermission();
         Boolean showSlideLocationPermission = !haveLocationPermission();
-        Boolean showSlideKeyGeneration = !configExists || !configParseable;
+        Boolean showSlideKeyGeneration = !checkForParseableConfig();
 
         /**
          * If we don't have to show slides for mandatory prerequisites,
@@ -583,10 +568,33 @@ public class FirstStartActivity extends AppCompatActivity {
                 return;
             }
             TextView keygenStatus = (TextView) firstStartActivity.findViewById(R.id.key_generation_status);
+            if (!firstStartActivity.checkForParseableConfig()) {
+                keygenStatus.setText(firstStartActivity.getString(R.string.config_read_failed));
+                return;
+            }
             keygenStatus.setText(firstStartActivity.getString(R.string.key_generation_success));
             Button nextButton = (Button) firstStartActivity.findViewById(R.id.btn_next);
             nextButton.setVisibility(View.VISIBLE);
             nextButton.requestFocus();
         }
+    }
+
+    private Boolean checkForParseableConfig() {
+        /**
+         * Check if a valid config exists that can be read and parsed.
+         */
+        Boolean configExists = Constants.getConfigFile(this).exists();
+        if (!configExists) {
+            return false;
+        }
+        Boolean configParseable = false;
+        ConfigXml configParseTest = new ConfigXml(this);
+        try {
+            configParseTest.loadConfig();
+            configParseable = true;
+        } catch (ConfigXml.OpenConfigException e) {
+            Log.d(TAG, "Failed to parse existing config. Will show key generation slide ...");
+        }
+        return configParseable;
     }
 }

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/NotificationHandler.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/NotificationHandler.java
@@ -192,7 +192,7 @@ public class NotificationHandler {
         Intent intent = new Intent(mContext, LogActivity.class);
         Notification n = getNotificationBuilder(mInfoChannel)
                 .setContentTitle(mContext.getString(title, extraInfo))
-                .setContentText(mContext.getString(R.string.notification_crash_text))
+                .setContentText(mContext.getString(R.string.notification_crash_text, extraInfo))
                 .setSmallIcon(R.drawable.ic_stat_notify)
                 .setContentIntent(PendingIntent.getActivity(mContext, 0, intent, 0))
                 .setAutoCancel(true)

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
@@ -428,10 +428,11 @@ public class SyncthingService extends Service {
         try {
             configXml.loadConfig();
         } catch (ConfigXml.OpenConfigException e) {
-            mNotificationHandler.showCrashedNotification(R.string.config_read_failed, "applyCustomRunConditions:ConfigXml.OpenConfigException");
+            mNotificationHandler.showCrashedNotification(R.string.config_read_failed, "applyCustomRunConditions:OpenConfigException");
             synchronized (mStateLock) {
                 onServiceStateChange(State.ERROR);
             }
+            stopSelf();
             return;
         }
 
@@ -508,10 +509,12 @@ public class SyncthingService extends Service {
         try {
             mConfig.loadConfig();
         } catch (ConfigXml.OpenConfigException e) {
-            mNotificationHandler.showCrashedNotification(R.string.config_read_failed, "ConfigXml.OpenConfigException");
+            Log.v(TAG,"MIP0");
+            mNotificationHandler.showCrashedNotification(R.string.config_read_failed, "launchStartupTask:OpenConfigException");
             synchronized (mStateLock) {
                 onServiceStateChange(State.ERROR);
             }
+            stopSelf();
             return;
         }
 

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
@@ -509,7 +509,6 @@ public class SyncthingService extends Service {
         try {
             mConfig.loadConfig();
         } catch (ConfigXml.OpenConfigException e) {
-            Log.v(TAG,"MIP0");
             mNotificationHandler.showCrashedNotification(R.string.config_read_failed, "launchStartupTask:OpenConfigException");
             synchronized (mStateLock) {
                 onServiceStateChange(State.ERROR);

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/ConfigXml.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/ConfigXml.java
@@ -255,6 +255,9 @@ public class ConfigXml {
 
         /* Section - GUI */
         Element gui = getGuiElement();
+        if (gui == null) {
+            throw new OpenConfigException();
+        }
 
         // Platform-specific: Force REST API and Web UI access to use TLS 1.2 or not.
         Boolean forceHttps = Constants.osSupportsTLS12();
@@ -293,6 +296,9 @@ public class ConfigXml {
         // https://github.com/syncthing/syncthing/issues/4348
         Element options = (Element) mConfig.getDocumentElement()
                 .getElementsByTagName("options").item(0);
+        if (options == null) {
+            throw new OpenConfigException();
+        }
         changed = setConfigElement(options, "weakHashSelectionMethod", "never") || changed;
 
         /* Dismiss "fsWatcherNotification" according to https://github.com/syncthing/syncthing-android/pull/1051 */

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -200,6 +200,7 @@
     <!-- Text for WebGuiActivity loading view -->
     <string name="web_gui_loading">Изчакване на потребителския интерфейс</string>
 
+
     <!-- SettingsFragment -->
 
 
@@ -208,7 +209,6 @@
     <string name="category_run_conditions">Условия на работа</string>
     <string name="category_behaviour">Поведение</string>
     <string name="category_syncthing_options">Настройки на Syncthing</string>
-    <string name="category_debug">Дебъг</string>
     <string name="category_experimental">Експериментални</string>
 
     <!-- Preference screen - Run conditions -->

--- a/app/src/main/res/values-ca-rES/strings.xml
+++ b/app/src/main/res/values-ca-rES/strings.xml
@@ -44,10 +44,6 @@
 
     <string name="ignore">Ignora</string>
 
-    <!-- MainActivity -->
-
-
-
     <!-- Exception dialog message -->
     <string name="exception_known_bug_notice">S\'ha trobat un error conegut que encara no està resolt. Vegeu %1$s/%2$s per més informació. Siusplau doneu una descripció precisa del que ha passat amb antelació.</string>
 
@@ -320,7 +316,6 @@
     <string name="category_behaviour">Comportament</string>
     <string name="category_syncthing_options">Opcions del Syncthing</string>
     <string name="category_backup">Importa i Exporta</string>
-    <string name="category_debug">Depuració</string>
     <string name="category_experimental">Experimental</string>
 
     <!-- Preference screen - Run conditions -->
@@ -331,8 +326,6 @@
     <string name="run_on_mobile_data_summary">Executa quan el dispositiu es connecti a través de la xarxa de dades mòbils. Advertència: Si sincronitzeu gran quantitat de dades podríeu consumir un volum important del pla de dades del vostre operador mòbil.</string>
 
     <string name="run_on_wifi_title">Executa amb Wi-Fi</string>
-    <string name="run_on_wifi_summary">Executa quan el dispositiu es connecti a una xarxa Wi-Fi.</string>
-
     <string name="run_on_metered_wifi_title">Executa amb Wi-Fi mesurada</string>
     <string name="run_on_metered_wifi_summary">Executa quan el dispositiu estigui connectat a una xarxa Wi-Fi mesurada, com ara una zona amb cobertura o un ancoratge. Advertència: Si sincronitzeu gran quantitat de dades podríeu consumir un volum important del pla de dades del vostre operador mòbil.</string>
 
@@ -610,7 +603,6 @@
     <string name="reason_mobile_data_disallowed">El Syncthing no té permís per funcionar amb connexions de dades mòbils.</string>
     <string name="reason_on_mobile_data">El Syncthing està funcionant perquè les dades mòbils estan actives.</string>
     <string name="reason_not_on_mobile_data">El Syncthing pot funcionar amb connexions de dades mòbils però les dades mòbils no estan connectades.</string>
-    <string name="reason_wifi_disallowed">El Syncthing no té permís per funcionar amb WiFi.</string>
     <!-- SyncthingService -->
 
 
@@ -639,8 +631,6 @@
     <string name="default_folder_id">%1$s-fotos</string>
 
     <string name="notification_crash_title">El Syncthing s\'ha bloquejat %1$s</string>
-
-    <string name="notification_crash_text">Feu clic per veure els registres</string>
 
     <string name="notifications_persistent_channel">El Syncthing està actiu</string>
     <string name="notification_persistent_waiting_channel">Vigilant les condicions d\'execució</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -212,6 +212,7 @@
     <!-- Text for WebGuiActivity loading view -->
     <string name="web_gui_loading">Čeká se na Syncthing GUI</string>
 
+
     <!-- SettingsFragment -->
 
 
@@ -220,7 +221,6 @@
     <string name="category_run_conditions">Podmínky spuštění</string>
     <string name="category_behaviour">Chování</string>
     <string name="category_syncthing_options">Nastavení Syncthing</string>
-    <string name="category_debug">Ladění</string>
     <string name="category_experimental">Experimentální</string>
 
     <!-- Preference screen - Run conditions -->
@@ -426,8 +426,6 @@
     <string name="default_folder_id">%1$s-foto</string>
 
     <string name="notification_crash_title">Syncthing spadl %1$s</string>
-
-    <string name="notification_crash_text">Pro prohlížení logů klikněte</string>
 
     <string name="notifications_other_channel">Ostatní upozornění</string>
 

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -208,6 +208,7 @@
     <!-- Text for WebGuiActivity loading view -->
     <string name="web_gui_loading">Venter på GUI</string>
 
+
     <!-- SettingsFragment -->
 
 
@@ -216,7 +217,6 @@
     <string name="category_run_conditions">Kør betingelser</string>
     <string name="category_behaviour">Adfærd</string>
     <string name="category_syncthing_options">Syncthing Muligheder</string>
-    <string name="category_debug">Debug</string>
     <string name="category_experimental">Eksperimentalt</string>
 
     <!-- Preference screen - Run conditions -->
@@ -406,8 +406,6 @@
     <string name="default_folder_id">%1$s-fotos</string>
 
     <string name="notification_crash_title">Syncthing crashede %1$s</string>
-
-    <string name="notification_crash_text">Klik for at se logs</string>
 
     <!-- RestApi -->
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -740,7 +740,7 @@ Bitte melden Sie auftretende Probleme via GitHub.</string>
 
     <string name="notification_crash_title">Syncthing ist abgestürzt (Exit-Code %1$s)</string>
 
-    <string name="notification_crash_text">Klicken um Logs anzuzeigen</string>
+    <string name="notification_crash_text">Klicke für Logs (%1$s)</string>
 
     <string name="notifications_persistent_channel">Syncthing läuft</string>
     <string name="notification_persistent_waiting_channel">Laufkonditionen werden überwacht</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -208,6 +208,7 @@
     <!-- Text for WebGuiActivity loading view -->
     <string name="web_gui_loading">Αναμονή για το GUI</string>
 
+
     <!-- SettingsFragment -->
 
 
@@ -216,7 +217,6 @@
     <string name="category_run_conditions">Συνθήκες εκτέλεσης</string>
     <string name="category_behaviour">Συμπεριφορά</string>
     <string name="category_syncthing_options">Επιλογές Syncthing</string>
-    <string name="category_debug">Αποσφαλμάτωση</string>
     <string name="category_experimental">Πειραματικά</string>
 
     <!-- Preference screen - Run conditions -->
@@ -416,8 +416,6 @@
     <string name="default_folder_id">%1$s-photos</string>
 
     <string name="notification_crash_title">Το Syncthing κατέρρευσε %1$s</string>
-
-    <string name="notification_crash_text">Πατήστε για να δείτε την καταγραφή συμβάντων</string>
 
     <string name="notifications_other_channel">Άλλες ειδοποιήσεις</string>
 

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -190,6 +190,7 @@
     <!-- Text for WebGuiActivity loading view -->
     <string name="web_gui_loading">Esperando por la Interfaz</string>
 
+
     <!-- SettingsFragment -->
 
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -208,7 +208,6 @@
     <string name="category_run_conditions">Condiciones de ejecución</string>
     <string name="category_behaviour">Comportamiento</string>
     <string name="category_syncthing_options">Opciones de Syncthing</string>
-    <string name="category_debug">Depuración</string>
     <string name="category_experimental">Experimental</string>
 
     <!-- Preference screen - Run conditions -->
@@ -382,8 +381,6 @@
     <string name="default_folder_id">%1$s-photos</string>
 
     <string name="notification_crash_title">Syncthing se ha estrellado %1$s</string>
-
-    <string name="notification_crash_text">Haga clic para ver los registros</string>
 
     <!-- RestApi -->
 

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -212,6 +212,7 @@
     <!-- Text for WebGuiActivity loading view -->
     <string name="web_gui_loading">Käyttöliittymä käynnistyy</string>
 
+
     <!-- SettingsFragment -->
 
 
@@ -220,7 +221,6 @@
     <string name="category_run_conditions">Käyntiehdot</string>
     <string name="category_behaviour">Käyttäytyminen</string>
     <string name="category_syncthing_options">Syncthing asetukset</string>
-    <string name="category_debug">Vianhaku</string>
     <string name="category_experimental">Kokeellinen</string>
 
     <!-- Preference screen - Run conditions -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -237,7 +237,6 @@
     <string name="category_run_conditions">Conditions d\'exécution</string>
     <string name="category_behaviour">Comportement</string>
     <string name="category_syncthing_options">Options Syncthing</string>
-    <string name="category_debug">Debug</string>
     <string name="category_experimental">Expérimental</string>
 
     <!-- Preference screen - Run conditions -->
@@ -481,8 +480,6 @@
     <string name="default_folder_id">%1$s-photos</string>
 
     <string name="notification_crash_title">Syncthing s\'est planté %1$s</string>
-
-    <string name="notification_crash_text">Cliquer pour voir les journaux</string>
 
     <string name="notifications_persistent_channel">Syncthing en marche</string>
     <string name="notification_persistent_waiting_channel">Surveillance des conditions de fonctionnement</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -225,6 +225,7 @@ Az összesített statisztika nyilvánosan elérhető a https://data.syncthing.ne
     <!-- Text for WebGuiActivity loading view -->
     <string name="web_gui_loading">Várakozás a grafikus felületre</string>
 
+
     <!-- SettingsFragment -->
 
 
@@ -233,7 +234,6 @@ Az összesített statisztika nyilvánosan elérhető a https://data.syncthing.ne
     <string name="category_run_conditions">Futás feltételei</string>
     <string name="category_behaviour">Viselkedés</string>
     <string name="category_syncthing_options">Syncthing opciók</string>
-    <string name="category_debug">Hibakeresés</string>
     <string name="category_experimental">Kísérleti</string>
 
     <!-- Preference screen - Run conditions -->
@@ -470,8 +470,6 @@ VIGYÁZAT! Más alkalmazások kiolvashatják a backupból a titkos kulcsot, és 
     <string name="default_folder_id">%1$s-kepek</string>
 
     <string name="notification_crash_title">A Syncthing összeomlott %1$s</string>
-
-    <string name="notification_crash_text">Koppints a naplók megtekintéséhez</string>
 
     <string name="notifications_persistent_channel">Syncthing aktív</string>
     <string name="notification_persistent_waiting_channel">Futási feltételek monitorozása</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -202,6 +202,7 @@
     <!-- Text for WebGuiActivity loading view -->
     <string name="web_gui_loading">Memuat GUI</string>
 
+
     <!-- SettingsFragment -->
 
 
@@ -210,7 +211,6 @@
     <string name="category_run_conditions">Syarat Operasi</string>
     <string name="category_behaviour">Perilaku</string>
     <string name="category_syncthing_options">Opsi Syncthing</string>
-    <string name="category_debug">Debug</string>
     <string name="category_experimental">Ujicoba</string>
 
     <!-- Preference screen - Run conditions -->

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -234,7 +234,6 @@
     <string name="category_run_conditions">Condizioni di funzionamento</string>
     <string name="category_behaviour">Comportamento</string>
     <string name="category_syncthing_options">Opzioni di Syncthing</string>
-    <string name="category_debug">Debug</string>
     <string name="category_experimental">Sperimentale</string>
 
     <!-- Preference screen - Run conditions -->
@@ -478,8 +477,6 @@
     <string name="default_folder_id">%1$s-photos</string>
 
     <string name="notification_crash_title">Syncthing è andato in crash %1$s</string>
-
-    <string name="notification_crash_text">Clicca per visualizzare i log</string>
 
     <string name="notifications_persistent_channel">Syncthing attivo</string>
     <string name="notification_persistent_waiting_channel">Monitoraggio delle condizioni di esecuzione</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -218,7 +218,6 @@
     <string name="category_run_conditions">実行条件</string>
     <string name="category_behaviour">動作</string>
     <string name="category_syncthing_options">同期オプション</string>
-    <string name="category_debug">デバッグ</string>
     <string name="category_experimental">実験的</string>
 
     <!-- Preference screen - Run conditions -->
@@ -415,8 +414,6 @@
     <string name="default_folder_id">%1$s-写真</string>
 
     <string name="notification_crash_title">Syncthing がクラッシュしました %1$s</string>
-
-    <string name="notification_crash_text">クリックしてログを表示</string>
 
     <string name="notifications_other_channel">他の通知</string>
 

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -207,6 +207,7 @@
     <!-- Text for WebGuiActivity loading view -->
     <string name="web_gui_loading">GUI를 기다리는 중</string>
 
+
     <!-- SettingsFragment -->
 
 
@@ -215,7 +216,6 @@
     <string name="category_run_conditions">작동 상태</string>
     <string name="category_behaviour">동작</string>
     <string name="category_syncthing_options">Syncthing 옵션 </string>
-    <string name="category_debug">디버그</string>
     <string name="category_experimental">실험적인 기능</string>
 
     <!-- Preference screen - Run conditions -->
@@ -412,8 +412,6 @@
     <string name="default_folder_id">%1$s-사진</string>
 
     <string name="notification_crash_title">Syncthing이 충돌하였습니다. %1$s</string>
-
-    <string name="notification_crash_text">클릭해서 로그 보기</string>
 
     <string name="notifications_other_channel">기타 알림</string>
 

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -193,6 +193,7 @@
     <!-- Text for WebGuiActivity loading view -->
     <string name="web_gui_loading">Venter på GUI</string>
 
+
     <!-- SettingsFragment -->
 
 

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -256,7 +256,6 @@
     <string name="category_run_conditions">Uitvoervoorwaarden</string>
     <string name="category_behaviour">Gedrag</string>
     <string name="category_syncthing_options">Syncthing-opties</string>
-    <string name="category_debug">Debug</string>
     <string name="category_experimental">Experimenteel</string>
 
     <!-- Preference screen - Run conditions -->
@@ -500,8 +499,6 @@
     <string name="default_folder_id">%1$s-foto\'s</string>
 
     <string name="notification_crash_title">Syncthing is gecrasht %1$s</string>
-
-    <string name="notification_crash_text">Tik om logboeken te bekijken</string>
 
     <string name="notifications_persistent_channel">Syncthing is actief</string>
     <string name="notification_persistent_waiting_channel">Uitvoervoorwaarden controleren</string>

--- a/app/src/main/res/values-nn/strings.xml
+++ b/app/src/main/res/values-nn/strings.xml
@@ -193,6 +193,7 @@
     <!-- Text for WebGuiActivity loading view -->
     <string name="web_gui_loading">Venter på grafisk grensesnitt</string>
 
+
     <!-- SettingsFragment -->
 
 

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -212,6 +212,7 @@
     <!-- Text for WebGuiActivity loading view -->
     <string name="web_gui_loading">Oczekiwanie na interfejs użytkownika</string>
 
+
     <!-- SettingsFragment -->
 
 
@@ -220,7 +221,6 @@
     <string name="category_run_conditions">Warunki działania</string>
     <string name="category_behaviour">Zachowanie</string>
     <string name="category_syncthing_options">Ustawienia Syncthing</string>
-    <string name="category_debug">Diagnozowanie błędów</string>
     <string name="category_experimental">Eksperymentalne</string>
 
     <!-- Preference screen - Run conditions -->
@@ -426,8 +426,6 @@
     <string name="default_folder_id">%1$s-zdjęcia</string>
 
     <string name="notification_crash_title">Syncthing spadło z rowerka %1$s</string>
-
-    <string name="notification_crash_text">Dotknij, by zobaczyć logi</string>
 
     <string name="notifications_other_channel">Inne powiadomienia</string>
 

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -225,6 +225,7 @@
     <!-- Text for WebGuiActivity loading view -->
     <string name="web_gui_loading">Aguardando a interface web</string>
 
+
     <!-- SettingsFragment -->
 
 
@@ -233,7 +234,6 @@
     <string name="category_run_conditions">Condições de execução</string>
     <string name="category_behaviour">Comportamento</string>
     <string name="category_syncthing_options">Opções do Syncthing</string>
-    <string name="category_debug">Depuração</string>
     <string name="category_experimental">Configurações experimentais</string>
 
     <!-- Preference screen - Run conditions -->
@@ -457,8 +457,6 @@
     <string name="default_folder_id">%1$s-fotos</string>
 
     <string name="notification_crash_title">O Syncthing fechou inesperadamente %1$s</string>
-
-    <string name="notification_crash_text">Clique para ver os logs</string>
 
     <string name="notifications_persistent_channel">Syncthing ativado</string>
     <string name="notification_persistent_waiting_channel">Monitorando condições de execução</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -202,6 +202,7 @@
     <!-- Text for WebGuiActivity loading view -->
     <string name="web_gui_loading">Aguardando a interface web</string>
 
+
     <!-- SettingsFragment -->
 
 
@@ -210,7 +211,6 @@
     <string name="category_run_conditions">Condições de execução</string>
     <string name="category_behaviour">Comportamento</string>
     <string name="category_syncthing_options">Opções do Syncthing</string>
-    <string name="category_debug">Depuração</string>
     <string name="category_experimental">Experimental</string>
 
     <!-- Preference screen - Run conditions -->

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -252,7 +252,6 @@
     <string name="category_run_conditions">Condiții de rulare</string>
     <string name="category_behaviour">Comportament</string>
     <string name="category_syncthing_options">Opțiuni Syncthing</string>
-    <string name="category_debug">Depanare</string>
     <string name="category_experimental">Experimental</string>
 
     <!-- Preference screen - Run conditions -->
@@ -516,8 +515,6 @@
     <string name="default_folder_id">%1$s-fotografii</string>
 
     <string name="notification_crash_title">Syncthing s-a oprit neașteptat %1$s</string>
-
-    <string name="notification_crash_text">Atingeți pentru a vedea jurnalele de erori</string>
 
     <string name="notifications_persistent_channel">Syncthing este activ</string>
     <string name="notification_persistent_waiting_channel">Monitorizare condiții rulare</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -43,10 +43,6 @@
 
     <string name="ignore">Игнорировать</string>
 
-    <!-- MainActivity -->
-
-
-
     <!-- Exception dialog message -->
     <string name="exception_known_bug_notice">Была встречена найденная ошибка, которая ещё не была решена. Больше информации в %1$s/%2$s. Пожалуйста, оставьте нам точное описание произошедшего перед этим.</string>
 
@@ -539,7 +535,7 @@
 
     <string name="notification_crash_title">Syncthing завершился из-за сбоя %1$s</string>
 
-    <string name="notification_crash_text">Нажмите для просмотра логов</string>
+    <string name="notification_crash_text">Нажмите для просмотра логов (%1$s)</string>
 
     <string name="notifications_persistent_channel">Syncthing работает</string>
     <string name="notification_persistent_waiting_channel">Отслеживание условий работы</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -177,6 +177,7 @@
     <!-- Text for WebGuiActivity loading view -->
     <string name="web_gui_loading">Čakám na GUI</string>
 
+
     <!-- SettingsFragment -->
 
 

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -615,7 +615,7 @@
 
     <string name="notification_crash_title">Syncthing har kraschat %1$s</string>
 
-    <string name="notification_crash_text">Klicka för att visa loggar</string>
+    <string name="notification_crash_text">Klicka för att visa loggar (%1$s)</string>
 
     <string name="notifications_persistent_channel">Syncthing är aktiv</string>
     <string name="notification_persistent_waiting_channel">Övervakar körvillkor</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -198,6 +198,7 @@
     <!-- Text for WebGuiActivity loading view -->
     <string name="web_gui_loading">Arayüz Bekleniyor</string>
 
+
     <!-- SettingsFragment -->
 
 
@@ -206,7 +207,6 @@
     <string name="category_run_conditions">Çalışma Koşulları</string>
     <string name="category_behaviour">Davranış</string>
     <string name="category_syncthing_options">Syncthing Seçenekleri</string>
-    <string name="category_debug">Hata ayıklama</string>
     <string name="category_experimental">Deneysel</string>
 
     <!-- Preference screen - Run conditions -->

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -164,6 +164,7 @@
     <!-- Text for WebGuiActivity loading view -->
     <string name="web_gui_loading">Очікую на веб-інтерфейс</string>
 
+
     <!-- SettingsFragment -->
 
 
@@ -171,7 +172,6 @@
 
     <string name="category_run_conditions">Умови запуску</string>
     <string name="category_syncthing_options">Опції Syncthing</string>
-    <string name="category_debug">Відладка</string>
     <string name="category_experimental">Експериментальне</string>
 
     <!-- Preference screen - Run conditions -->

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -190,6 +190,7 @@
     <!-- Text for WebGuiActivity loading view -->
     <string name="web_gui_loading">Đang chờ GUI</string>
 
+
     <!-- SettingsFragment -->
 
 

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -582,7 +582,7 @@
 
     <string name="notification_crash_title">Syncthing 已崩溃 %1$s</string>
 
-    <string name="notification_crash_text">点击查看日志</string>
+    <string name="notification_crash_text">点击查看日志 (%1$s)</string>
 
     <string name="notifications_persistent_channel">Syncthing 運行。</string>
     <string name="notification_persistent_waiting_channel">监控正在运行的规则中</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -414,7 +414,7 @@
 
     <string name="notification_crash_title">Syncthing 已經當機 %1$s</string>
 
-    <string name="notification_crash_text">觸碰檢視日誌</string>
+    <string name="notification_crash_text">觸碰檢視日誌 (%1$s)</string>
 
     <string name="notifications_other_channel">其他通知</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -756,7 +756,7 @@ Please report any problems you encounter via Github.</string>
 
     <string name="notification_crash_title">Syncthing has crashed (exit code %1$s)</string>
 
-    <string name="notification_crash_text">Click to view logs</string>
+    <string name="notification_crash_text">Click to view logs (%1$s)</string>
 
     <string name="notifications_persistent_channel">Syncthing active</string>
     <string name="notification_persistent_waiting_channel">Monitoring run conditions</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -756,7 +756,7 @@ Please report any problems you encounter via Github.</string>
 
     <string name="notification_crash_title">Syncthing has crashed (exit code %1$s)</string>
 
-    <string name="notification_crash_text">Click to view logs (%1$s)</string>
+    <string name="notification_crash_text">Click for logs (%1$s)</string>
 
     <string name="notifications_persistent_channel">Syncthing active</string>
     <string name="notification_persistent_waiting_channel">Monitoring run conditions</string>


### PR DESCRIPTION
Purpose:
Don't crash if config got corrupted and inform the user

Related issues:
- NullPointerException crash when config elements gui, options are missing (fixes #291)
- SyncthingService doesn't stop if config got corrupted (fixes #292)
- Broken config results in welcome wizard loop with no indication of what's wrong (fixes #293)
- Small screens: Crash notification reason is off-screen (fixes #294)

Testing:
Verified working on AVD 9.x at commit https://github.com/Catfriend1/syncthing-android/pull/295/commits/ad5a749f662c088db06fbf94efd21ba940ee4ebf .