### PR TITLE
Show explanation text below versioning row on FolderDialog (fixes #475)

### DIFF
--- a/app/src/main/res/layout/activity_folder.xml
+++ b/app/src/main/res/layout/activity_folder.xml
@@ -242,6 +242,7 @@
 
             </LinearLayout>
 
+            <!-- Versioning -->
             <LinearLayout
                 android:id="@+id/versioningContainer"
                 android:layout_width="match_parent"
@@ -263,12 +264,21 @@
                     android:text="@string/file_versioning" />
 
                 <TextView
-                    android:id="@+id/versioningType"
+                    android:id="@+id/versioningGenericDescription"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginLeft="75dp"
                     android:layout_marginStart="75dp"
                     android:layout_marginTop="-20dp"
+                    android:text="@string/file_versioning_generic_description"
+                    android:textAppearance="@style/TextAppearance.AppCompat.Caption" />
+
+                <TextView
+                    android:id="@+id/versioningType"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="75dp"
+                    android:layout_marginStart="75dp"
                     android:textAppearance="@style/TextAppearance.AppCompat.Caption" />
 
                 <TextView

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -945,6 +945,7 @@ Bitte melden Sie auftretende Probleme via GitHub.</string>
     <string name="maximum_age">Höchstalter</string>
     <string name="clean_out_after">Aufräumen nach</string>
     <string name="file_versioning">Dateiversionierung</string>
+    <string name="file_versioning_generic_description">Syncthing unterstützt das Archivieren der alten Version einer Datei, wenn diese gelöscht oder durch eine neuere Version aus dem Cluster ersetzt wird. Klicke hier, um die verfügbaren Versionierungsstrategien anzuzeigen. Die Dateiversionierung wird pro Ordner und Gerät konfiguriert. Gewählte Strategie:</string>
     <string name="none">Keine</string>
     <string name="versions_path">Versionspfad</string>
     <string name="command">Befehl</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -966,6 +966,7 @@ Please report any problems you encounter via Github.</string>
     <string name="maximum_age">Maximum Age</string>
     <string name="clean_out_after">Clean out after</string>
     <string name="file_versioning">File Versioning</string>
+    <string name="file_versioning_generic_description">Syncthing supports archiving the old version of a file when it is deleted or replaced with a newer version from the cluster. Click to see available versioning strategies. File versioning is configured per folder, on a per-device basis. Selected strategy:</string>
     <string name="none"> None</string>
     <string name="versions_path">Versions Path</string>
     <string name="command">Command</string>


### PR DESCRIPTION
Purpose:
- Show explanation text below versioning row on FolderDialog (fixes #475)

Testing:
Verified working on AVD 9.x at commit https://github.com/Catfriend1/syncthing-android/commit/68c6f0b0453ab8586a8d76a9a51afa74168e75e7 .
![image](https://user-images.githubusercontent.com/16361913/64076392-9a8b7d80-ccc4-11e9-8aa6-483ea031fe0c.png)
