### PR TITLE
Fix "Share to Syncthing" when user didn't complete welcome wizard (fixes #354)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/ShareActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/ShareActivity.java
@@ -29,6 +29,7 @@ import com.nutomic.syncthingandroid.model.Folder;
 import com.nutomic.syncthingandroid.service.SyncthingService;
 import com.nutomic.syncthingandroid.service.SyncthingServiceBinder;
 import com.nutomic.syncthingandroid.util.ConfigRouter;
+import com.nutomic.syncthingandroid.util.ConfigXml.OpenConfigException;
 import com.nutomic.syncthingandroid.util.Util;
 
 import java.io.File;
@@ -76,7 +77,14 @@ public class ShareActivity extends SyncthingActivity
 
     @Override
     public void onServiceStateChange(SyncthingService.State currentState) {
-        List<Folder> folders = mConfig.getFolders(getApi());
+        List<Folder> folders = null;
+        try {
+            folders = mConfig.getFolders(getApi());
+        } catch (OpenConfigException e) {
+            Toast.makeText(this, getString(R.string.complete_welcome_wizard_first), Toast.LENGTH_LONG).show();
+            finish();
+            return;
+        }
 
         // Get the index of the previously selected folder.
         int folderIndex = 0;

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -703,6 +703,9 @@ Bitte melden Sie auftretende Probleme via GitHub.</string>
     <!-- ShareActivity -->
 
 
+    <!-- Toast if user didn't complete the welcome wizard yet -->
+    <string name="complete_welcome_wizard_first">Starte zuerst die App aus der App-Übersicht und schließe den Willkommensassistenten ab, bevor Du Dateien teilst.</string>
+
     <!-- Title of the "share" activity -->
     <string name="share_activity_title">Speichern in Syncthing</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -724,6 +724,9 @@ Please report any problems you encounter via Github.</string>
     <!-- ShareActivity -->
 
 
+    <!-- Toast if user didn't complete the welcome wizard yet -->
+    <string name="complete_welcome_wizard_first">First, launch the app from the app drawer and complete the welcome wizard before sharing files.</string>
+
     <!-- Title of the "share" activity -->
     <string name="share_activity_title">Save to Syncthing</string>
 


### PR DESCRIPTION
Purpose:
- Show a message when user tries to "Share to Syncthing" and hasn't completed the welcome wizard yet. (fixes #354)

Testing:
- Verified working on AVD 9.x at commit https://github.com/Catfriend1/syncthing-android/pull/360/commits/658810d0ae89020170f17570c71b58623116d717 .

Screenshot:
![image](https://user-images.githubusercontent.com/16361913/54077904-6a3bc700-42bf-11e9-81a7-d2adb8f5b83e.png)
