### PR TITLE
Status tab - add button to "force start" / "force stop" (fixes #394)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/fragments/StatusFragment.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/fragments/StatusFragment.java
@@ -63,7 +63,6 @@ public class StatusFragment extends ListFragment implements SyncthingService.OnS
     };
 
     private MainActivity mActivity;
-    private View mStatusFragmentView;
     private ArrayAdapter mAdapter;
     private SyncthingService.State mServiceState = SyncthingService.State.INIT;
     private final Handler mRestApiQueryHandler = new Handler();
@@ -139,8 +138,7 @@ public class StatusFragment extends ListFragment implements SyncthingService.OnS
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
             Bundle savedInstanceState) {
-        mStatusFragmentView = inflater.inflate(R.layout.fragment_status, container, false);
-        return mStatusFragmentView;
+        return inflater.inflate(R.layout.fragment_status, container, false);
     }
 
     @Override

--- a/app/src/main/java/com/nutomic/syncthingandroid/fragments/StatusFragment.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/fragments/StatusFragment.java
@@ -31,6 +31,8 @@ import com.nutomic.syncthingandroid.service.Constants;
 import com.nutomic.syncthingandroid.service.RestApi;
 import com.nutomic.syncthingandroid.service.SyncthingService;
 import com.nutomic.syncthingandroid.util.Util;
+import com.nutomic.syncthingandroid.views.SegmentedButton;
+import com.nutomic.syncthingandroid.views.SegmentedButton.OnClickListenerSegmentedButton;
 
 import java.util.concurrent.TimeUnit;
 import java.util.ArrayList;
@@ -156,13 +158,24 @@ public class StatusFragment extends ListFragment implements SyncthingService.OnS
         super.onActivityCreated(savedInstanceState);
         mActivity = (MainActivity) getActivity();
 
