### PR TITLE
Hide launcher icon "Syncthing-Fork Camera" on user request (fixes #520)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
@@ -640,6 +640,12 @@ public class SettingsActivity extends SyncthingActivity {
                     mSuggestNewFolderRoot.setValue(o.toString());
                     preference.setSummary(mSuggestNewFolderRoot.getEntry());
                     break;
+                case Constants.PREF_LAUNCHER_SHOW_CAMERA_ICON:
+                    if (!showHideLauncherCameraIcon((Boolean) o)) {
+                        Toast.makeText(getActivity(), R.string.toast_show_hide_launcher_icon_failed, Toast.LENGTH_LONG)
+                                .show();
+                    }
+                    break;
             }
             return true;
         }
@@ -1154,6 +1160,26 @@ public class SettingsActivity extends SyncthingActivity {
                 return "N/A";
             }
             return result;
+        }
+
+        /**
+         * Returns if the operation succeeded.
+         */
+        private Boolean showHideLauncherCameraIcon(Boolean showIcon) {
+            try {
+                SyncthingActivity syncthingActivity = (SyncthingActivity) getActivity();
+                PackageManager packageManager = syncthingActivity.getPackageManager();
+                ComponentName componentName = new ComponentName(syncthingActivity, com.nutomic.syncthingandroid.activities.PhotoShootActivity.class);
+                packageManager.setComponentEnabledSetting(
+                        componentName,
+                        showIcon ? PackageManager.COMPONENT_ENABLED_STATE_ENABLED : PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+                        PackageManager.DONT_KILL_APP
+                );
+                return true;
+            } catch (Exception e) {
+                Log.e(TAG, "showHideLauncherCameraIcon", e);
+                return false;
+            }
         }
     }
 }

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
@@ -1152,7 +1152,7 @@ public class SettingsActivity extends SyncthingActivity {
          */
         private String getOpenFileLimit() {
             String shellCommand = "ulimit -n";
-            if (Build.VERSION.SDK_INT < 29) {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
                 shellCommand = "/system/bin/" + shellCommand;
             }
             String result = Util.runShellCommandGetOutput(shellCommand, false);

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
@@ -1166,14 +1166,6 @@ public class SettingsActivity extends SyncthingActivity {
          * Returns if the operation succeeded.
          */
         private Boolean showHideLauncherCameraIcon(Boolean showIcon) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                /**
-                 * According to
-                 * https://developer.android.com/reference/android/content/pm/LauncherApps#getActivityList(java.lang.String,%20android.os.UserHandle)
-                 * this won't work on Android 10+
-                 */
-                return false;
-            }
             try {
                 SyncthingActivity syncthingActivity = (SyncthingActivity) getActivity();
                 PackageManager packageManager = syncthingActivity.getPackageManager();

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
@@ -1166,6 +1166,14 @@ public class SettingsActivity extends SyncthingActivity {
          * Returns if the operation succeeded.
          */
         private Boolean showHideLauncherCameraIcon(Boolean showIcon) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                /**
+                 * According to
+                 * https://developer.android.com/reference/android/content/pm/LauncherApps#getActivityList(java.lang.String,%20android.os.UserHandle)
+                 * this won't work on Android 10+
+                 */
+                return false;
+            }
             try {
                 SyncthingActivity syncthingActivity = (SyncthingActivity) getActivity();
                 PackageManager packageManager = syncthingActivity.getPackageManager();

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
@@ -41,6 +41,8 @@ public class Constants {
     public static final String PREF_SUGGEST_NEW_FOLDER_ROOT_DATA    = "external_android_data";
     public static final String PREF_SUGGEST_NEW_FOLDER_ROOT_MEDIA   = "external_android_media";
 
+    public static final String PREF_LAUNCHER_SHOW_CAMERA_ICON       = "launcher_show_camera_icon";
+
     // Preferences - Troubleshooting
     public static final String PREF_VERBOSE_LOG                 = "verbose_log";
     public static final String PREF_ENVIRONMENT_VARIABLES       = "environment_variables";

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
@@ -926,6 +926,10 @@ public class SyncthingService extends Service {
                     for (Map.Entry<?, ?> e : sharedPrefsMap.entrySet()) {
                         String prefKey = (String) e.getKey();
                         switch (prefKey) {
+                            // Preferences we explicitly require the user to set again manually after a config import.
+                            case Constants.PREF_LAUNCHER_SHOW_CAMERA_ICON:
+                                LogV("importConfig: Explicitly ignoring pref \"" + prefKey + "\".");
+                                break;
                             // Preferences that are no longer used and left-overs from previous versions of the app.
                             case "first_start":
                             case "advanced_folder_picker":

--- a/app/src/main/java/com/nutomic/syncthingandroid/views/WifiSsidPreference.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/views/WifiSsidPreference.java
@@ -116,7 +116,7 @@ public class WifiSsidPreference extends MultiSelectListPreference {
      * Required permissions:
      * - API 16 to 28
      *      permission.ACCESS_COARSE_LOCATIO
-     * - API 29+
+     * - API 29+ (Android 10+)
      *      permission.ACCESS_FINE_LOCATION
      *      permission.ACCESS_BACKGROUND_LOCATION
      */

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -519,6 +519,12 @@ Bitte melden Sie auftretende Probleme via GitHub.</string>
         <item>[Ext_Speicher]/Android/media</item>
     </string-array>
 
+    <string name="launcher_show_camera_icon_title">Kamera-Symbol im Launcher anzeigen</string>
+
+    <string name="launcher_show_camera_icon_summary">Deaktivieren Sie diese Option, wenn Sie die Funktion \"Syncthing Kamera\" nicht verwenden möchten. Dies funktioniert nicht mit Launcher-Apps, die das Ausblenden von Symbolen nicht unterstützen.</string>
+
+    <string name="toast_show_hide_launcher_icon_failed">Das Launcher-Symbol konnte nicht ein- oder ausgeblendet werden.</string>
+
     <string name="expert_mode_title">Expertenmodus</string>
 
     <string name="expert_mode_summary">Durch Aktivieren dieser Option werden erweiterte Konfigurationsoptionen angezeigt. Du solltest Dir zuerst die Syncthing-Dokumentation ansehen, um sicherzustellen, dass Du weißt, wie sie richtig verwendet werden. Falsche Einstellungen können zu hohem Batterieverbrauch, Erschöpfung der Systemressourcen oder unvollständiger Synchronisation führen.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -524,7 +524,7 @@ Please report any problems you encounter via Github.</string>
 
     <string name="launcher_show_camera_icon_title">Show camera icon in launcher</string>
 
-    <string name="launcher_show_camera_icon_summary">Disable this option if you do not like to use the \'Syncthing Camera\' feature. This does not work on Android 10+ or with launcher apps that do not support hiding icons.</string>
+    <string name="launcher_show_camera_icon_summary">Disable this option if you do not like to use the \'Syncthing Camera\' feature. This does not work with launcher apps that do not support hiding icons.</string>
 
     <string name="toast_show_hide_launcher_icon_failed">Failed to show or hide the launcher icon.</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -522,6 +522,12 @@ Please report any problems you encounter via Github.</string>
         <item>[external_storage]/Android/media</item>
     </string-array>
 
+    <string name="launcher_show_camera_icon_title">Show camera icon in launcher</string>
+
+    <string name="launcher_show_camera_icon_summary">Disable this option if you do not like to use the \'Syncthing Camera\' feature. This does not work on Android 10+ or with launcher apps that do not support hiding icons.</string>
+
+    <string name="toast_show_hide_launcher_icon_failed">Failed to show or hide the launcher icon.</string>
+
     <string name="expert_mode_title">Expert mode</string>
 
     <string name="expert_mode_summary">Enabling this option will show advanced configuration options. You should have a look at the Syncthing Docs first to make sure you know how to use them correctly. Incorrect settings may cause battery drain, system resource exhaust or incomplete synchronization.</string>

--- a/app/src/main/res/xml/app_settings.xml
+++ b/app/src/main/res/xml/app_settings.xml
@@ -133,6 +133,7 @@
             android:summary="@string/use_root_summary"
             android:defaultValue="false" />
 
+        <!-- Folder root suggestion -->
         <ListPreference
             android:key="suggest_new_folder_root"
             android:title="@string/suggest_new_folder_root_title"

--- a/app/src/main/res/xml/app_settings.xml
+++ b/app/src/main/res/xml/app_settings.xml
@@ -141,6 +141,13 @@
             android:summary="@null"
             android:defaultValue="external_android_data" />
 
+        <!-- Show "Syncthing Camera" icon in launcher -->
+        <CheckBoxPreference
+            android:key="launcher_show_camera_icon"
+            android:title="@string/launcher_show_camera_icon_title"
+            android:summary="@string/launcher_show_camera_icon_summary"
+            android:defaultValue="true" />
+
     </PreferenceScreen>
 
     <PreferenceScreen


### PR DESCRIPTION
Purpose:
- Hide launcher icon "Syncthing-Fork Camera" on user request (fixes #520)

Testing:
- Verified working on AVD 10, AVD 9 at commit #https://github.com/Catfriend1/syncthing-android/commit/6cf905603790260990fcf3f2a93ff33c04c555c8 .