### PR TITLE
Fix NPE crash when config.xml "version" attr is broken (fixes #490)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/util/ConfigXml.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/ConfigXml.java
@@ -337,7 +337,7 @@ public class ConfigXml {
         Folder defaultFolder = new Folder();
 
         /* Read existing config version */
-        int iConfigVersion = Integer.parseInt(mConfig.getDocumentElement().getAttribute("version"));
+        int iConfigVersion = getAttributeOrDefault(mConfig.getDocumentElement(), "version", 0);
         int iOldConfigVersion = iConfigVersion;
         LogV("Found existing config version " + Integer.toString(iConfigVersion));
 


### PR DESCRIPTION
Purpose:
- Fix NPE crash when config.xml "version" attr is broken (fixes #490)

Testing:
- Verified working on AVD 10 at commit https://github.com/Catfriend1/syncthing-android/commit/39d6c55a6d0021f5033c0145c57defbf3e817631 .