### PR TITLE
Show Android Open File Limit (fixes #346)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
@@ -150,6 +150,7 @@ public class SettingsActivity extends SyncthingActivity {
         // Settings/About
         private static final String KEY_SYNCTHING_API_KEY = "syncthing_api_key";
         private static final String KEY_SYNCTHING_DATABASE_SIZE = "syncthing_database_size";
+        private static final String KEY_OS_OPEN_FILE_LIMIT = "os_open_file_limit";
 
         private static final String BIND_ALL = "0.0.0.0";
         private static final String BIND_LOCALHOST = "127.0.0.1";
@@ -394,6 +395,7 @@ public class SettingsActivity extends SyncthingActivity {
                 Log.d(TAG, "Failed to get app version name");
             }
             screen.findPreference(KEY_SYNCTHING_DATABASE_SIZE).setSummary(getDatabaseSize());
+            screen.findPreference(KEY_OS_OPEN_FILE_LIMIT).setSummary(getOpenFileLimit());
 
             // Check if we should directly show a sub preference screen.
             Bundle bundle = getArguments();
@@ -1080,6 +1082,17 @@ public class SettingsActivity extends SyncthingActivity {
                 return "N/A";
             }
             return resultParts[0];
+        }
+
+        /**
+         * Get current open file limit enforced by the Android OS.
+         */
+        private String getOpenFileLimit() {
+            String result = Util.runShellCommandGetOutput("/system/bin/ulimit -n", false);
+            if (TextUtils.isEmpty(result)) {
+                return "N/A";
+            }
+            return result;
         }
     }
 }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -651,6 +651,9 @@ Bitte melden Sie auftretende Probleme via GitHub.</string>
     <!-- Title of the preference showing database size -->
     <string name="syncthing_database_size">Syncthing Datenbankgröße</string>
 
+    <!-- Title of the preference showing the OS open file limit -->
+    <string name="os_open_file_limit">Android Offene Dateien Limit</string>
+
     <!-- FolderPickerAcitivity -->
 
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -672,6 +672,9 @@ Please report any problems you encounter via Github.</string>
     <!-- Title of the preference showing database size -->
     <string name="syncthing_database_size">Syncthing Database Size</string>
 
+    <!-- Title of the preference showing the OS open file limit -->
+    <string name="os_open_file_limit">Android Open File Limit</string>
+
     <!-- FolderPickerAcitivity -->
 
 

--- a/app/src/main/res/xml/app_settings.xml
+++ b/app/src/main/res/xml/app_settings.xml
@@ -344,6 +344,12 @@
             android:key="syncthing_database_size"
             android:title="@string/syncthing_database_size" />
 
+        <Preference
+            android:persistent="false"
+            android:selectable="false"
+            android:key="os_open_file_limit"
+            android:title="@string/os_open_file_limit" />
+
     </PreferenceScreen>
 
 </PreferenceScreen>


### PR DESCRIPTION
Purpose:
- Show Android Open File Limit (fixes #346)

Testing:
- Verified working at commit https://github.com/Catfriend1/syncthing-android/commit/97997c059c32e03a1989456d881fe1be15816438 on AVD 9.x .