### PR TITLE
Hourly sync - Sync immediately when app starts (fixes #393)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/service/RunConditionMonitor.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/RunConditionMonitor.java
@@ -100,8 +100,9 @@ public class RunConditionMonitor {
      * Only relevant if the user has enabled turning Syncthing on by
      * time schedule for a specific amount of time periodically.
      * Holds true if we are within a "SyncthingNative should run" time frame.
+     * Initial status true because we like to sync on app start, too.
      */
-    private Boolean mTimeConditionMatch = false;
+    private Boolean mTimeConditionMatch = true;
 
     @Inject
     SharedPreferences mPreferences;
@@ -165,7 +166,11 @@ public class RunConditionMonitor {
         updateShouldRunDecision();
 
         // Initially schedule the SyncTrigger job.
-        JobUtils.scheduleSyncTriggerServiceJob(context, Constants.WAIT_FOR_NEXT_SYNC_DELAY_SECS);
+        JobUtils.scheduleSyncTriggerServiceJob(context,
+                mTimeConditionMatch ?
+                    Constants.TRIGGERED_SYNC_DURATION_SECS :
+                    Constants.WAIT_FOR_NEXT_SYNC_DELAY_SECS
+        );
     }
 
     public void shutdown() {


### PR DESCRIPTION
Purpose:
- Hourly sync - Sync immediately when app starts (fixes #393)

Testing:
- Verified working on AVD 9.x at commit https://github.com/Catfriend1/syncthing-android/commit/730fbe4bf1d7663f38f87e69a380d0f94fd7e9b9 .