### PR TITLE
Add Binary Eye barcode scanner support (fixes #325)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/DeviceActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/DeviceActivity.java
@@ -612,6 +612,7 @@ public class DeviceActivity extends SyncthingActivity {
         );
         IntentIntegrator integrator = new IntentIntegrator(DeviceActivity.this);
         integrator.setTargetApplications(targetApplications);
+        integrator.setMessage(getString(R.string.install_barcode_scanner_app_message));
         integrator.initiateScan();
     }
 

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/DeviceActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/DeviceActivity.java
@@ -607,8 +607,8 @@ public class DeviceActivity extends SyncthingActivity {
         final List<String> targetApplications = list(
             "de.markusfisch.android.binaryeye",                 // Binary Eye
             "com.srowen.bs.android",                            // Barcode Scanner+
-            "com.srowen.bs.android.simple",                     // Barcode Scanner+ Simple
-            "com.google.zxing.client.android"                   // Barcode Scanner (2019-02-24: no longer on GPlay)
+            "com.srowen.bs.android.simple"                      // Barcode Scanner+ Simple
+            // "com.google.zxing.client.android"                // Barcode Scanner (2019-02-24: no longer on GPlay)
         );
         IntentIntegrator integrator = new IntentIntegrator(DeviceActivity.this);
         integrator.setTargetApplications(targetApplications);

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/DeviceActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/DeviceActivity.java
@@ -604,7 +604,14 @@ public class DeviceActivity extends SyncthingActivity {
     }
 
     private void onQrButtonClick() {
+        final List<String> targetApplications = list(
+            "de.markusfisch.android.binaryeye",                 // Binary Eye
+            "com.srowen.bs.android",                            // Barcode Scanner+
+            "com.srowen.bs.android.simple",                     // Barcode Scanner+ Simple
+            "com.google.zxing.client.android"                   // Barcode Scanner (2019-02-24: no longer on GPlay)
+        );
         IntentIntegrator integrator = new IntentIntegrator(DeviceActivity.this);
+        integrator.setTargetApplications(targetApplications);
         integrator.initiateScan();
     }
 
@@ -720,5 +727,9 @@ public class DeviceActivity extends SyncthingActivity {
         mEditDeviceId.setText((String) view.getTag());
         mDiscoveredDevicesTitle.setVisibility(View.GONE);
         mDiscoveredDevicesContainer.setVisibility(View.GONE);
+    }
+
+    private static List<String> list(String... values) {
+        return Collections.unmodifiableList(Arrays.asList(values));
     }
 }

--- a/app/src/main/play/en-GB/whatsnew
+++ b/app/src/main/play/en-GB/whatsnew
@@ -1,4 +1,5 @@
 Enhancements
+* Add Binary Eye barcode scanner support (#325)
 * Download Support Bundle (#332)
 * Add label to explain why Syncthing Options are greyed out (#337)
 Notes

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -320,6 +320,9 @@ Bitte melden Sie auftretende Probleme via GitHub.</string>
     <!-- Content description for device ID qr code icon -->
     <string name="scan_qr_code_description">QR Code scannen</string>
 
+    <!-- Dialog message if no compatible barcode scanner app is installed -->
+    <string name="install_barcode_scanner_app_message">Dies erfordert eine Barcode Scanner App. Möchtest Du die App \'Binary Eye\' von F-Droid installieren?</string>
+
     <!-- Toast show if we could not get root permissions -->
     <string name="toast_root_denied">Konnte keine Root-Rechte erhalten.</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -323,6 +323,9 @@ Please report any problems you encounter via Github.</string>
     <!-- Content description for device ID qr code icon -->
     <string name="scan_qr_code_description">Scan QR Code</string>
 
+    <!-- Dialog message if no compatible barcode scanner app is installed -->
+    <string name="install_barcode_scanner_app_message">This requires a barcode scanner app. Would you like to install the app \'Binary Eye\' from F-Droid?</string>
+
     <!-- Toast show if we could not get root permissions -->
     <string name="toast_root_denied">Did not get root permissions</string>
 


### PR DESCRIPTION
Purpose:
- Add Binary Eye barcode scanner support (fixes #325)

Testing:
- Verified working on AVD 9.x at commit https://github.com/Catfriend1/syncthing-android/pull/339/commits/09898b781c3b6a0f1dc2ddc43e78837200d428de .
