### PR TITLE
Enable trash can file versioner by default (fixes #480)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
@@ -683,6 +683,8 @@ public class FolderActivity extends SyncthingActivity {
         mFolder.type = Constants.FOLDER_TYPE_SEND_RECEIVE;      // Default for {@link #checkWriteAndUpdateUI}.
         mFolder.minDiskFree = new Folder.MinDiskFree();
         mFolder.versioning = new Folder.Versioning();
+        mFolder.versioning.type = "trashcan";
+        mFolder.versioning.params.put("cleanoutDays", Integer.toString(14));
     }
 
     private void addEmptyDeviceListView() {


### PR DESCRIPTION
Purpose:
- Enable trash can file versioner by default (fixes #480)
- Suggest "cleanoutDays = 14" for the trash can versioner.

Related issues:
- #480 
- #475
- https://forum.syncthing.net/t/missing-syncthing-directory-missing-data-on-devices/13684/9
- https://docs.syncthing.net/users/versioning.html

Testing:
- Verified working on AVD 9.x at commit https://github.com/Catfriend1/syncthing-android/pull/481/commits/3cd66927357d11801084a5bfe21a854d138c5ee8 .