### PR TITLE
Add option to trigger sync every hour (fixes #15)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -147,6 +147,11 @@
                 android:value=".activities.MainActivity" />
         </activity>
         <service android:name=".service.SyncthingService" />
+        <service
+            android:name=".service.SyncTriggerJobService"
+            android:label="SyncTriggerJobService"
+            android:permission="android.permission.BIND_JOB_SERVICE" >
+       </service>
         <receiver android:name=".receiver.BootReceiver">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
@@ -298,6 +298,11 @@ public class SettingsActivity extends SyncthingActivity {
             );
 
             mCategoryRunConditions = (PreferenceScreen) findPreference("category_run_conditions");
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+                // Remove pref as we use JobScheduler implementation which is not available on API < 21.
+                CheckBoxPreference prefRunOnTimeSchedule = (CheckBoxPreference) findPreference(Constants.PREF_RUN_ON_TIME_SCHEDULE);
+                mCategoryRunConditions.removePreference(prefRunOnTimeSchedule);
+            }
             setPreferenceCategoryChangeListener(mCategoryRunConditions, this::onRunConditionPreferenceChange);
 
             /* Behaviour */

--- a/app/src/main/java/com/nutomic/syncthingandroid/receiver/BootReceiver.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/receiver/BootReceiver.java
@@ -11,7 +11,7 @@ import android.util.Log;
 import com.nutomic.syncthingandroid.service.Constants;
 import com.nutomic.syncthingandroid.service.SyncthingRunnable;
 import com.nutomic.syncthingandroid.service.SyncthingService;
-import com.nutomic.syncthingandroid.util.JobUtils;
+// ToDo - import com.nutomic.syncthingandroid.util.JobUtils;
 
 import eu.chainfire.libsuperuser.Shell;
 

--- a/app/src/main/java/com/nutomic/syncthingandroid/receiver/BootReceiver.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/receiver/BootReceiver.java
@@ -11,7 +11,6 @@ import android.util.Log;
 import com.nutomic.syncthingandroid.service.Constants;
 import com.nutomic.syncthingandroid.service.SyncthingRunnable;
 import com.nutomic.syncthingandroid.service.SyncthingService;
-// ToDo - import com.nutomic.syncthingandroid.util.JobUtils;
 
 import eu.chainfire.libsuperuser.Shell;
 
