### PR TITLE
Opt-out of Android Q's "Scoped Storage" as it would be the death of this app (fixes #457)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,6 +36,7 @@
         android:supportsRtl="true"
         android:installLocation="internalOnly"
         android:name=".SyncthingApp"
+        android:requestLegacyExternalStorage="true"
         android:networkSecurityConfig="@xml/network_security_config">
         <activity
                 android:name=".activities.FirstStartActivity"


### PR DESCRIPTION
 - I know this is not the fix everyone wants but it keeps Syncthing-Fork alive a little longer.

See issue #457 to know why.