### PR TITLE
Rename icon to "Sync. Camera" (fixes #516)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -60,7 +60,7 @@
         <activity
                 android:name=".activities.PhotoShootActivity"
                 android:icon="@mipmap/ic_launcher_photoshoot"
-                android:label="@string/photo_shoot_activity_title"
+                android:label="@string/photo_shoot_launcher_title"
                 android:launchMode="singleInstance">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -66,6 +66,7 @@ Bitte melden Sie auftretende Probleme via GitHub.</string>
 
     <!-- PhotoShootActivity -->
 
+    <string name="photo_shoot_launcher_title">Sync. Kamera</string>
 
     <string name="photo_shoot_activity_title">Syncthing-Fork Kamera</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -66,6 +66,7 @@ Please report any problems you encounter via Github.</string>
 
     <!-- PhotoShootActivity -->
 
+    <string name="photo_shoot_launcher_title">Sync. Camera</string>
 
     <string name="photo_shoot_activity_title">Syncthing-Fork Camera</string>
 


### PR DESCRIPTION
Purpose:
- Rename icon to "Sync. Camera" (fixes #516)