@@ -19,6 +18,10 @@ public class BootReceiver extends BroadcastReceiver {
 
     private static final String TAG = "BootReceiver";
 
+    /**
+     * For testing purposes:
+     * adb root & adb shell am broadcast -a android.intent.action.BOOT_COMPLETED
+     */
     @Override
     public void onReceive(Context context, Intent intent) {
         Boolean bootCompleted = intent.getAction().equals(Intent.ACTION_BOOT_COMPLETED);
@@ -26,13 +29,6 @@ public class BootReceiver extends BroadcastReceiver {
         if (!bootCompleted && !packageReplaced) {
             return;
         }
-
-        /**
-         * Initially schedule "SyncTriggerJobService".
-         * For testing purposes:
-         * adb root & adb shell am broadcast -a android.intent.action.BOOT_COMPLETED
-         */
-        // ToDo - JobUtils.scheduleSyncTriggerServiceJob(context, Constants.WAIT_FOR_NEXT_SYNC_DELAY_SECS);
 
         if (packageReplaced) {
             if (getPrefUseRoot(context) && Shell.SU.available()) {

--- a/app/src/main/java/com/nutomic/syncthingandroid/receiver/BootReceiver.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/receiver/BootReceiver.java
@@ -11,6 +11,7 @@ import android.util.Log;
 import com.nutomic.syncthingandroid.service.Constants;
 import com.nutomic.syncthingandroid.service.SyncthingRunnable;
 import com.nutomic.syncthingandroid.service.SyncthingService;
+import com.nutomic.syncthingandroid.util.JobUtils;
 
 import eu.chainfire.libsuperuser.Shell;
 
@@ -25,6 +26,13 @@ public class BootReceiver extends BroadcastReceiver {
         if (!bootCompleted && !packageReplaced) {
             return;
         }
+
+        /**
+         * Initially schedule "SyncTriggerJobService".
+         * For testing purposes:
+         * adb root & adb shell am broadcast -a android.intent.action.BOOT_COMPLETED
+         */
+        // ToDo - JobUtils.scheduleSyncTriggerServiceJob(context, Constants.WAIT_FOR_NEXT_SYNC_DELAY_SECS);
 
         if (packageReplaced) {
             if (getPrefUseRoot(context) && Shell.SU.available()) {

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
@@ -3,6 +3,7 @@ package com.nutomic.syncthingandroid.service;
 import android.content.Context;
 import android.os.Build;
 import android.os.Environment;
+import android.text.TextUtils;
 
 import java.io.File;
 import java.util.concurrent.TimeUnit;
@@ -188,6 +189,16 @@ public class Constants {
 
     static File getLogFile(Context context) {
         return new File(context.getExternalFilesDir(null), "syncthing.log");
+    }
+
+    /**
+     * Checks if the app is running on an Android emulator (AVD).
+     */
+    public static Boolean isRunningOnEmulator() {
+        return !TextUtils.isEmpty(Build.MANUFACTURER) &&
+                !TextUtils.isEmpty(Build.MODEL) &&
+                Build.MANUFACTURER.equals("Google") &&
+                Build.MODEL.equals("Android SDK built for x86");
     }
 
     /**

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
@@ -27,6 +27,7 @@ public class Constants {
     public static final String PREF_RESPECT_BATTERY_SAVING      = "respect_battery_saving";
     public static final String PREF_RESPECT_MASTER_SYNC         = "respect_master_sync";
     public static final String PREF_RUN_IN_FLIGHT_MODE          = "run_in_flight_mode";
+    public static final String PREF_RUN_ON_TIME_SCHEDULE        = "run_on_time_schedule";
 
     // Preferences - Behaviour
     public static final String PREF_USE_ROOT                        = "use_root";

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
@@ -128,8 +128,8 @@ public class Constants {
      * If the user enabled hourly one-time shot sync, the following
      * parameters are effective.
      */
-    public static final int WAIT_FOR_NEXT_SYNC_DELAY_SECS       = isRunningOnEmulator() ? 5 : 3600;
-    public static final int TRIGGERED_SYNC_DURATION_SECS        = isRunningOnEmulator() ? 10 : 300;
+    public static final int WAIT_FOR_NEXT_SYNC_DELAY_SECS       = isRunningOnEmulator() ? 10 : 3600;
+    public static final int TRIGGERED_SYNC_DURATION_SECS        = isRunningOnEmulator() ? 20 : 300;
 
     /**
      * Directory where config is exported to and imported from.

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
@@ -124,6 +124,13 @@ public class Constants {
     );
 
     /**
+     * If the user enabled hourly one-time shot sync, the following
+     * parameters are effective.
+     */
+    public static final int WAIT_FOR_NEXT_SYNC_DELAY_SECS       = isRunningOnEmulator() ? 5 : 3600;
+    public static final int TRIGGERED_SYNC_DURATION_SECS        = isRunningOnEmulator() ? 10 : 300;
+
+    /**
      * Directory where config is exported to and imported from.
      */
     public static final String EXPORT_PATH = Environment.getExternalStorageDirectory() + "/backups/syncthing";

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncTriggerJobService.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncTriggerJobService.java
@@ -1,0 +1,35 @@
+package com.nutomic.syncthingandroid.service;
+
+import android.app.job.JobParameters;
+import android.app.job.JobService;
+import android.content.Context;
+import android.content.Intent;
+import android.support.v4.content.LocalBroadcastManager;
+// import android.util.Log;
+
+import com.nutomic.syncthingandroid.service.Constants;
+import com.nutomic.syncthingandroid.service.RunConditionMonitor;
+import com.nutomic.syncthingandroid.util.JobUtils;
+
+/**
+ * SyncTriggerJobService to be scheduled by the JobScheduler.
+ * See {@link JobUtils#scheduleSyncTriggerServiceJob} for more details.
+ */
+public class SyncTriggerJobService extends JobService {
+    private static final String TAG = "SyncTriggerJobService";
+
+    @Override
+    public boolean onStartJob(JobParameters params) {
+        // Log.v(TAG, "onStartJob: Job fired.");
+        Context context = getApplicationContext();
+        LocalBroadcastManager localBroadcastManager = LocalBroadcastManager.getInstance(context);
+        Intent intent = new Intent(RunConditionMonitor.ACTION_SYNC_TRIGGER_FIRED);
+        localBroadcastManager.sendBroadcast(intent);
+        return true;
+    }
+
+    @Override
+    public boolean onStopJob(JobParameters params) {
+        return true;
+    }
+}

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncTriggerJobService.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncTriggerJobService.java
@@ -4,6 +4,7 @@ import android.app.job.JobParameters;
 import android.app.job.JobService;
 import android.content.Context;
 import android.content.Intent;
+import android.support.annotation.RequiresApi;
 import android.support.v4.content.LocalBroadcastManager;
 // import android.util.Log;
 
@@ -15,6 +16,7 @@ import com.nutomic.syncthingandroid.util.JobUtils;
  * SyncTriggerJobService to be scheduled by the JobScheduler.
  * See {@link JobUtils#scheduleSyncTriggerServiceJob} for more details.
  */
+@RequiresApi(21)
 public class SyncTriggerJobService extends JobService {
     private static final String TAG = "SyncTriggerJobService";
 

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/JobUtils.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/JobUtils.java
@@ -33,7 +33,9 @@ public class JobUtils {
         // Schedule the start of "SyncTriggerJobService" in "X" seconds.
         JobScheduler jobScheduler = (JobScheduler) context.getSystemService(context.JOB_SCHEDULER_SERVICE);
         jobScheduler.schedule(builder.build());
-        Log.i(TAG, "Scheduled SyncTriggerJobService to run in " + Integer.toString(delayInSeconds) + " seconds.");
+        Log.i(TAG, "Scheduled SyncTriggerJobService to run in " +
+                Integer.toString(delayInSeconds) +
+                "(+" + Integer.toString(TOLERATED_INACCURACY_IN_SECONDS) + ") seconds.");
     }
 
     @TargetApi(21)

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/JobUtils.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/JobUtils.java
@@ -27,7 +27,7 @@ public class JobUtils {
         // Schedule the start of "SyncTriggerJobService" in "X" seconds.
         JobScheduler jobScheduler = context.getSystemService(JobScheduler.class);
         jobScheduler.schedule(builder.build());
-        Log.e(TAG, "Scheduled job to run SyncTriggerJobService in " + Integer.toString(delayInSeconds / 60) + " minutes.");
+        Log.i(TAG, "Scheduled SyncTriggerJobService to run in " + Integer.toString(delayInSeconds / 60) + " minutes.");
     }
 
     public static void cancelAllScheduledJobs(Context context) {

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/JobUtils.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/JobUtils.java
@@ -1,0 +1,37 @@
+package com.nutomic.syncthingandroid.util;
+
+import android.app.job.JobInfo;
+import android.app.job.JobScheduler;
+import android.content.ComponentName;
+import android.content.Context;
+import android.util.Log;
+
+import com.nutomic.syncthingandroid.service.SyncTriggerJobService;
+
+public class JobUtils {
+
+    private static final String TAG = "JobUtils";
+
+    private static final int TOLERATED_INACCURACY_IN_SECONDS = 120;
+
+    public static void scheduleSyncTriggerServiceJob(Context context, int delayInSeconds) {
+        ComponentName serviceComponent = new ComponentName(context, SyncTriggerJobService.class);
+        JobInfo.Builder builder = new JobInfo.Builder(0, serviceComponent);
+
+        // Wait at least "delayInSeconds".
+        builder.setMinimumLatency(delayInSeconds * 1000);
+
+        // Maximum tolerated delay.
+        builder.setOverrideDeadline((delayInSeconds + TOLERATED_INACCURACY_IN_SECONDS) * 1000);
+
+        // Schedule the start of "SyncTriggerJobService" in "X" seconds.
+        JobScheduler jobScheduler = context.getSystemService(JobScheduler.class);
+        jobScheduler.schedule(builder.build());
+        Log.e(TAG, "Scheduled job to run SyncTriggerJobService in " + Integer.toString(delayInSeconds / 60) + " minutes.");
+    }
+
+    public static void cancelAllScheduledJobs(Context context) {
+        JobScheduler jobScheduler = context.getSystemService(JobScheduler.class);
+        jobScheduler.cancelAll();
+    }
+}

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/JobUtils.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/JobUtils.java
@@ -25,13 +25,13 @@ public class JobUtils {
         builder.setOverrideDeadline((delayInSeconds + TOLERATED_INACCURACY_IN_SECONDS) * 1000);
 
         // Schedule the start of "SyncTriggerJobService" in "X" seconds.
-        JobScheduler jobScheduler = context.getSystemService(JobScheduler.class);
+        JobScheduler jobScheduler = (JobScheduler) context.getSystemService(context.JOB_SCHEDULER_SERVICE);
         jobScheduler.schedule(builder.build());
         Log.i(TAG, "Scheduled SyncTriggerJobService to run in " + Integer.toString(delayInSeconds) + " seconds.");
     }
 
     public static void cancelAllScheduledJobs(Context context) {
-        JobScheduler jobScheduler = context.getSystemService(JobScheduler.class);
+        JobScheduler jobScheduler = (JobScheduler) context.getSystemService(context.JOB_SCHEDULER_SERVICE);
         jobScheduler.cancelAll();
     }
 }

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/JobUtils.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/JobUtils.java
@@ -27,7 +27,7 @@ public class JobUtils {
         // Schedule the start of "SyncTriggerJobService" in "X" seconds.
         JobScheduler jobScheduler = context.getSystemService(JobScheduler.class);
         jobScheduler.schedule(builder.build());
-        Log.i(TAG, "Scheduled SyncTriggerJobService to run in " + Integer.toString(delayInSeconds / 60) + " minutes.");
+        Log.i(TAG, "Scheduled SyncTriggerJobService to run in " + Integer.toString(delayInSeconds) + " seconds.");
     }
 
     public static void cancelAllScheduledJobs(Context context) {

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/JobUtils.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/JobUtils.java
@@ -1,9 +1,11 @@
 package com.nutomic.syncthingandroid.util;
 
+import android.annotation.TargetApi;
 import android.app.job.JobInfo;
 import android.app.job.JobScheduler;
 import android.content.ComponentName;
 import android.content.Context;
+import android.os.Build;
 import android.util.Log;
 
 import com.nutomic.syncthingandroid.service.SyncTriggerJobService;
@@ -14,7 +16,11 @@ public class JobUtils {
 
     private static final int TOLERATED_INACCURACY_IN_SECONDS = 120;
 
+    @TargetApi(21)
     public static void scheduleSyncTriggerServiceJob(Context context, int delayInSeconds) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            return;
+        }
         ComponentName serviceComponent = new ComponentName(context, SyncTriggerJobService.class);
         JobInfo.Builder builder = new JobInfo.Builder(0, serviceComponent);
 
@@ -30,7 +36,11 @@ public class JobUtils {
         Log.i(TAG, "Scheduled SyncTriggerJobService to run in " + Integer.toString(delayInSeconds) + " seconds.");
     }
 
+    @TargetApi(21)
     public static void cancelAllScheduledJobs(Context context) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            return;
+        }
         JobScheduler jobScheduler = (JobScheduler) context.getSystemService(context.JOB_SCHEDULER_SERVICE);
         jobScheduler.cancelAll();
     }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -454,6 +454,9 @@ Bitte melden Sie auftretende Probleme via GitHub.</string>
     <string name="run_in_flight_mode_title">Starte ohne Netzwerkverbindung</string>
     <string name="run_in_flight_mode_summary">Durch Aktivieren der Option wird Syncthing auch dann laufen, wenn Du offline bist. Aktiviere dies, wenn dein Telefon Probleme beim Erkennen von manuell hergestellten WLAN-Verbindungen im Flugmodus hat.</string>
 
+    <string name="run_on_time_schedule_title">Gemäß Zeitplan synchronisieren</string>
+    <string name="run_on_time_schedule_summary">Durch Aktivieren dieser Option wird versucht, stündlich für 5 Minuten zu synchronisieren. Dies kann eine Menge Batterie einsparen, erfordert jedoch, dass Synchronisierungspartner online sind. Hinweis: Dies kann unvollständige temporäre Dateien zurücklassen, bis die nächste geplante Synchronisierung stattfindet und abgeschlossen ist.</string>
+
     <!-- Preferences - Behaviour -->
     <string name="behaviour_autostart_title">Autostart</string>
     <string name="behaviour_autostart_summary">Starte die App automatisch beim Hochfahren.</string>
@@ -760,6 +763,7 @@ Bitte melden Sie auftretende Probleme via GitHub.</string>
     <!-- RunConditionMonitor -->
 
     <!-- Explanations why syncthing is running or not running -->
+    <string name="reason_not_within_time_frame">Sie haben \'Gemäß Zeitplan synchronisieren\' aktiviert, und die letzte Synchronisierung ist nicht länger als eine Stunde her.</string>
     <string name="reason_not_charging">Telefon wird nicht aufgeladen</string>
     <string name="reason_not_on_battery_power">Telefon wird nicht batteriebetrieben</string>
     <string name="reason_not_while_power_saving">Syncthing läuft nicht, weil das Telefon im Energiesparmodus ist.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -457,6 +457,9 @@ Please report any problems you encounter via Github.</string>
     <string name="run_in_flight_mode_title">Run without network connection</string>
     <string name="run_in_flight_mode_summary">Enabling this option will cause Syncthing to run even when you\'re offline. Enable if your device has problems detecting manual Wi-Fi connections during flight mode.</string>
 
+    <string name="run_on_time_schedule_title">Run according to time schedule</string>
+    <string name="run_on_time_schedule_summary">Enabling this option will attempt to sync every hour for the duration of 5 minutes. This can save a lot of battery but requires sync partners to be online. Please note: This may leave incomplete temporary files behind until the next scheduled sync takes place.</string>
+
     <!-- Preferences - Behaviour -->
     <string name="behaviour_autostart_title">Autostart</string>
     <string name="behaviour_autostart_summary">Start app automatically on operating system startup.</string>
@@ -781,6 +784,7 @@ Please report any problems you encounter via Github.</string>
     <!-- RunConditionMonitor -->
 
     <!-- Explanations why syncthing is running or not running -->
+    <string name="reason_not_within_time_frame">You enabled \'Run according to time schedule\' and the last sync was no more than an hour ago.</string>
     <string name="reason_not_charging">Phone is not charging.</string>
     <string name="reason_not_on_battery_power">Phone is not running on battery power.</string>
     <string name="reason_not_while_power_saving">Syncthing is not running as the phone is currently power saving.</string>

--- a/app/src/main/res/xml/app_settings.xml
+++ b/app/src/main/res/xml/app_settings.xml
@@ -72,6 +72,13 @@
             android:summary="@string/run_in_flight_mode_summary"
             android:defaultValue="false" />
 
+        <!-- Run on time schedule -->
+        <CheckBoxPreference
+            android:key="run_on_time_schedule"
+            android:title="@string/run_on_time_schedule_title"
+            android:summary="@string/run_on_time_schedule_summary"
+            android:defaultValue="false" />
+
     </PreferenceScreen>
 
     <PreferenceScreen


### PR DESCRIPTION
Purpose:
- Add option to trigger sync every hour (fixes #15)

Testing:
Verified working at commit https://github.com/Catfriend1/syncthing-android/pull/387/commits/cc7359b52c91fe9b77912306e7bb90a063de1d4f on:
- AVD 6.x
- Physical device running 6.0.1
- AVD 9.x
- Physical device running 4.4 (the pref is disabled, no functionality under this OS and no crash)

