### PR TITLE
Be compatible with v1.3.0 API changes (fixes #495)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/model/SystemStatus.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/model/SystemStatus.java
@@ -6,18 +6,67 @@ import java.util.Map;
  * REST API endpoint "/rest/system/status"
  */
 public class SystemStatus {
+    // Example: 25857744
     public long alloc;
+
+    // Example: 1.1183119275778985
     public double cpuPercent;
+
+    // Example:
+    //  connectionServiceStatus: {dynamic+https://relays.syncthing.net/endpoint: {error: null, lanAddresses: [], wanAddresses: []},…}
+    //      dynamic+https://relays.syncthing.net/endpoint: {error: null, lanAddresses: [], wanAddresses: []}
+    //      quic://0.0.0.0:22000: {error: null, lanAddresses: ["quic://0.0.0.0:22000"],…}
+    //      tcp://0.0.0.0:22000: {error: null, lanAddresses: ["tcp://0.0.0.0:22000"], wanAddresses: ["tcp://0.0.0.0:22000"]}
     public Map<String, SystemStatusConnectionServiceStatusElement> connectionServiceStatus;
+
+    // Example: true
     public boolean discoveryEnabled;
+
+    // Example:
+    //  discoveryErrors: {,…}
+    //      IPv4 local: "listen udp4 :21027: bind: Normalerweise darf jede Socketadresse (Protokoll, Netzwerkadresse oder Anschluss) nur jeweils einmal verwendet werden."
+    //      IPv6 local: "listen udp6 [ff12::8384]:21027: bind: Der Zugriff auf einen Socket war aufgrund der Zugriffsrechte des Sockets unzulässig."
+    //      global@https://discovery-v6.syncthing.net/v2/: "Post https://discovery-v6.syncthing.net/v2/: dial tcp: lookup discovery-v6.syncthing.net: no such host"
     public Map<String, String> discoveryErrors;
+
+    // Example: 5
     public int discoveryMethods;
+
+    // Example: 77
     public int goroutines;
+
+    // Example: "7LTUV3P-Y37HQXK-UUM7S5Q-2NDQT3B-SA4WAT4-T5ODX3V-XRXAF7Z-MXM7GAA"
     public String myID;
+
+    // Example: "\"
     public String pathSeparator;
+
+    // Example: "2019-09-21T10:59:47.1951229+02:00"
     public String startTime;
+
+    // Example: 46476920
     public long sys;
+
+    // Example: "C:\Users\Dev"
     public String tilde;
+
+    // Example: 29
     public long uptime;
+
+    // Example: 3
     public int urVersionMax;
+
+    // Example:
+    //  lastDialStatus: {,…}
+    //      tcp4://192.168.5.1: {when: "2019-09-21T09:10:35Z", error: "dial tcp4 192.168.5.1:22000: i/o timeout"}
+    public Map<String, SystemStatusLastDialStatusElement> lastDialStatus;
+
+    // Example: false
+    public boolean guiAddressOverridden;
+
+    /**
+     * Since SyncthingNative v1.3.0
+     */
+    // Example: "127.0.0.1:8384"
+    public String guiAddressUsed;
 }

--- a/app/src/main/java/com/nutomic/syncthingandroid/model/SystemStatusLastDialStatusElement.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/model/SystemStatusLastDialStatusElement.java
@@ -1,0 +1,13 @@
+package com.nutomic.syncthingandroid.model;
+
+/**
+ * REST API endpoint "/rest/system/status"
+ * Part of JSON answer in field {@link SystemStatus#lastDialStatus}
+ */
+public class SystemStatusLastDialStatusElement {
+    // Example: "dial tcp4 192.168.5.1:22000: i/o timeout"
+    public String error;
+
+    // Example: "2019-09-21T09:10:35Z"
+    public String when;
+}


### PR DESCRIPTION
Purpose:
- Be compatible with v1.3.0 API changes @SyncthingNative
- Add field "guiAddressUsed" to the system status response, issue #495

Testing:
- Verified working on AVD 10 at commit #https://github.com/Catfriend1/syncthing-android/pull/496/commits/32f64e956305ad27df08a3ef29c86a3c179bf089