### PR TITLE
Fix crash after taking picture on pre-nougat cyanogen OS (fixes #529)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/PhotoShootActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/PhotoShootActivity.java
@@ -1,6 +1,7 @@
 package com.nutomic.syncthingandroid.activities;
 
 import android.app.Activity;
+import android.content.ClipData;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
@@ -165,6 +166,10 @@ public class PhotoShootActivity extends AppCompatActivity {
         if (photoFile != null) {
             Uri photoURI = FileProvider.getUriForFile(this, getPackageName() + ".provider", photoFile);
             pictureIntent.putExtra(MediaStore.EXTRA_OUTPUT, photoURI);
+            if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.LOLLIPOP) {
+                pictureIntent.setClipData(ClipData.newRawUri("", photoURI));
+                pictureIntent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION | Intent.FLAG_GRANT_READ_URI_PERMISSION);
+            }
 
             Log.d(TAG, "Launching take picture intent ...");
             lastPhotoURI = photoURI;


### PR DESCRIPTION
Purpose:
- Fix crash after taking picture on pre-nougat cyanogen OS (fixes #529)

Testing:
- Verified working on Samsung Note N7000 running Android 4.4 at commit https://github.com/Catfriend1/syncthing-android/commit/3c8427c18a8575eeec030503bf76f548f80c7949 .
