### PR TITLE
Disable DuraSpeed on HMD Global phones (fixes #404)

### DIFF
--- a/app/lint.xml
+++ b/app/lint.xml
@@ -13,6 +13,7 @@
     <issue id="UnusedAttribute" severity="ignore" />
     <!-- We don't care about Google App Indexing -->
     <issue id="GoogleAppIndexingWarning" severity="ignore" />
+    <issue id="ProtectedPermissions" severity="ignore" />
     <!-- Disabling battery optimizations is optional, so this warning doesn't apply to us -->
     <issue id="BatteryLife" severity="ignore" />
     <!-- Ignore types in translations (not handled by us) -->

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,9 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <!-- FOREGROUND_SERVICE is required since Android 9 SDK 28 -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <!-- WRITE_SETTINGS, WRITE_SECURE_SETTINGS are required to disable DuraSpeed -->
+    <uses-permission android:name="android.permission.WRITE_SETTINGS" />
+    <uses-permission android:name="android.permission.WRITE_SECURE_SETTINGS" />
 
     <application
         android:allowBackup="false"

--- a/app/src/main/java/com/nutomic/syncthingandroid/receiver/BootReceiver.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/receiver/BootReceiver.java
@@ -1,11 +1,14 @@
 package com.nutomic.syncthingandroid.receiver;
 
+import android.annotation.TargetApi;
 import android.content.BroadcastReceiver;
+import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Build;
 import android.preference.PreferenceManager;
+import android.provider.Settings;
 import android.util.Log;
 
 import com.nutomic.syncthingandroid.service.Constants;
@@ -13,6 +16,8 @@ import com.nutomic.syncthingandroid.service.SyncthingRunnable;
 import com.nutomic.syncthingandroid.service.SyncthingService;
 
 import eu.chainfire.libsuperuser.Shell;
+
+import java.lang.SecurityException;
 
 public class BootReceiver extends BroadcastReceiver {
 
@@ -28,6 +33,10 @@ public class BootReceiver extends BroadcastReceiver {
         Boolean packageReplaced = intent.getAction().equals(Intent.ACTION_MY_PACKAGE_REPLACED);
         if (!bootCompleted && !packageReplaced) {
             return;
+        }
+
+        if ("HMD Global".equals(Build.MANUFACTURER)) {
+            disableDuraSpeed(context);
         }
 
         if (packageReplaced) {
@@ -72,5 +81,28 @@ public class BootReceiver extends BroadcastReceiver {
     private static boolean getPrefUseRoot(Context context) {
         SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(context);
         return sp.getBoolean(Constants.PREF_USE_ROOT, false);
+    }
+
+    @TargetApi(17)
+    /**
+     * Prerequisistes:
+     * - android.permission.WRITE_SETTINGS
+     * - android.permission.WRITE_SECURE_SETTINGS
+     *      adb shell pm grant com.github.catfriend1.syncthingandroid android.permission.WRITE_SECURE_SETTINGS
+     *      adb shell pm grant com.github.catfriend1.syncthingandroid.debug android.permission.WRITE_SECURE_SETTINGS
+     */
+    private static void disableDuraSpeed(Context context) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            return;
+        }
+        Log.d(TAG, "Disabling DuraSpeed");
+        try {
+            Settings.Global.putInt(context.getContentResolver(), "setting.duraspeed.enabled", -1);
+            Settings.Global.putInt(context.getContentResolver(), "setting.duraspeed.enabled", 0);
+        } catch (SecurityException e) {
+            Log.e(TAG, "Insufficient permissions to disable DuraSpeed. Run the following command from a computer: 'adb shell pm grant " +
+                    context.getPackageName() +
+                    " android.permission.WRITE_SECURE_SETTINGS'");
+        }
     }
 }


### PR DESCRIPTION
Purpose:
- Disable DuraSpeed on HMD Global phones (fixes #404)

Testing:
- Code structure and permission-missing catch tested on the emulator AVD 9.x. @https://github.com/Catfriend1/syncthing-android/commit/1724981854a9ac620c384e3559da9649a7c570c2
- Full test has to be done by @YoRyan as he owns a Nokia HMD Global phone where DuraSpeed can be disabled by the app.

ToDo:
- Create a wiki page if this works correctly and gets released.