### PR TITLE
Send a shutdown POST request first (fixes #320)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/http/PostRequest.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/http/PostRequest.java
@@ -16,6 +16,7 @@ public class PostRequest extends ApiRequest {
     public static final String URI_DB_IGNORES       = "/rest/db/ignores";
     public static final String URI_DB_OVERRIDE      = "/rest/db/override";
     public static final String URI_SYSTEM_CONFIG    = "/rest/system/config";
+    public static final String URI_SYSTEM_SHUTDOWN  = "/rest/system/shutdown";
 
     public PostRequest(Context context, URL url, String path, String apiKey,
         	           @Nullable Map<String, String> params, @Nullable String postBody,

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/RestApi.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/RestApi.java
@@ -147,8 +147,6 @@ public class RestApi {
 
     private Gson mGson;
 
-    @Inject NotificationHandler mNotificationHandler;
-
     public RestApi(Context context, URL url, String apiKey, OnApiAvailableListener apiListener,
                    OnConfigChangedListener configListener) {
         ((SyncthingApp) context.getApplicationContext()).component().inject(this);
@@ -410,10 +408,6 @@ public class RestApi {
             mContext.startService(intent);
         });
         mOnConfigChangedListener.onConfigChanged();
-    }
-
-    public void shutdown() {
-        mNotificationHandler.cancelRestartNotification();
     }
 
     /**

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/RestApi.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/RestApi.java
@@ -411,6 +411,15 @@ public class RestApi {
     }
 
     /**
+     * Posts shutdown request.
+     * This will cause SyncthingNative to exit and not restart.
+     */
+    public void shutdown() {
+        new PostRequest(mContext, mUrl, PostRequest.URI_SYSTEM_SHUTDOWN, mApiKey,
+                null, null, null);
+    }
+
+    /**
      * Returns the version name, or a (text) error message on failure.
      */
     public String getVersion() {

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
@@ -653,8 +653,11 @@ public class SyncthingService extends Service {
             mEventProcessor = null;
         }
 
+        if (mNotificationHandler != null) {
+            mNotificationHandler.cancelRestartNotification();
+        }
+
         if (mRestApi != null) {
-            mRestApi.shutdown();
             mRestApi = null;
         }
 

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
@@ -658,6 +658,9 @@ public class SyncthingService extends Service {
         }
 
         if (mRestApi != null) {
+            if (mSyncthingRunnable != null) {
+                mRestApi.shutdown();
+            }
             mRestApi = null;
         }
 


### PR DESCRIPTION
Purpose:
- SyncthingService#shutdown: Send a shutdown POST request first in case the kill via shell fails (fixes #320)

Testing:
- Verified working on AVD 9.x at commit https://github.com/Catfriend1/syncthing-android/commit/02b1415138eb07298109be9cb3be90c1fe69b191 .