### PR TITLE
Shorten logcat excerpts (fixes #364)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/LogActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/LogActivity.java
@@ -5,6 +5,7 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.v4.view.MenuItemCompat;
 import android.support.v7.widget.ShareActionProvider;
+import android.text.TextUtils;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -19,6 +20,10 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.lang.ref.WeakReference;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.ListIterator;
+import java.util.List;
 
 /**
  * Shows the log information from Syncthing.
@@ -148,12 +153,61 @@ public class LogActivity extends SyncthingActivity {
          * @param syncthingLog Filter on Syncthing's native messages.
          */
         private String getLog(final boolean syncthingLog) {
+            String output;
             if (syncthingLog) {
-                String output = Util.runShellCommandGetOutput("/system/bin/logcat -t 900 -v time -s SyncthingNativeCode", false);
-                return output.replaceAll("SyncthingNativeCode", "");
+                output = Util.runShellCommandGetOutput("/system/bin/logcat -t 900 -v time -s SyncthingNativeCode", false);
             } else {
-                return Util.runShellCommandGetOutput("/system/bin/logcat -t 900 -v time *:i ps:s art:s", false);
+                // Get Android log.
+                output = Util.runShellCommandGetOutput("/system/bin/logcat -t 900 -v time *:i ps:s art:s", false);
             }
+
+            // Filter Android log.
+            output = output.replaceAll("I/SyncthingNativeCode", "");
+            // Remove PID.
+            output = output.replaceAll("\\([0-9]+\\):", "");
+            String[] lines = output.split("\n");
+            List<String> list = new ArrayList<String>(Arrays.asList(lines));
+            ListIterator<String> it = list.listIterator();
+            while (it.hasNext()) {
+                String logline = it.next();
+                if (
+                            logline.contains("W/ActionBarDrawerToggle") ||
+                            logline.contains("W/ActivityThread") ||
+                            logline.contains("I/chatty") ||
+                            logline.contains("/Choreographer") ||
+                            logline.contains("W/chmod") ||
+                            logline.contains("/chromium") ||
+                            logline.contains("/ContentCatcher") ||
+                            logline.contains("/cr_AwContents") ||
+                            logline.contains("/cr_base") ||
+                            logline.contains("/cr_ChildProcessConn") ||
+                            logline.contains("/cr_ChildProcLH") ||
+                            logline.contains("/cr_CrashFileManager") ||
+                            logline.contains("/cr_LibraryLoader") ||
+                            logline.contains("/cr_media") ||
+                            logline.contains("/cr_MediaCodecUtil") ||
+                            logline.contains("I/ConfigStore") ||
+                            logline.contains("/eglCodecCommon") ||
+                            logline.contains("/ngandroid.debu") ||
+                            logline.contains("/OpenGLRenderer") ||
+                            logline.contains("/PacProxySelector") ||
+                            logline.contains("W/sh") ||
+                            logline.contains("/StrictMode") ||
+                            logline.contains("/VideoCapabilities") ||
+                            logline.contains("I/WebViewFactory") ||
+                            logline.contains("I/X509Util") ||
+                            logline.contains("/zygote64")
+                        ) {
+                    it.remove();
+                    continue;
+                }
+                // Remove date.
+                logline = logline.replaceFirst("^[0-9]{2}-[0-9]{2}\\s", "");
+                // Remove milliseconds.
+                // logline = logline.replaceFirst("^(:[0-9]{2})\\.[0-9]+\\s", "");
+                it.set(logline);
+            }
+            return TextUtils.join("\n", list.toArray(new String[0]));
         }
     }
 

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/LogActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/LogActivity.java
@@ -204,7 +204,7 @@ public class LogActivity extends SyncthingActivity {
                 // Remove date.
                 logline = logline.replaceFirst("^[0-9]{2}-[0-9]{2}\\s", "");
                 // Remove milliseconds.
-                // logline = logline.replaceFirst("^(:[0-9]{2})\\.[0-9]+\\s", "");
+                logline = logline.replaceFirst("^([0-9]{2}:[0-9]{2}:[0-9]{2})\\.[0-9]{3}\\s", "$1");
                 it.set(logline);
             }
             return TextUtils.join("\n", list.toArray(new String[0]));

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/LogActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/LogActivity.java
@@ -171,6 +171,7 @@ public class LogActivity extends SyncthingActivity {
             while (it.hasNext()) {
                 String logline = it.next();
                 if (
+                            logline.contains("--- beginning of ") ||
                             logline.contains("W/ActionBarDrawerToggle") ||
                             logline.contains("W/ActivityThread") ||
                             logline.contains("I/chatty") ||
@@ -180,6 +181,7 @@ public class LogActivity extends SyncthingActivity {
                             logline.contains("/ContentCatcher") ||
                             logline.contains("/cr_AwContents") ||
                             logline.contains("/cr_base") ||
+                            logline.contains("/cr_BrowserStartup") ||
                             logline.contains("/cr_ChildProcessConn") ||
                             logline.contains("/cr_ChildProcLH") ||
                             logline.contains("/cr_CrashFileManager") ||

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/LogActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/LogActivity.java
@@ -164,7 +164,7 @@ public class LogActivity extends SyncthingActivity {
             // Filter Android log.
             output = output.replaceAll("I/SyncthingNativeCode", "");
             // Remove PID.
-            output = output.replaceAll("\\([0-9]+\\):", "");
+            output = output.replaceAll("\\(\\s?[0-9]+\\):", "");
             String[] lines = output.split("\n");
             List<String> list = new ArrayList<String>(Arrays.asList(lines));
             ListIterator<String> it = list.listIterator();

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/LogActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/LogActivity.java
@@ -149,10 +149,10 @@ public class LogActivity extends SyncthingActivity {
          */
         private String getLog(final boolean syncthingLog) {
             if (syncthingLog) {
-                String output = Util.runShellCommandGetOutput("/system/bin/logcat -t 300 -v time -s SyncthingNativeCode", false);
+                String output = Util.runShellCommandGetOutput("/system/bin/logcat -t 900 -v time -s SyncthingNativeCode", false);
                 return output.replaceAll("SyncthingNativeCode", "");
             } else {
-                return Util.runShellCommandGetOutput("/system/bin/logcat -t 300 -v time *:i ps:s art:s", false);
+                return Util.runShellCommandGetOutput("/system/bin/logcat -t 900 -v time *:i ps:s art:s", false);
             }
         }
     }


### PR DESCRIPTION
Purpose:
- Shorten logcat excerpts (fixes #364)
- Exclude OS stuff from log (fixes #364) (ref: https://github.com/Catfriend1/syncthing-android/issues/409)

Testing:
- Verified working on AVD 9.x at commit https://github.com/Catfriend1/syncthing-android/pull/412/commits/0b70e99be30a0dcd422f65a0c39da6fb84426712 .