### PR TITLE
fragmentManager: commitAllowingStateLoss (fixes #321)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/MainActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/MainActivity.java
@@ -208,7 +208,7 @@ public class MainActivity extends SyncthingActivity
             }
         }
 
-        fm.beginTransaction().replace(R.id.drawer, mDrawerFragment).commit();
+        fm.beginTransaction().replace(R.id.drawer, mDrawerFragment).commitAllowingStateLoss();
         mDrawerToggle = new Toggle(this, mDrawerLayout);
         mDrawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_UNLOCKED);
         mDrawerLayout.addDrawerListener(mDrawerToggle);


### PR DESCRIPTION
Purpose:
Fix issue #321 according to the StackOverflow linked in the issue.

Testing:
I tested screen rotation and service state change during app in background after screen rotated. Found no crash, but  that was already the case before this PR. So we'll have to use the community and check the gplay reports if the situation got better, same or worse.