### PR TITLE
Suggest new folder creation on primary storage (fixes #376)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
@@ -327,6 +327,11 @@ public class FolderActivity extends SyncthingActivity {
         Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);
         if (externalFilesDirUri != null) {
             intent.putExtra("android.provider.extra.INITIAL_URI", externalFilesDirUri);
+        } else {
+            android.net.Uri internalFilesDirUri = FileUtils.getInternalStorageRootUri();
+            if (internalFilesDirUri != null) {
+                intent.putExtra("android.provider.extra.INITIAL_URI", internalFilesDirUri);
+            }
         }
         intent.putExtra(Intent.EXTRA_LOCAL_ONLY, true);
         intent.putExtra("android.content.extra.SHOW_ADVANCED", true);

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/FileUtils.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/FileUtils.java
@@ -217,6 +217,15 @@ public class FileUtils {
         return null;
     }
 
+    /**
+     * FileProvider does not support converting absolute paths
+     * to a "content://" Uri. As "file://" Uri has been blocked
+     * since Android 7+, we need to build the Uri manually.
+     */
+    public static android.net.Uri getInternalStorageRootUri() {
+        return android.net.Uri.parse("content://com.android.externalstorage.documents/document/primary%3A");
+    }
+
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     private static String getVolumeIdFromTreeUri(final Uri treeUri) {
         final String docId = DocumentsContract.getTreeDocumentId(treeUri);


### PR DESCRIPTION
Purpose:
- Suggest new folder creation on primary storage if no external sdcard has been found. (fixes #376)

Testing:
- Verified working on AVD 9.x at commit https://github.com/Catfriend1/syncthing-android/commit/f246943db656e591a0c6ccc220f0d010af5084b1 .