### PR TITLE
MainActivity: Let the fragmentManager execute pending transactions (fixes #108)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/MainActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/MainActivity.java
@@ -351,6 +351,7 @@ public class MainActivity extends SyncthingActivity
         super.onSaveInstanceState(outState);
 
         FragmentManager fm = getSupportFragmentManager();
+        fm.executePendingTransactions();
         Consumer<Fragment> putFragment = fragment -> {
             if (fragment != null && fragment.isAdded()) {
                 fm.putFragment(outState, fragment.getClass().getName(), fragment);


### PR DESCRIPTION
Purpose:
- MainActivity: Let the fragmentManager execute pending transactions before checking isAdded() (fixes #108)

Testing:
- I cannot reproduce the problem and it's hard to verify this helps against it. The StackOverflow article linked in the issue *just* tells it would fix this.