-        Button btnForceStartStop = (Button) mStatusFragmentView.findViewById(R.id.forceStartStop);
-        btnForceStartStop.setOnClickListener(new View.OnClickListener() {
+        // Create button group.
+        SegmentedButton btnForceStartStop = (SegmentedButton) mActivity.findViewById(R.id.forceStartStop);
+        btnForceStartStop.clearButtons();
+        btnForceStartStop.addButtons(
+                getString(R.string.button_follow_run_conditions),
+                getString(R.string.button_force_start),
+                getString(R.string.button_force_stop)
+        );
+        btnForceStartStop.setOnClickListener(new OnClickListenerSegmentedButton() {
                 @Override
-                public void onClick(View view) {
-                    onBtnForceStartStopClick();
+                public void onClick(int index) {
+                    onBtnForceStartStopClick(index);
                 }
         });
+
+        // Restore last state of button group.
+        int prefBtnStateForceStartStop = mPreferences.getInt(Constants.PREF_BTNSTATE_FORCE_START_STOP, Constants.BTNSTATE_NO_FORCE_START_STOP);
+        btnForceStartStop.setPushedButtonIndex(prefBtnStateForceStartStop);
     }
 
     @Override
@@ -333,23 +346,12 @@ public class StatusFragment extends ListFragment implements SyncthingService.OnS
         updateStatus();
     }
 
-    private void onBtnForceStartStopClick() {
+    private void onBtnForceStartStopClick(int index) {
         LogV("onBtnForceStartStopClick");
 
-        int prefBtnStateForceStartStop = mPreferences.getInt(Constants.PREF_BTNSTATE_FORCE_START_STOP, Constants.BTNSTATE_NO_FORCE_START_STOP);
-        switch (prefBtnStateForceStartStop) {
-            case Constants.BTNSTATE_NO_FORCE_START_STOP:
-                prefBtnStateForceStartStop = Constants.BTNSTATE_FORCE_START;
-                break;
-            case Constants.BTNSTATE_FORCE_START:
-                prefBtnStateForceStartStop = Constants.BTNSTATE_FORCE_STOP;
-                break;
-            case Constants.BTNSTATE_FORCE_STOP:
-                prefBtnStateForceStartStop = Constants.BTNSTATE_NO_FORCE_START_STOP;
-                break;
-        }
+        // Note: "index" is equivalent to the defined integer "Constants.PREF_BTNSTATE_*" values.
         SharedPreferences.Editor editor = mPreferences.edit();
-        editor.putInt(Constants.PREF_BTNSTATE_FORCE_START_STOP, prefBtnStateForceStartStop);
+        editor.putInt(Constants.PREF_BTNSTATE_FORCE_START_STOP, index);
         editor.apply();
 
         // Notify {@link RunConditionMonitor} that the button's state changed.

--- a/app/src/main/java/com/nutomic/syncthingandroid/fragments/StatusFragment.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/fragments/StatusFragment.java
@@ -16,7 +16,6 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
-import android.widget.Button;
 
 import com.google.common.base.Optional;
 import com.nutomic.syncthingandroid.R;

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
@@ -88,6 +88,16 @@ public class Constants {
     public static final String PREF_LOCAL_DEVICE_ID             = "localDeviceID";
 
     /**
+     * {@link RunConditionMonitor}
+     * {@link StatusFragment}
+     */
+    public static final String PREF_BTNSTATE_FORCE_START_STOP   = "btnStateForceStartStop";
+
+    public static final int BTNSTATE_NO_FORCE_START_STOP        = 0;
+    public static final int BTNSTATE_FORCE_START                = 1;
+    public static final int BTNSTATE_FORCE_STOP                 = 2;
+
+    /**
      * {@link EventProcessor}
      */
     public static final String PREF_EVENT_PROCESSOR_LAST_SYNC_ID = "last_sync_id";

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
@@ -933,6 +933,7 @@ public class SyncthingService extends Service {
                             LogV("importConfig: Ignoring deprecated pref \"" + prefKey + "\".");
                             break;
                         // Cached information which is not available on SettingsActivity.
+                        case Constants.PREF_BTNSTATE_FORCE_START_STOP:
                         case Constants.PREF_DEBUG_FACILITIES_AVAILABLE:
                         case Constants.PREF_EVENT_PROCESSOR_LAST_SYNC_ID:
                         case Constants.PREF_LAST_BINARY_VERSION:

--- a/app/src/main/java/com/nutomic/syncthingandroid/views/SegmentedButton.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/views/SegmentedButton.java
@@ -109,7 +109,7 @@ public class SegmentedButton extends LinearLayout {
 
             Button button = new Button(getContext());
             button.setText(titles[i]);
-            button.setTag(new Integer(i));
+            button.setTag(Integer.valueOf(i));
             button.setOnClickListener(mOnClickListener);
             if (mTextStyle != -1) {
                 button.setTextAppearance(getContext(), mTextStyle);

--- a/app/src/main/java/com/nutomic/syncthingandroid/views/SegmentedButton.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/views/SegmentedButton.java
@@ -136,7 +136,7 @@ public class SegmentedButton extends LinearLayout {
             LinearLayout.LayoutParams llp =
                 new LinearLayout.LayoutParams(
                         0,
-                        LinearLayout.LayoutParams.WRAP_CONTENT,
+                        LinearLayout.LayoutParams.MATCH_PARENT,
                         1);
             addView(button, llp);
             button.setPadding(0, mBtnPaddingTop, 0, mBtnPaddingBottom);

--- a/app/src/main/java/com/nutomic/syncthingandroid/views/SegmentedButton.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/views/SegmentedButton.java
@@ -1,0 +1,316 @@
+/**
+ * Copyright 2010 Mark Wyszomierski
+ * A multi-button control which can only have one pressed button at
+ * any given time. Its functionality is quite similar to a tab control.
+ * Tabs can't be skinned in android 1.5, and our main frame is a tab
+ * host - which causes some different android problems, thus this control
+ * was created.
+ *
+ * @date September 15, 2010
+ * @author Mark Wyszomierski (markww@gmail.com)
+ */
+
+package com.nutomic.syncthingandroid.views;
+
+import com.nutomic.syncthingandroid.R;
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.graphics.drawable.GradientDrawable;
+import android.graphics.drawable.StateListDrawable;
+import android.util.AttributeSet;
+import android.view.View;
+import android.widget.Button;
+import android.widget.LinearLayout;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SegmentedButton extends LinearLayout {
+
+    private StateListDrawable mBgLeftOn;
+    private StateListDrawable mBgRightOn;
+    private StateListDrawable mBgCenterOn;
+    private StateListDrawable mBgLeftOff;
+    private StateListDrawable mBgRightOff;
+    private StateListDrawable mBgCenterOff;
+    private int mSelectedButtonIndex = 0;
+
+    private List<String> mButtonTitles = new ArrayList<String>();
+    private int mColorOnStart;
+    private int mColorOnEnd;
+    private int mColorOffStart;
+    private int mColorOffEnd;
+    private int mColorSelectedStart;
+    private int mColorSelectedEnd;
+    private int mColorStroke;
+    private int mStrokeWidth;
+    private int mCornerRadius;
+    private int mTextStyle;
+    private int mBtnPaddingTop;
+    private int mBtnPaddingBottom;
+
+    private OnClickListenerSegmentedButton mOnClickListenerExternal;
+
+
+    public SegmentedButton(Context context) {
+        super(context);
+    }
+
+    public SegmentedButton(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.SegmentedButton, 0, 0);
+
+        CharSequence btnText1 = a.getString(R.styleable.SegmentedButton_btnText1);
+        CharSequence btnText2 = a.getString(R.styleable.SegmentedButton_btnText2);
+        if (btnText1 != null) {
+            mButtonTitles.add(btnText1.toString());
+        }
+        if (btnText2 != null) {
+            mButtonTitles.add(btnText2.toString());
+        }
+
+        mColorOnStart = a.getColor(R.styleable.SegmentedButton_gradientColorOnStart, 0xFF0000);
+        mColorOnEnd = a.getColor(R.styleable.SegmentedButton_gradientColorOnEnd, 0xFF0000);
+        mColorOffStart = a.getColor(R.styleable.SegmentedButton_gradientColorOffStart, 0xFF0000);
+        mColorOffEnd = a.getColor(R.styleable.SegmentedButton_gradientColorOffEnd, 0xFF0000);
+        mColorStroke = a.getColor(R.styleable.SegmentedButton_strokeColor, 0xFF0000);
+        mColorSelectedEnd = a.getColor(R.styleable.SegmentedButton_gradientColorSelectedEnd, 0xFF0000);
+        mColorSelectedStart = a.getColor(R.styleable.SegmentedButton_gradientColorSelectedStart, 0xFF0000);
+        mStrokeWidth = a.getDimensionPixelSize(R.styleable.SegmentedButton_strokeWidth, 1);
+        mCornerRadius = a.getDimensionPixelSize(R.styleable.SegmentedButton_cornerRadius, 4);
+        mTextStyle = a.getResourceId(R.styleable.SegmentedButton_textStyle, -1);
+        mBtnPaddingTop = a.getDimensionPixelSize(R.styleable.SegmentedButton_btnPaddingTop, 0);
+        mBtnPaddingBottom = a.getDimensionPixelSize(R.styleable.SegmentedButton_btnPaddingBottom, 0);
+
+
+        a.recycle();
+
+        buildDrawables(mColorOnStart, mColorOnEnd, mColorOffStart, mColorOffEnd,
+                mColorSelectedStart, mColorSelectedEnd, mCornerRadius, mColorStroke,
+                mStrokeWidth);
+
+        if (mButtonTitles.size() > 0) {
+            _addButtons(new String[mButtonTitles.size()]);
+        }
+    }
+
+    public void clearButtons() {
+        removeAllViews();
+    }
+
+    public void addButtons(String ... titles) {
+        _addButtons(titles);
+    }
+
+    private void _addButtons(String[] titles) {
+
+        for (int i = 0; i < titles.length; i++) {
+
+            Button button = new Button(getContext());
+            button.setText(titles[i]);
+            button.setTag(new Integer(i));
+            button.setOnClickListener(mOnClickListener);
+            if (mTextStyle != -1) {
+                button.setTextAppearance(getContext(), mTextStyle);
+            }
+
+            if (titles.length == 1) {
+                // Don't use a segmented button with one button.
+                return;
+            } else if (titles.length == 2) {
+                if (i == 0) {
+                    button.setBackgroundDrawable(mBgLeftOff);
+                } else {
+                    button.setBackgroundDrawable(mBgRightOn);
+                }
+            } else {
+                if (i == 0) {
+                    button.setBackgroundDrawable(mBgLeftOff);
+                } else if (i == titles.length-1) {
+                    button.setBackgroundDrawable(mBgRightOn);
+                } else {
+                    button.setBackgroundDrawable(mBgCenterOn);
+                }
+            }
+            LinearLayout.LayoutParams llp =
+                new LinearLayout.LayoutParams(
+                        0,
+                        LinearLayout.LayoutParams.WRAP_CONTENT,
+                        1);
+            addView(button, llp);
+            button.setPadding(0, mBtnPaddingTop, 0, mBtnPaddingBottom);
+        }
+    }
+
+    private void buildDrawables(int colorOnStart,
+                                int colorOnEnd,
+                                int colorOffStart,
+                                int colorOffEnd,
+                                int colorSelectedStart,
+                                int colorSelectedEnd,
+                                float crad,
+                                int strokeColor,
+                                int strokeWidth)
+    {
+        // top-left, top-right, bottom-right, bottom-left
+        float[] radiiLeft = new float[] {
+            crad, crad, 0, 0, 0, 0, crad, crad
+        };
+        float[] radiiRight = new float[] {
+            0, 0, crad, crad, crad, crad, 0, 0
+        };
+        float[] radiiCenter = new float[] {
+            0, 0, 0, 0, 0, 0, 0, 0
+        };
+
+        GradientDrawable leftOn = buildGradientDrawable(colorOnStart, colorOnEnd, strokeWidth, strokeColor);
+        leftOn.setCornerRadii(radiiLeft);
+        GradientDrawable leftOff = buildGradientDrawable(colorOffStart, colorOffEnd, strokeWidth, strokeColor);
+        leftOff.setCornerRadii(radiiLeft);
+        GradientDrawable leftSelected = buildGradientDrawable(colorSelectedStart, colorSelectedEnd, strokeWidth, strokeColor);
+        leftSelected.setCornerRadii(radiiLeft);
+
+        GradientDrawable rightOn = buildGradientDrawable(colorOnStart, colorOnEnd, strokeWidth, strokeColor);
+        rightOn.setCornerRadii(radiiRight);
+        GradientDrawable rightOff = buildGradientDrawable(colorOffStart, colorOffEnd, strokeWidth, strokeColor);
+        rightOff.setCornerRadii(radiiRight);
+        GradientDrawable rightSelected = buildGradientDrawable(colorSelectedStart, colorSelectedEnd, strokeWidth, strokeColor);
+        rightSelected.setCornerRadii(radiiRight);
+
+        GradientDrawable centerOn = buildGradientDrawable(colorOnStart, colorOnEnd, strokeWidth, strokeColor);
+        centerOn.setCornerRadii(radiiCenter);
+        GradientDrawable centerOff = buildGradientDrawable(colorOffStart, colorOffEnd, strokeWidth, strokeColor);
+        centerOff.setCornerRadii(radiiCenter);
+        GradientDrawable centerSelected = buildGradientDrawable(colorSelectedStart, colorSelectedEnd, strokeWidth, strokeColor);
+        centerSelected.setCornerRadii(radiiCenter);
+
+        List<int[]> onStates = buildOnStates();
+        List<int[]> offStates = buildOffStates();
+
+        mBgLeftOn = new StateListDrawable();
+        mBgRightOn = new StateListDrawable();
+        mBgCenterOn = new StateListDrawable();
+        mBgLeftOff = new StateListDrawable();
+        mBgRightOff = new StateListDrawable();
+        mBgCenterOff = new StateListDrawable();
+        for (int[] it : onStates) {
+            mBgLeftOn.addState(it, leftSelected);
+            mBgRightOn.addState(it, rightSelected);
+            mBgCenterOn.addState(it, centerSelected);
+            mBgLeftOff.addState(it, leftSelected);
+            mBgRightOff.addState(it, rightSelected);
+            mBgCenterOff.addState(it, centerSelected);
+        }
+        for (int[] it : offStates) {
+            mBgLeftOn.addState(it, leftOn);
+            mBgRightOn.addState(it, rightOn);
+            mBgCenterOn.addState(it, centerOn);
+            mBgLeftOff.addState(it, leftOff);
+            mBgRightOff.addState(it, rightOff);
+            mBgCenterOff.addState(it, centerOff);
+        }
+    }
+
+    private List<int[]> buildOnStates() {
+        List<int[]> res = new ArrayList<int[]>();
+        res.add(new int[] {
+            android.R.attr.state_focused, android.R.attr.state_enabled});
+        res.add(new int[] {
+                android.R.attr.state_focused, android.R.attr.state_selected, android.R.attr.state_enabled});
+        res.add(new int[] {
+                android.R.attr.state_pressed});
+        return res;
+    }
+
+    private List<int[]> buildOffStates() {
+        List<int[]> res = new ArrayList<int[]>();
+        res.add(new int[] {
+            android.R.attr.state_enabled});
+        res.add(new int[] {
+                android.R.attr.state_selected, android.R.attr.state_enabled});
+        return res;
+    }
+
+    private GradientDrawable buildGradientDrawable(int colorStart, int colorEnd, int strokeWidth, int strokeColor) {
+        GradientDrawable gd = new GradientDrawable(
+                GradientDrawable.Orientation.TOP_BOTTOM,
+                new int[] { colorStart, colorEnd });
+        gd.setShape(GradientDrawable.RECTANGLE);
+        gd.setStroke(strokeWidth, strokeColor);
+        return gd;
+    }
+
+    private OnClickListener mOnClickListener = new OnClickListener() {
+        @Override
+        public void onClick(View v) {
+            Button btnNext = (Button)v;
+            int btnNextIndex = ((Integer)btnNext.getTag()).intValue();
+            if (btnNextIndex == mSelectedButtonIndex) {
+                return;
+            }
+
+            handleStateChange(mSelectedButtonIndex, btnNextIndex);
+
+            if (mOnClickListenerExternal != null) {
+                mOnClickListenerExternal.onClick(mSelectedButtonIndex);
+            }
+        }
+    };
+
+    private void handleStateChange(int btnLastIndex, int btnNextIndex) {
+        int count = getChildCount();
+        Button btnLast = (Button)getChildAt(btnLastIndex);
+        Button btnNext = (Button)getChildAt(btnNextIndex);
+
+        if (count < 3) {
+            if (btnLastIndex == 0) {
+                btnLast.setBackgroundDrawable(mBgLeftOn);
+            } else {
+                btnLast.setBackgroundDrawable(mBgRightOn);
+            }
+            if (btnNextIndex == 0) {
+                btnNext.setBackgroundDrawable(mBgLeftOff);
+            } else {
+                btnNext.setBackgroundDrawable(mBgRightOff);
+            }
+        } else {
+            if (btnLastIndex == 0) {
+                btnLast.setBackgroundDrawable(mBgLeftOn);
+            } else if (btnLastIndex == count-1) {
+                btnLast.setBackgroundDrawable(mBgRightOn);
+            } else {
+                btnLast.setBackgroundDrawable(mBgCenterOn);
+            }
+
+            if (btnNextIndex == 0) {
+                btnNext.setBackgroundDrawable(mBgLeftOff);
+            } else if (btnNextIndex == count-1) {
+                btnNext.setBackgroundDrawable(mBgRightOff);
+            } else {
+                btnNext.setBackgroundDrawable(mBgCenterOff);
+            }
+        }
+
+        btnLast.setPadding(0, mBtnPaddingTop, 0, mBtnPaddingBottom);
+        btnNext.setPadding(0, mBtnPaddingTop, 0, mBtnPaddingBottom);
+
+        mSelectedButtonIndex = btnNextIndex;
+    }
+
+    public int getSelectedButtonIndex() {
+        return mSelectedButtonIndex;
+    }
+
+    public void setPushedButtonIndex(int index) {
+        handleStateChange(mSelectedButtonIndex, index);
+    }
+
+    public void setOnClickListener(OnClickListenerSegmentedButton listener) {
+        mOnClickListenerExternal = listener;
+    }
+
+    public interface OnClickListenerSegmentedButton {
+        public void onClick(int index);
+    }
+}

--- a/app/src/main/play/release-notes/en-GB/beta.txt
+++ b/app/src/main/play/release-notes/en-GB/beta.txt
@@ -2,6 +2,7 @@ Notes
 * Syncthing v1.2.0
 * Refer to GitHub for detailed change log.
 Enhancements
+* Add button to "force start/stop" regardless of run conditions (#443)
 * Add "roaming" option to run conditions (#441)
 * Add "Revert local changes" button to UI (#439)
 * Override changes: Show confirmation dialog (#436)

--- a/app/src/main/res/layout/fragment_status.xml
+++ b/app/src/main/res/layout/fragment_status.xml
@@ -5,15 +5,35 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <Button
-        android:id="@+id/forceStartStop"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="15dp"
-        android:layout_marginTop="10dp"
-        android:text="@string/action_force_start" />
+    <LinearLayout
+        android:orientation="horizontal"
+        android:layout_width="match_parent"
+        android:layout_height="100dp"
+        android:paddingTop="10dp"
+        android:paddingBottom="10dp"
+        android:paddingLeft="10dp"
+        android:paddingRight="10dp">
 
-    <ListView xmlns:android="http://schemas.android.com/apk/res/android"
+        <com.nutomic.syncthingandroid.views.SegmentedButton
+            android:id="@+id/forceStartStop"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:gradientColorOnStart="#00264d"
+            app:gradientColorOnEnd="#004d99"
+            app:gradientColorOffStart="#006bb3"
+            app:gradientColorOffEnd="#4db8ff"
+            app:gradientColorSelectedStart="#46d9ff"
+            app:gradientColorSelectedEnd="#b9e6ff"
+            app:textStyle="@style/TextViewStyleSegmentedButtonHeader"
+            app:strokeColor="#bbbbbb"
+            app:strokeWidth="3dp"
+            app:cornerRadius="10dp"
+            app:btnPaddingTop="10dp"
+            app:btnPaddingBottom="10dp" />
+
+    </LinearLayout>
+
+    <ListView
         android:id="@android:id/list"
         android:layout_width="match_parent"
         android:layout_height="match_parent">

--- a/app/src/main/res/layout/fragment_status.xml
+++ b/app/src/main/res/layout/fragment_status.xml
@@ -10,7 +10,6 @@
         android:layout_width="match_parent"
         android:layout_height="100dp"
         android:paddingTop="10dp"
-        android:paddingBottom="10dp"
         android:paddingLeft="10dp"
         android:paddingRight="10dp">
 
@@ -28,8 +27,7 @@
             app:strokeColor="#bbbbbb"
             app:strokeWidth="3dp"
             app:cornerRadius="10dp"
-            app:btnPaddingTop="10dp"
-            app:btnPaddingBottom="10dp" />
+            app:btnPaddingTop="10dp" />
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_status.xml
+++ b/app/src/main/res/layout/fragment_status.xml
@@ -6,7 +6,7 @@
     android:layout_height="match_parent">
 
     <Button
-        android:id="@+id/forceRunStop"
+        android:id="@+id/forceStartStop"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="15dp"

--- a/app/src/main/res/layout/fragment_status.xml
+++ b/app/src/main/res/layout/fragment_status.xml
@@ -1,6 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ListView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@android:id/list"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
-</ListView>
+
+    <Button
+        android:id="@+id/forceRunStop"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="15dp"
+        android:layout_marginTop="10dp"
+        android:text="@string/action_force_start" />
+
+    <ListView xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@android:id/list"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+    </ListView>
+
+</LinearLayout>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -174,6 +174,11 @@ Bitte melden Sie auftretende Probleme via GitHub.</string>
 
     <!-- StatusFragment -->
     <string name="status_fragment_title">Status</string>
+
+    <string name="button_follow_run_conditions">Befolge Laufkonditionen</string>
+    <string name="button_force_start">Start erzwingen\nLaufkonditionen ignorieren</string>
+    <string name="button_force_stop">Stopp erzwingen\nLaufkonditionen ignorieren</string>
+
     <string name="syncthing_starting">Syncthing wird gestartet.</string>
     <string name="syncthing_running">Syncthing läuft.</string>
     <string name="syncthing_not_running">Syncthing läuft nicht.</string>
@@ -775,6 +780,9 @@ Bitte melden Sie auftretende Probleme via GitHub.</string>
     <string name="sub_folder">Unterverzeichnis</string>
 
     <!-- RunConditionMonitor -->
+
+    <string name="reason_force_start">Syncthing läuft, weil Sie den Start unabhängig von den Laufkonditionen erzwungen haben.</string>
+    <string name="reason_force_stop">Syncthing schläft, weil Sie den Stopp unabhängig von den Laufkonditionen erzwungen haben.</string>
 
     <!-- Explanations why syncthing is running or not running -->
     <string name="reason_not_within_time_frame">Sie haben \'Gemäß Zeitplan synchronisieren\' aktiviert, und die letzte Synchronisierung ist nicht länger als eine Stunde her.</string>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -2,4 +2,21 @@
 <resources>
     <attr name="textAppearanceListItemPrimary" format="reference"/>
     <attr name="textAppearanceListItemSecondary" format="reference"/>
+
+    <declare-styleable name="SegmentedButton">
+      <attr name="btnText1" format="string" />
+      <attr name="btnText2" format="string" />
+      <attr name="gradientColorOnStart" format="color" />
+      <attr name="gradientColorOnEnd" format="color" />
+      <attr name="gradientColorOffStart" format="color" />
+      <attr name="gradientColorOffEnd" format="color" />
+      <attr name="gradientColorSelectedStart" format="color" />
+      <attr name="gradientColorSelectedEnd" format="color" />
+      <attr name="strokeColor" format="color" />
+      <attr name="strokeWidth" format="dimension" />
+      <attr name="cornerRadius" format="dimension" />
+      <attr name="textStyle" format="reference" />
+      <attr name="btnPaddingTop" format="dimension" />
+      <attr name="btnPaddingBottom" format="dimension" />
+    </declare-styleable>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -801,6 +801,9 @@ Please report any problems you encounter via Github.</string>
 
     <!-- RunConditionMonitor -->
 
+    <string name="reason_force_start">Syncthing is running because you forced it to start regardless of the run conditions.</string>
+    <string name="reason_force_stop">Syncthing is not running because you forced it to stop regardless of the run conditions.</string>
+
     <!-- Explanations why syncthing is running or not running -->
     <string name="reason_not_within_time_frame">You enabled \'Run according to time schedule\' and the last sync was no more than an hour ago.</string>
     <string name="reason_not_charging">Phone is not charging.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -177,6 +177,10 @@ Please report any problems you encounter via Github.</string>
 
     <!-- StatusFragment -->
     <string name="status_fragment_title">Status</string>
+
+    <string name="action_force_start">Force start</string>
+    <string name="action_force_stop">Force stop</string>
+
     <string name="syncthing_starting">Syncthing is starting.</string>
     <string name="syncthing_running">Syncthing is running.</string>
     <string name="syncthing_not_running">Syncthing is not running.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -178,8 +178,9 @@ Please report any problems you encounter via Github.</string>
     <!-- StatusFragment -->
     <string name="status_fragment_title">Status</string>
 
-    <string name="action_force_start">Force start</string>
-    <string name="action_force_stop">Force stop</string>
+    <string name="button_follow_run_conditions">FOLLOW RUN CONDITIONS</string>
+    <string name="button_force_start">FORCE START\nIGNORE RUN CONDITIONS</string>
+    <string name="button_force_stop">FORCE STOP\nIGNORE RUN CONDITIONS</string>
 
     <string name="syncthing_starting">Syncthing is starting.</string>
     <string name="syncthing_running">Syncthing is running.</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -73,7 +73,7 @@
     <!-- SegmentedButton -->
     <style name="TextViewStyleSegmentedButtonHeader">
         <item name="android:textSize">13dip</item>
-        <item name="android:textColor">#EEFFFFFF</item>
+        <item name="android:textColor">#FFFFFFFF</item>
         <item name="android:textStyle">bold</item>
     </style>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -69,4 +69,11 @@
         <item name="android:paddingTop">5dp</item>
         <item name="android:paddingBottom">5dp</item>
     </style>
+
+    <!-- SegmentedButton -->
+    <style name="TextViewStyleSegmentedButtonHeader">
+        <item name="android:textSize">13dip</item>
+        <item name="android:textColor">#EEFFFFFF</item>
+        <item name="android:textStyle">bold</item>
+    </style>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -72,7 +72,7 @@
 
     <!-- SegmentedButton -->
     <style name="TextViewStyleSegmentedButtonHeader">
-        <item name="android:textSize">13dip</item>
+        <item name="android:textSize">13sp</item>
         <item name="android:textColor">#FFFFFFFF</item>
         <item name="android:textStyle">bold</item>
     </style>


### PR DESCRIPTION
Purpose:
- Status tab - add button to "force start" / "force stop" (fixes #394)

Issues:
- Status tab - add button to "force start" / "force stop" (fixes #394)
- "Manual sync" #https://github.com/syncthing/syncthing-android/issues/1031
- "Temporarily ignore Sync Restrictions" #https://github.com/syncthing/syncthing-android/issues/769
- "Enhancement. Force sync button in the Android app" #https://github.com/syncthing/syncthing/issues/4861

Requested by:
@felixwiemuth
@nelsonblaha
@grwlf
@sephore
@ymage
@rubenbe
@sojusnik
@vontrapp
@alok0
@Mannshoch

Testing:
- Verified working on AVD 9.x at commit https://github.com/Catfriend1/syncthing-android/pull/443/commits/ac9c3102c01b146ac79dadcd7b355c05f7fa09e3 and on AVD 7.x (Nexus One).