### PR TITLE
Allow changing suggested path for new folder (fixes #309)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
@@ -41,6 +41,7 @@ import com.nutomic.syncthingandroid.service.SyncthingServiceBinder;
 import com.nutomic.syncthingandroid.SyncthingApp;
 import com.nutomic.syncthingandroid.util.ConfigRouter;
 import com.nutomic.syncthingandroid.util.FileUtils;
+import com.nutomic.syncthingandroid.util.FileUtils.ExternalStorageDirType;
 import com.nutomic.syncthingandroid.util.TextWatcherAdapter;
 import com.nutomic.syncthingandroid.util.Util;
 
@@ -293,13 +294,20 @@ public class FolderActivity extends SyncthingActivity {
     @SuppressLint("InlinedAPI")
     private void onPathViewClick() {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            // API < 21
             startActivityForResult(FolderPickerActivity.createIntent(this, mFolder.path, null),
                 FolderPickerActivity.DIRECTORY_REQUEST_CODE);
             return;
         }
+        String prefSuggestNewFolderRoot = mPreferences.getString(Constants.PREF_SUGGEST_NEW_FOLDER_ROOT, Constants.PREF_SUGGEST_NEW_FOLDER_ROOT_DATA);
 
         // This has to be android.net.Uri as it implements a Parcelable.
-        android.net.Uri externalFilesDirUri = FileUtils.getExternalFilesDirUri(FolderActivity.this);
+        android.net.Uri externalFilesDirUri = FileUtils.getExternalFilesDirUri(
+                FolderActivity.this,
+                prefSuggestNewFolderRoot.equals(Constants.PREF_SUGGEST_NEW_FOLDER_ROOT_DATA) ?
+                        ExternalStorageDirType.DATA :
+                        ExternalStorageDirType.MEDIA
+        );
 
         // Display storage access framework directory picker UI.
         Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
@@ -298,6 +298,10 @@ public class SettingsActivity extends SyncthingActivity {
             mSuggestNewFolderRoot =
                     (ListPreference) findPreference(Constants.PREF_SUGGEST_NEW_FOLDER_ROOT);
             screen.findPreference(Constants.PREF_SUGGEST_NEW_FOLDER_ROOT).setSummary(mSuggestNewFolderRoot.getEntry());
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+                // Remove preference as FileUtils#getExternalFilesDirUri is only supported on API 21+ (LOLLIPOP+).
+                categoryBehaviour.removePreference(mSuggestNewFolderRoot);
+            }
             setPreferenceCategoryChangeListener(categoryBehaviour, this::onBehaviourPreferenceChange);
 
             /* Syncthing options */

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
@@ -416,7 +416,12 @@ public class SettingsActivity extends SyncthingActivity {
                 // User has clicked on a sub-preferences screen.
                 try {
                     mCurrentPrefScreenDialog = ((PreferenceScreen) preference).getDialog();
-                    LinearLayout root = (LinearLayout) mCurrentPrefScreenDialog.findViewById(android.R.id.list).getParent().getParent();
+                    LinearLayout root;
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                        root = (LinearLayout) mCurrentPrefScreenDialog.findViewById(android.R.id.list).getParent().getParent();
+                    } else {
+                        root = (LinearLayout) mCurrentPrefScreenDialog.findViewById(android.R.id.list).getParent();
+                    }
                     SyncthingActivity syncthingActivity = (SyncthingActivity) getActivity();
                     LayoutInflater layoutInflater = syncthingActivity.getLayoutInflater();
                     Toolbar toolbar = (Toolbar) layoutInflater.inflate(R.layout.widget_toolbar, root, false);

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
@@ -27,8 +27,12 @@ public class Constants {
     public static final String PREF_RUN_IN_FLIGHT_MODE          = "run_in_flight_mode";
 
     // Preferences - Behaviour
-    public static final String PREF_USE_ROOT                    = "use_root";
-    public static final String PREF_SUGGEST_NEW_FOLDER_ROOT     = "suggest_new_folder_root";
+    public static final String PREF_USE_ROOT                        = "use_root";
+
+    public static final String PREF_SUGGEST_NEW_FOLDER_ROOT         = "suggest_new_folder_root";
+    public static final String PREF_SUGGEST_NEW_FOLDER_ROOT_DATA    = "external_android_data";
+    public static final String PREF_SUGGEST_NEW_FOLDER_ROOT_MEDIA   = "external_android_media";
+
 
     // Preferences - Troubleshooting
     public static final String PREF_ENVIRONMENT_VARIABLES       = "environment_variables";

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
@@ -28,13 +28,18 @@ public class Constants {
 
     // Preferences - Behaviour
     public static final String PREF_USE_ROOT                    = "use_root";
+    public static final String PREF_SUGGEST_NEW_FOLDER_ROOT     = "suggest_new_folder_root";
+
+    // Preferences - Troubleshooting
     public static final String PREF_ENVIRONMENT_VARIABLES       = "environment_variables";
     public static final String PREF_DEBUG_FACILITIES_ENABLED    = "debug_facilities_enabled";
-    public static final String PREF_USE_WAKE_LOCK               = "wakelock_while_binary_running";
+
+    // Preferences - Experimental
     public static final String PREF_USE_TOR                     = "use_tor";
     public static final String PREF_SOCKS_PROXY_ADDRESS         = "socks_proxy_address";
     public static final String PREF_HTTP_PROXY_ADDRESS          = "http_proxy_address";
     public static final String PREF_BROADCAST_SERVICE_CONTROL   = "broadcast_service_control";
+    public static final String PREF_USE_WAKE_LOCK               = "wakelock_while_binary_running";
 
     // Preferences - per Folder and Device Sync Conditions
     public static final String PREF_OBJECT_PREFIX_FOLDER        = "sc_folder_";

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/ConfigXml.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/ConfigXml.java
@@ -459,8 +459,10 @@ public class ConfigXml {
             */
             folder.minDiskFree = new Folder.MinDiskFree();
             Element elementMinDiskFree = (Element) r.getElementsByTagName("minDiskFree").item(0);
-            folder.minDiskFree.unit = getAttributeOrDefault(elementMinDiskFree, "unit", "%");
-            folder.minDiskFree.value = getContentOrDefault(elementMinDiskFree, 1f);
+            if (elementMinDiskFree != null) {
+                folder.minDiskFree.unit = getAttributeOrDefault(elementMinDiskFree, "unit", "%");
+                folder.minDiskFree.value = getContentOrDefault(elementMinDiskFree, 1f);
+            }
             // Log.v(TAG, "folder.minDiskFree.unit=" + folder.minDiskFree.unit + ", folder.minDiskFree.value=" + folder.minDiskFree.value);
 
             // Versioning

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -439,6 +439,13 @@ Bitte melden Sie auftretende Probleme via GitHub.</string>
 
     <string name="use_root_summary">Wenn Syncthing unter dem Root-Benutzer ausgeführt wird, hat es Schreibzugriff auf Ordner, die Android normalerweise auf schreibgeschützten Zugriff beschränkt. Verwende diese Funktion mit Bedacht.</string>
 
+    <string name="suggest_new_folder_root_title">Wähle Stamm für neue Ordner</string>
+
+    <string-array name="suggest_new_folder_root_entries">
+        <item>[Ext_Speicher]/Android/data</item>
+        <item>[Ext_Speicher]/Android/media</item>
+    </string-array>
+
     <string name="preference_language_title">Sprache</string>
 
     <string name="preference_language_summary">Anwendungssprache ändern</string>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -15,4 +15,10 @@
         <item>battery_power</item>
     </string-array>
 
+    <!-- Preference screen -->
+    <string-array name="suggest_new_folder_root_values">
+        <item>external_android_data</item>
+        <item>external_android_media</item>
+    </string-array>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -442,6 +442,13 @@ Please report any problems you encounter via Github.</string>
 
     <string name="use_root_summary">Running Syncthing as root allows it to write to folders Android normally restricts to be readonly accessed. Use this feature cautious.</string>
 
+    <string name="suggest_new_folder_root_title">Select new folder root</string>
+
+    <string-array name="suggest_new_folder_root_entries">
+        <item>[external_storage]/Android/data</item>
+        <item>[external_storage]/Android/media</item>
+    </string-array>
+
     <string name="preference_language_title">Language</string>
 
     <string name="preference_language_summary">Change the app language</string>

--- a/app/src/main/res/xml/app_settings.xml
+++ b/app/src/main/res/xml/app_settings.xml
@@ -91,6 +91,14 @@
             android:defaultValue="false" />
 
         <ListPreference
+            android:key="suggest_new_folder_root"
+            android:title="@string/suggest_new_folder_root_title"
+            android:entryValues="@array/suggest_new_folder_root_values"
+            android:entries="@array/suggest_new_folder_root_entries"
+            android:summary="@null"
+            android:defaultValue="external_android_data" />
+
+        <ListPreference
             android:key="pref_current_language"
             android:title="@string/preference_language_title"
             android:summary="@string/preference_language_summary" />


### PR DESCRIPTION
Purpose:
- Allow changing suggested path for new folder (fixes #309)

Testing:
Verified working on AVD 9.x at commit https://github.com/Catfriend1/syncthing-android/pull/318/commits/b131f64fb9b505c15d5c10be61945c912d23e32d .
Verified by @mbirth in https://github.com/Catfriend1/syncthing-android/issues/309#issuecomment-462530706 .