### PR TITLE
Disable NAT option if a buggy 3.4 kernel is detected (fixes #505)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
@@ -251,4 +251,17 @@ public class Constants {
 
         return true;
     }
+
+    /**
+     * Detect kernels with a bug causing kernel oops when
+     * Syncthing v1.3.0+ attempts to enable the NAT feature.
+     * See: https://github.com/Catfriend1/syncthing-android/issues/505
+     */
+    public static Boolean osHasKernelBugIssue505() {
+        String kernelVersion = java.lang.System.getProperty("os.version");
+        if (kernelVersion == null) {
+            return false;
+        }
+        return kernelVersion.startsWith("3.4.");
+    }
 }

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/ConfigXml.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/ConfigXml.java
@@ -319,6 +319,14 @@ public class ConfigXml {
         changed = setConfigElement(options, "startBrowser", Boolean.toString(defaultOptions.startBrowser)) || changed;
         changed = setConfigElement(options, "databaseTuning", defaultOptions.databaseTuning) || changed;
 
+        /**
+         * Disable Syncthing's NAT feature because it causes kernel oops on some buggy kernels.
+         */
+        if (Constants.osHasKernelBugIssue505()) {
+            LogV("Disabling NAT option because a buggy kernel was detected. See https://github.com/Catfriend1/syncthing-android/issues/505 .");
+            changed = setConfigElement(options, "natEnabled", Boolean.toString(false)) || changed;
+        }
+
         // Save changes if we made any.
         if (changed) {
             saveChanges();


### PR DESCRIPTION
Purpose:
- Disable NAT option if a buggy 3.4 kernel is detected (fixes #505)

Testing:
- Verified working on AVD but I don't have a phone running the affected 3.4.x kernel versions. "Virtually working".