### PR TITLE
TipsAndTricks: Add "Backup pictures from phone to computer" (fixes #257)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/TipsAndTricksActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/TipsAndTricksActivity.java
@@ -56,10 +56,6 @@ public class TipsAndTricksActivity extends SyncthingActivity {
             }
         }
 
-        // Fill tip title and text content.
-        mTipListAdapter.add(getString(R.string.tip_sync_on_local_network_title), getString(R.string.tip_sync_on_local_network_text));
-        mTipListAdapter.add(getString(R.string.tip_custom_sync_conditions_title), getString(R.string.tip_custom_sync_conditions_text));
-
         // Tips referring to Huawei devices.
         if ("huawei".equalsIgnoreCase(Build.MANUFACTURER)) {
             String ipAddress = getString(R.string.tip_phone_ip_address_syntax);
@@ -74,6 +70,11 @@ public class TipsAndTricksActivity extends SyncthingActivity {
         if ("xiaomi".equalsIgnoreCase(Build.MANUFACTURER)) {
             mTipListAdapter.add(getString(R.string.tip_xiaomi_autostart_title), getString(R.string.tip_xiaomi_autostart_text));
         }
+
+        // Fill tip title and text content.
+        mTipListAdapter.add(getString(R.string.tip_sync_on_local_network_title), getString(R.string.tip_sync_on_local_network_text));
+        mTipListAdapter.add(getString(R.string.tip_custom_sync_conditions_title), getString(R.string.tip_custom_sync_conditions_text));
+        mTipListAdapter.add(getString(R.string.tip_ignore_delete_title), getString(R.string.tip_ignore_delete_text));
 
         // Set onClick listener and add adapter to recycler view.
         mTipListAdapter.setOnClickListener(

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -329,6 +329,9 @@ Bitte melden Sie auftretende Probleme via GitHub.</string>
     <string name="tip_custom_sync_conditions_title">Sync-Bedingungen pro Ordner/Gerät festlegen</string>
     <string name="tip_custom_sync_conditions_text">Diese Funktion wird in zukünftigen Releases weiter verbessert. Für den Moment wollten wir das App-Verhalten nicht \"umstürzen\", um bestehende Konfigurationen nicht zu \"brechen\". Deshalb können die \"individuellen Sync-Bedingungen\" für einen bestimmten Netzwerktyp erst festgelegt werden, wenn dieser Netzwerktyp vorher in den globalen Laufkonditionen aktiviert wurde.</string>
 
+    <string name="tip_ignore_delete_title">Bilder vom Telefon auf den Computer sichern?</string>
+    <string name="tip_ignore_delete_text">Wenn Du alle vom Telefon gemachten Bilder auf einen Computer sichern möchtest, teile den Ordner \'Kamera\' mit dem Computer. Öffne Syncthing auf dem Computer, füge den Ordner hinzu und gehe zu \'Aktionen\'  > \'Erweitert\' > \'Kamera\' Ordner. Aktiviere \'Ignore Delete\' und klicke \'Speichern\'. Du kannst nun Bilder aus dem Kamera-Ordner vom Telefon löschen und sie bleiben auf dem Computer gesichert.</string>
+
     <string name="tip_huawei_device_disconnected_title">Huawei: Workaround für \"Gerät getrennt\"</string>
     <string name="tip_huawei_device_disconnected_text">Falls der Computer das Huawei-Gerät permanent als \"getrennt\" meldet, öffne die Syncthing-Oberfläche auf dem Computer. Gehe zu \"Externe Geräte\", klappe den Eintrag des Mobilgeräts aus, klicke \"Bearbeiten\", wechsle zu \"Erweitert\". Trage die IP-Adresse deines Mobilgeräts in \"Adressen\" wie folgt ein:\ntcp4://%1$s, dynamic\nFunktioniert sicher auf: Huawei P10</string>
     <string name="tip_phone_ip_address_syntax">TELEFON_IP_ADRESSE</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -332,6 +332,9 @@ Please report any problems you encounter via Github.</string>
     <string name="tip_custom_sync_conditions_title">Use per folder/device custom sync conditions</string>
     <string name="tip_custom_sync_conditions_text">This feature will still be improved in future releases. For now, we didn\'t want to break existing configs and app behaviour. That\'s why custom sync conditions for a certain network type can only be set if you enable syncing on the network in the global run conditions first.</string>
 
+    <string name="tip_ignore_delete_title">Backup pictures from phone to computer?</string>
+    <string name="tip_ignore_delete_text">If you\'d like to have all pictures made on your phone backed up to a computer, share the \'Camera\' folder with the computer. Open Syncthing on the computer, add the folder and go to \'Actions\' > \'Advanced\' > \'Camera\' folder. Enable \'Ignore Delete\' and click \'Save\'. You can now delete pictures from your camera folder on the phone and they will stay backed up on the computer.</string>
+
     <string name="tip_huawei_device_disconnected_title">Huawei: \'device disconnected\' workaround</string>
     <string name="tip_huawei_device_disconnected_text">If your desktop constantly reports your Huawei device as disconnected, open Syncthing UI of your desktop. Go to \'remote devices\', expand the phone\'s entry, click \'Edit\', switch to \'Advanced\'. Put your phone IP address into \'Addresses\' like this:\ntcp4://%1$s, dynamic\nConfirmed working for: Huawei P10</string>
     <string name="tip_phone_ip_address_syntax">PHONE_IP_ADDRESS</string>


### PR DESCRIPTION
Purpose:
- TipsAndTricks: Add "Backup pictures from phone to computer" (fixes #257)

Testing:
- Followed the tip to setup the camera folder using "IgnoreDelete" on computer.
- Synced new pictures
- After syncing completed: Deleted pictures from the phone
- Result is correct: The pictures are preserved on the computer.

Phone side:
![image](https://user-images.githubusercontent.com/16361913/52175726-6a204700-27a8-11e9-8970-a4a927d54868.png)
![image](https://user-images.githubusercontent.com/16361913/52175729-72788200-27a8-11e9-9255-4202a010a8b2.png)

Computer side:
![image](https://user-images.githubusercontent.com/16361913/52175733-80c69e00-27a8-11e9-87f6-778b98e433f6.png)
![image](https://user-images.githubusercontent.com/16361913/52175735-858b5200-27a8-11e9-99c6-f1d371b950fa.png)
