### PR TITLE
Optimize memory usage on older phones (fixes #448)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
@@ -492,6 +492,17 @@ public class SyncthingRunnable implements Runnable {
         }
         if (mPreferences.getBoolean("use_legacy_hashing", false))
             targetEnv.put("STHASHING", "standard");
+
+        // Optimize memory usage for older devices.
+        int gogc = 100;         // GO default
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            gogc = 50;
+        } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            gogc = 75;
+        }
+        LogV("GOGC=" + Integer.toString(gogc));
+        targetEnv.put("GOGC", Integer.toString(gogc));
+
         putCustomEnvironmentVariables(targetEnv, mPreferences);
         return targetEnv;
     }


### PR DESCRIPTION
Purpose:
- Optimize memory usage on older phones (fixes #448)
The older the phone software, we assume the older the phone is.
The older the phone, the more GOGC we need to keep memory usage spikes low (and prevent crashing those devices).

Sources:
- https://dave.cheney.net/tag/gogc
- https://forum.syncthing.net/t/freebsd-memory-usage/13140/13
