### PR TITLE
Fix crash in config reader getFolders/elementVersioning (fixes #445)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/util/ConfigXml.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/ConfigXml.java
@@ -483,20 +483,22 @@ public class ConfigXml {
             */
             folder.versioning = new Folder.Versioning();
             Element elementVersioning = (Element) r.getElementsByTagName("versioning").item(0);
-            folder.versioning.type = getAttributeOrDefault(elementVersioning, "type", "");
-            NodeList nodeVersioningParam = elementVersioning.getElementsByTagName("param");
-            for (int j = 0; j < nodeVersioningParam.getLength(); j++) {
-                Element elementVersioningParam = (Element) nodeVersioningParam.item(j);
-                folder.versioning.params.put(
-                        getAttributeOrDefault(elementVersioningParam, "key", ""),
-                        getAttributeOrDefault(elementVersioningParam, "val", "")
-                );
-                /*
-                Log.v(TAG, "folder.versioning.type=" + folder.versioning.type +
-                        ", key=" + getAttributeOrDefault(elementVersioningParam, "key", "") +
-                        ", val=" + getAttributeOrDefault(elementVersioningParam, "val", "")
-                );
-                */
+            if (elementVersioning != null) {
+                folder.versioning.type = getAttributeOrDefault(elementVersioning, "type", "");
+                NodeList nodeVersioningParam = elementVersioning.getElementsByTagName("param");
+                for (int j = 0; j < nodeVersioningParam.getLength(); j++) {
+                    Element elementVersioningParam = (Element) nodeVersioningParam.item(j);
+                    folder.versioning.params.put(
+                            getAttributeOrDefault(elementVersioningParam, "key", ""),
+                            getAttributeOrDefault(elementVersioningParam, "val", "")
+                    );
+                    /*
+                    Log.v(TAG, "folder.versioning.type=" + folder.versioning.type +
+                            ", key=" + getAttributeOrDefault(elementVersioningParam, "key", "") +
+                            ", val=" + getAttributeOrDefault(elementVersioningParam, "val", "")
+                    );
+                    */
+                }
             }
 
             // For testing purposes only.


### PR DESCRIPTION
Purpose:
- Fix crash in config reader getFolders/elementVersioning (fixes #445)

Testing:
- Verified working on AVD 7.1.1 (Nexus One) using a prepared reproducer where the config.xml has a folder with no "versioning" node.