### PR TITLE
Fix bug in env var splitting logic related to the equal sign (fixes #474)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
@@ -368,7 +368,7 @@ public class SettingsActivity extends SyncthingActivity {
             Preference verboseLog                   = findPreference(Constants.PREF_VERBOSE_LOG);
             Preference openIssueTracker             = findPreference(KEY_OPEN_ISSUE_TRACKER);
             Preference debugFacilitiesEnabled       = findPreference(Constants.PREF_DEBUG_FACILITIES_ENABLED);
-            Preference environmentVariables         = findPreference("environment_variables");
+            Preference environmentVariables         = findPreference(Constants.PREF_ENVIRONMENT_VARIABLES);
             Preference stResetDatabase              = findPreference("st_reset_database");
             Preference stResetDeltas                = findPreference("st_reset_deltas");
 

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
@@ -767,14 +767,18 @@ public class SettingsActivity extends SyncthingActivity {
                     mPendingConfig = true;
                     break;
                 case Constants.PREF_ENVIRONMENT_VARIABLES:
-                    if (((String) o).matches("^(\\w+=[\\w:/\\.]+)?( \\w+=[\\w:/\\.]+)*$")) {
-                        mPendingConfig = true;
+                    // Verify if valid environment VAR=VALUE pairs were given as text string.
+                    if (!((String) o).isEmpty()) {
+                        for (String e : ((String) o).split(" ")) {
+                            if (e.split("=", 2).length != 2) {
+                                // Found an invalid "VAR=VALUE" pair.
+                                Toast.makeText(getActivity(), R.string.toast_invalid_environment_variables, Toast.LENGTH_SHORT)
+                                        .show();
+                                return false;
+                            }
+                        }
                     }
-                    else {
-                        Toast.makeText(getActivity(), R.string.toast_invalid_environment_variables, Toast.LENGTH_SHORT)
-                                .show();
-                        return false;
-                    }
+                    mPendingConfig = true;
                     break;
                 case Constants.PREF_USE_WAKE_LOCK:
                     mPendingConfig = true;

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
@@ -279,7 +279,8 @@ public class SyncthingRunnable implements Runnable {
             return;
 
         for (String e : customEnvironment.split(" ")) {
-            String[] e2 = e.split("=");
+            String[] e2 = e.split("=", 2);
+            LogV("Setting env var: [" + e2[0] + "]=[" + e2[1] + "]");
             environment.put(e2[0], e2[1]);
         }
     }
@@ -500,7 +501,7 @@ public class SyncthingRunnable implements Runnable {
         } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
             gogc = 75;
         }
-        LogV("GOGC=" + Integer.toString(gogc));
+        LogV("Setting env var: [GOGC]=[" + Integer.toString(gogc) + "]");
         targetEnv.put("GOGC", Integer.toString(gogc));
 
         putCustomEnvironmentVariables(targetEnv, mPreferences);


### PR DESCRIPTION
Purpose:
- Fix bug in env var splitting logic related to the equal sign (fixes #474)

Verified working, see log below @ https://github.com/Catfriend1/syncthing-android/pull/478/commits/9fd236cfdd10d88e598714d956e31e711c43f2b6