### PR TITLE
Revoke Syncthing Camera Feature Consent if folder is removed by user (fixes #518)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
@@ -554,6 +554,12 @@ public class FolderActivity extends SyncthingActivity {
                 .setMessage(R.string.remove_folder_confirm)
                 .setPositiveButton(android.R.string.yes, (dialogInterface, i) -> {
                     mConfig.removeFolder(getApi(), mFolder.id);
+                    if (mFolder.id.equals(Constants.syncthingCameraFolderId)) {
+                        // Remove consent to "Syncthing Camera" feature.
+                        SharedPreferences.Editor editor = mPreferences.edit();
+                        editor.putBoolean(Constants.PREF_ENABLE_SYNCTHING_CAMERA, false);
+                        editor.apply();
+                    }
                     mFolderNeedsToUpdate = false;
                     finish();
                 })


### PR DESCRIPTION
Purpose:
- Revoke Syncthing Camera Feature Consent if folder is removed by user (fixes #518)

Testing:
- Verified on AVD 10.