### PR TITLE
Raise targetSdk to 28

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ android:
   components:
     - tools
     - platform-tools
-    - build-tools-27.0.3
-    - android-27
+    - build-tools-29.0.0-rc1
+    - android-28
     - extra-android-m2repository
 
 # Install Android NDK (apparently there is no easier way to do this)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,15 +7,15 @@ dependencies {
     implementation 'com.android.support:design:28.0.0'
     implementation 'com.android.support:recyclerview-v7:28.0.0'
     implementation 'com.google.zxing:android-integration:3.3.0'
-    implementation 'com.google.code.gson:gson:2.8.3'
+    implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'org.mindrot:jbcrypt:0.4'
     // com.google.guava:guava:24.1-jre will crash on Android 5.x
     implementation 'com.google.guava:guava:26.0-android'
-    implementation 'com.annimon:stream:1.1.9'
-    implementation 'com.android.volley:volley:1.1.0'
+    implementation 'com.annimon:stream:1.2.1'
+    implementation 'com.android.volley:volley:1.1.1'
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
-    implementation 'com.google.dagger:dagger:2.14.1'
-    annotationProcessor "com.google.dagger:dagger-compiler:2.14.1"
+    implementation 'com.google.dagger:dagger:2.21'
+    annotationProcessor "com.google.dagger:dagger-compiler:2.21"
     androidTestImplementation 'com.android.support.test:rules:1.0.2'
     androidTestImplementation 'com.android.support:support-annotations:28.0.0'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,7 +23,7 @@ dependencies {
 android {
     // Changes to these values need to be reflected in `.travis.yml`
     compileSdkVersion 28
-    buildToolsVersion '28.0.3'
+    buildToolsVersion '29.0.0-rc1'
 
     buildTypes.debug.applicationIdSuffix ".debug"
     dataBinding.enabled = true

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,7 +36,7 @@ android {
     defaultConfig {
         applicationId "com.github.catfriend1.syncthingandroid"
         minSdkVersion 16
-        targetSdkVersion 26
+        targetSdkVersion 28
         versionCode 1010005
         versionName "1.1.0.5"
         testApplicationId 'com.github.catfriend1.syncthingandroid.test'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
 
     <uses-feature android:name="android.software.leanback" android:required="false" />
     <uses-feature android:name="android.hardware.touchscreen" android:required="false" />
+    <uses-feature android:name="android.hardware.location.gps" android:required="false" />
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.INTERNET" />
@@ -16,6 +17,8 @@
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/>
     <!-- ACCESS_COARSE_LOCATION is required to get WiFi's SSID on 8.1 -->
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <!-- ACCESS_FINE_LOCATION is required to get WiFi's SSID on 10 "Q" -->
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <application
         android:allowBackup="false"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,7 +19,7 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <!-- ACCESS_FINE_LOCATION is required to get WiFi's SSID on 10 "Q" -->
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-    <!-- FOREGROUND_SERVICE is required since Android 8.1 SDK 28 -->
+    <!-- FOREGROUND_SERVICE is required since Android 9 SDK 28 -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <application

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,8 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <!-- ACCESS_FINE_LOCATION is required to get WiFi's SSID on 10 "Q" -->
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <!-- FOREGROUND_SERVICE is required since Android 8.1 SDK 28 -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <application
         android:allowBackup="false"

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.3.2'
         classpath 'com.github.triplet.gradle:play-publisher:1.2.0'
         classpath 'com.github.ben-manes:gradle-versions-plugin:0.15.0'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -4,3 +4,4 @@ distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+android.enableSeparateAnnotationProcessing=true


### PR DESCRIPTION
Purpose:
- Raise targetSdk to 28 (Android 9 PIE)

Testing:
- Verified working on AVD 9 at commit https://github.com/Catfriend1/syncthing-android/pull/378/commits/53adf934c4b75ae5e1e592d9946c4e216675acbc .