### PR TITLE
 Fix device sync percentage calculation for paused folders (fixes #463)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/model/Completion.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/model/Completion.java
@@ -150,6 +150,9 @@ public class Completion {
             deviceFolderMap.put(deviceId, new HashMap<String, CompletionInfo>());
         }
         // Add folder or update existing folder entry.
+        if (ENABLE_VERBOSE_LOG) {
+            Log.v(TAG, "setCompletionInfo: Storing " + completionInfo.completion + "% for folder \"" + folderId + "\".");
+        }
         deviceFolderMap.get(deviceId).put(folderId, completionInfo);
     }
 }

--- a/app/src/main/java/com/nutomic/syncthingandroid/model/CompletionInfo.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/model/CompletionInfo.java
@@ -10,14 +10,4 @@ package com.nutomic.syncthingandroid.model;
  */
 public class CompletionInfo {
     public double completion = 100;
-
-    /**
-     * The following values are only returned by the REST API call
-     * to ""/completion". We will need them in the future to show
-     * more statistics in the device UI.
-     */
-    // public long globalBytes = 0;
-    // public long needBytes = 0;
-    // public long needDeletes = 0;
-    // public long needItems = 0;
 }

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/RestApi.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/RestApi.java
@@ -806,6 +806,22 @@ public class RestApi {
      * Updates cached folder and device completion info according to event data.
      */
     public void setCompletionInfo(String deviceId, String folderId, CompletionInfo completionInfo) {
+        final Folder folder = getFolderByID(folderId);
+        if (folder == null) {
+            Log.e(TAG, "setCompletionInfo: folderId == null");
+            return;
+        }
+        if (folder.paused) {
+            /**
+             * Fixes issue #463 where device sync percentage is displayed 50% on wrapper UI
+             * and 100% on Web UI if there are at least two folders syncing with the same device and
+             * at least one of them is paused. This is caused by EventProcessor telling us a paused
+             * to be 0% complete. To get consistent UI output, we assume 100% completion for paused
+             * folders.
+            **/
+            LogV("setCompletionInfo: Paused folder \"" + folderId + "\" - got " + completionInfo.completion + "%, passing on 100%");
+            completionInfo.completion = 100;
+        }
         mCompletion.setCompletionInfo(deviceId, folderId, completionInfo);
     }
 


### PR DESCRIPTION
Purpose:
- Fix device sync percentage calculation for paused folders (fixes #463)

Testing:
- Verified working on AVD 9.x at commit #https://github.com/Catfriend1/syncthing-android/commit/f40ab808fbc328af3bc71b99335d42b2ded4118b