### PR TITLE
Add "folder is unshared" status label (fixes #347)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/views/FoldersAdapter.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/views/FoldersAdapter.java
@@ -105,8 +105,14 @@ public class FoldersAdapter extends ArrayAdapter<Folder> {
             } else {
                 switch(folderStatus.state) {
                     case "idle":
-                        binding.state.setText(mContext.getString(R.string.state_idle));
-                        binding.state.setTextColor(ContextCompat.getColor(mContext, R.color.text_green));
+                        if (folder.getDeviceCount() <= 1) {
+                            // Special case: The folder is IDLE and UNSHARED.
+                            binding.state.setText(mContext.getString(R.string.state_unshared));
+                            binding.state.setTextColor(ContextCompat.getColor(mContext, R.color.text_orange));
+                        } else {
+                            binding.state.setText(mContext.getString(R.string.state_idle));
+                            binding.state.setTextColor(ContextCompat.getColor(mContext, R.color.text_green));
+                        }
                         break;
                     case "scanning":
                         binding.state.setText(mContext.getString(R.string.state_scanning));

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -840,6 +840,7 @@ Bitte melden Sie auftretende Probleme via GitHub.</string>
     <string name="state_unknown">Unbekannt</string>
     <string name="state_paused">Pausiert</string>
     <string name="status_outofsync">Nicht synchronisiert</string>
+    <string name="state_unshared">Ungeteilt</string>
 
     <!-- Format string for folder size, eg "500 MiB / 1 GiB" -->
     <string name="folder_size_format">%1$s / %2$s</string>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -9,6 +9,7 @@
     <color name="text_red">#ffff4444</color>
     <color name="text_blue">#ff33b5e5</color>
     <color name="text_green">#ff99cc00</color>
+    <color name="text_orange">#f57c00</color>
     <color name="light_grey">#cccccc</color>
 
     <!-- FirstStartActivity welcome wizard start -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -861,6 +861,7 @@ Please report any problems you encounter via Github.</string>
     <string name="state_unknown">Unknown</string>
     <string name="state_paused">Paused</string>
     <string name="status_outofsync">Out of Sync</string>
+    <string name="state_unshared">Unshared</string>
 
     <!-- Format string for folder size, eg "500 MiB / 1 GiB" -->
     <string name="folder_size_format">%1$s / %2$s</string>


### PR DESCRIPTION
Purpose:
- Add "folder is unshared" status label (fixes #347)

Testing:
- Verified working on AVD 9.x at commit https://github.com/Catfriend1/syncthing-android/pull/351/commits/cc5c5041eae6293b3d99fa76da56de1824113a7f .