### PR TITLE
 Show notification badge if user interaction is required (fixes #406)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/service/NotificationHandler.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/NotificationHandler.java
@@ -57,6 +57,7 @@ public class NotificationHandler {
             mPersistentChannel.enableLights(false);
             mPersistentChannel.enableVibration(false);
             mPersistentChannel.setSound(null, null);
+            mPersistentChannel.setShowBadge(false);
             mNotificationManager.createNotificationChannel(mPersistentChannel);
 
             mPersistentChannelWaiting = new NotificationChannel(
@@ -65,6 +66,7 @@ public class NotificationHandler {
             mPersistentChannelWaiting.enableLights(false);
             mPersistentChannelWaiting.enableVibration(false);
             mPersistentChannelWaiting.setSound(null, null);
+            mPersistentChannelWaiting.setShowBadge(false);
             mNotificationManager.createNotificationChannel(mPersistentChannelWaiting);
 
             mInfoChannel = new NotificationChannel(
@@ -72,6 +74,7 @@ public class NotificationHandler {
                     NotificationManager.IMPORTANCE_LOW);
             mPersistentChannel.enableVibration(false);
             mPersistentChannel.setSound(null, null);
+            mPersistentChannel.setShowBadge(true);
             mNotificationManager.createNotificationChannel(mInfoChannel);
         } else {
             mPersistentChannel = null;


### PR DESCRIPTION
Purpose:
- Show notification badge if user interaction is required (fixes #406)

Testing:
- UPDATE: It's working on Android 8.0 AVD, I had to uninstall and reinstall the app first before testing this PR. @https://github.com/Catfriend1/syncthing-android/pull/408/commits/dd05263627b6d634960388bf401fa0e100652383

Sources/Reference:
- https://github.com/syncthing/syncthing-android/pull/1307