### PR TITLE
Use model/Folder defaults for the camera folder (fixes #352)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/util/ConfigXml.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/ConfigXml.java
@@ -963,6 +963,7 @@ public class ConfigXml {
      * Returns if changes to the config have been made.
      */
     private boolean changeDefaultFolder() {
+        Folder defaultFolder = new Folder();
         Element folder = (Element) mConfig.getDocumentElement()
                 .getElementsByTagName("folder").item(0);
         String deviceModel = Build.MODEL
@@ -975,8 +976,9 @@ public class ConfigXml {
         folder.setAttribute("path", Environment
                 .getExternalStoragePublicDirectory(Environment.DIRECTORY_DCIM).getAbsolutePath());
         folder.setAttribute("type", Constants.FOLDER_TYPE_SEND_ONLY);
-        folder.setAttribute("fsWatcherEnabled", "true");
-        folder.setAttribute("fsWatcherDelayS", "10");
+        folder.setAttribute("fsWatcherEnabled", Boolean.toString(defaultFolder.fsWatcherEnabled));
+        folder.setAttribute("fsWatcherDelayS", Integer.toString(defaultFolder.fsWatcherDelayS));
+        setConfigElement(folder, "useLargeBlocks", Boolean.toString(defaultFolder.useLargeBlocks));
         return true;
     }
 


### PR DESCRIPTION
Purpose
- Use model/Folder defaults for the camera folder (fixes #352)

Testing
- Verified working on AVD 9.x at commit https://github.com/Catfriend1/syncthing-android/commit/bb5a7ad84541b2464d9e2d7491324975855042bf .