### PR TITLE
Create folder dialog - trim folder label (fixes #367)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
@@ -680,7 +680,10 @@ public class FolderActivity extends SyncthingActivity {
         mFolder.id = (getIntent().hasExtra(EXTRA_FOLDER_ID))
                 ? getIntent().getStringExtra(EXTRA_FOLDER_ID)
                 : generateRandomFolderId();
-        mFolder.label = getIntent().getStringExtra(EXTRA_FOLDER_LABEL).trim();
+        mFolder.label = getIntent().getStringExtra(EXTRA_FOLDER_LABEL);
+        if (!TextUtils.isEmpty(mFolder.label)) {
+            mFolder.label = mFolder.label.trim();
+        }
         mFolder.paused = false;
         mFolder.type = Constants.FOLDER_TYPE_SEND_RECEIVE;      // Default for {@link #checkWriteAndUpdateUI}.
         mFolder.minDiskFree = new Folder.MinDiskFree();

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
@@ -131,7 +131,7 @@ public class FolderActivity extends SyncthingActivity {
     private final TextWatcher mTextWatcher = new TextWatcherAdapter() {
         @Override
         public void afterTextChanged(Editable s) {
-            mFolder.label        = mLabelView.getText().toString();
+            mFolder.label        = mLabelView.getText().toString().trim();
             mFolder.id           = mIdView.getText().toString();
             // mPathView must not be handled here as it's handled by {@link onActivityResult}
             // mEditIgnoreListContent must not be handled here as it's written back when the dialog ends.
@@ -680,7 +680,7 @@ public class FolderActivity extends SyncthingActivity {
         mFolder.id = (getIntent().hasExtra(EXTRA_FOLDER_ID))
                 ? getIntent().getStringExtra(EXTRA_FOLDER_ID)
                 : generateRandomFolderId();
-        mFolder.label = getIntent().getStringExtra(EXTRA_FOLDER_LABEL);
+        mFolder.label = getIntent().getStringExtra(EXTRA_FOLDER_LABEL).trim();
         mFolder.paused = false;
         mFolder.type = Constants.FOLDER_TYPE_SEND_RECEIVE;      // Default for {@link #checkWriteAndUpdateUI}.
         mFolder.minDiskFree = new Folder.MinDiskFree();


### PR DESCRIPTION
Purpose:
- Create folder dialog - trim folder label (fixes #367)

Testing:
- Verified working on AVD 9.x at commit https://github.com/Catfriend1/syncthing-android/pull/368/commits/c912aa12ba9736d0b27e91063d7fffd336f12bd0 .
- Waiting for ticket opener in #367 to confirm the bug is solved.