### PR TITLE
Bump dependencies: gradle 6.5.1 (plugin 3.5.0), fix lint crash

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,19 +3,19 @@ apply plugin: 'com.github.ben-manes.versions'
 apply plugin: 'com.github.triplet.play'
 
 dependencies {
-    implementation 'eu.chainfire:libsuperuser:1.1.0.201903290044'
+    implementation 'eu.chainfire:libsuperuser:1.1.0.201907261845'
     implementation 'com.google.android.material:material:1.0.0'
     implementation 'androidx.recyclerview:recyclerview:1.0.0'
     implementation 'com.google.zxing:android-integration:3.3.0'
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'org.mindrot:jbcrypt:0.4'
     // com.google.guava:guava:24.1-jre will crash on Android 5.x
-    implementation 'com.google.guava:guava:27.1-android'
+    implementation 'com.google.guava:guava:28.0-android'
     implementation 'com.annimon:stream:1.2.1'
     implementation 'com.android.volley:volley:1.1.1'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation 'com.google.dagger:dagger:2.23.1'
-    annotationProcessor "com.google.dagger:dagger-compiler:2.23.1"
+    implementation 'com.google.dagger:dagger:2.24'
+    annotationProcessor "com.google.dagger:dagger-compiler:2.24"
     androidTestImplementation 'androidx.test:rules:1.1.0'
     androidTestImplementation 'androidx.annotation:annotation:1.0.0'
 }
@@ -27,7 +27,7 @@ def ourVersionName = "${versionMajor}.${versionMinor}.${versionPatch}.${versionW
 android {
     // Changes to these values need to be reflected in `.travis.yml`
     compileSdkVersion 29
-    buildToolsVersion '29.0.0'
+    buildToolsVersion '29.0.2'
 
     buildTypes.debug.applicationIdSuffix ".debug"
     dataBinding.enabled = true

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     implementation 'com.google.zxing:android-integration:3.3.0'
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'org.mindrot:jbcrypt:0.4'
-    // com.google.guava:guava:24.1-jre will crash on Android 5.x
+    // com.google.guava:guava:x.y-jre will crash on Android 5.x
     implementation 'com.google.guava:guava:28.0-android'
     implementation 'com.annimon:stream:1.2.1'
     implementation 'com.android.volley:volley:1.1.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -77,6 +77,8 @@ android {
     }
 
     lintOptions {
+        // Gradle 5.6.1: Lint crashes while running pass "IconMissingDensityFolder".
+        disable "IconMissingDensityFolder"
         abortOnError true
     }
 }

--- a/app/src/main/res/xml/app_settings.xml
+++ b/app/src/main/res/xml/app_settings.xml
@@ -163,14 +163,12 @@
         <EditTextPreference
             android:key="maxRecvKbps"
             android:title="@string/max_recv_kbps"
-            android:numeric="integer"
             android:persistent="false"
             android:inputType="number" />
 
         <EditTextPreference
             android:key="maxSendKbps"
             android:title="@string/max_send_kbps"
-            android:numeric="integer"
             android:persistent="false"
             android:inputType="number" />
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.1'
-        classpath 'com.github.ben-manes:gradle-versions-plugin:0.21.0'
+        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.github.ben-manes:gradle-versions-plugin:0.24.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -15,7 +15,7 @@ buildscript {
 }
 
 plugins {
-    id 'com.github.triplet.play' version '2.2.1'
+    id 'com.github.triplet.play' version '2.3.0'
 }
 
 allprojects {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Bump dependencies, gradle 3.5.0