### PR TITLE
Fix Android App Bundle GPlay Store Release (fixes #536)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
@@ -20,6 +20,7 @@ import com.nutomic.syncthingandroid.SyncthingApp;
 import com.nutomic.syncthingandroid.http.PollWebGuiAvailableTask;
 import com.nutomic.syncthingandroid.model.Device;
 import com.nutomic.syncthingandroid.model.Folder;
+import com.nutomic.syncthingandroid.service.SyncthingRunnable.ExecutableNotFoundException;
 import com.nutomic.syncthingandroid.util.ConfigXml;
 import com.nutomic.syncthingandroid.util.FileUtils;
 import com.nutomic.syncthingandroid.util.Util;
@@ -540,7 +541,14 @@ public class SyncthingService extends Service {
         mSyncthingRunnable.killSyncthing();
 
         // Start the syncthing binary in a separate thread.
+        Thread.UncaughtExceptionHandler syncthingRunnableThreadExceptionHandler = new Thread.UncaughtExceptionHandler() {
+                public void uncaughtException(Thread syncthingRunnableThread, Throwable ex) {
+                    Log.e(TAG, "mSyncthingRunnableThread: Uncaught exception [ExecutableNotFoundException]");
+                    mNotificationHandler.showCrashedNotification(R.string.executable_not_found, "libsyncthing.so");
+                }
+        };
         mSyncthingRunnableThread = new Thread(mSyncthingRunnable);
+        mSyncthingRunnableThread.setUncaughtExceptionHandler(syncthingRunnableThreadExceptionHandler);
         mSyncthingRunnableThread.start();
 
         /**

--- a/debug_scripts/.gitignore
+++ b/debug_scripts/.gitignore
@@ -1,0 +1,3 @@
+bundletool.jar
+extracted.apks
+extracted_apks/

--- a/debug_scripts/convert_bundle_to_apks.cmd
+++ b/debug_scripts/convert_bundle_to_apks.cmd
@@ -1,0 +1,39 @@
+@echo off
+SET SCRIPT_PATH=%~dps0
+cd /d "%SCRIPT_PATH%"
+REM
+REM Runtime Variables.
+SET SYNCTHING_RELEASE_KEY_ALIAS=Syncthing-Fork
+REM 
+where java 2>&1 1> NUL: || call ..\setenv.cmd
+REM 
+REM Check prerequisites.
+IF NOT DEFINED SYNCTHING_RELEASE_KEY_ALIAS echo [ERROR] Env var [SYNCTHING_RELEASE_KEY_ALIAS] not defined. & pause & goto :eof
+IF NOT DEFINED SYNCTHING_RELEASE_STORE_FILE echo [ERROR] Env var [SYNCTHING_RELEASE_STORE_FILE] not defined. & pause & goto :eof
+REM 
+REM Download Google BundleTool from GitHub.
+IF NOT EXIST "bundletool.jar" echo [INFO] Downloading [bundletool.jar] ... & wget --no-check-certificate -q -O"bundletool.jar" "https://github.com/google/bundletool/releases/download/0.11.0/bundletool-all-0.11.0.jar" 2> NUL:
+IF NOT EXIST "bundletool.jar" echo [ERROR] Download [bundletool.jar] FAILED. & pause & goto :eof
+REM 
+REM Extract APKs from Android Bundle "AAB" file.
+IF NOT EXIST "%SCRIPT_PATH%extracted.apks" echo [INFO] Extracting Android Bundle ... & java -jar "bundletool.jar" build-apks --bundle="..\app\build\outputs\bundle\release\app-release.aab" --output="%SCRIPT_PATH%extracted.apks" --ks="%SYNCTHING_RELEASE_STORE_FILE%" --ks-key-alias=%SYNCTHING_RELEASE_KEY_ALIAS%
+IF NOT EXIST "%SCRIPT_PATH%extracted.apks" echo [ERROR] Extracting Android Bundle FAILED. & pause & goto :eof
+REM 
+where unzip 2>&1 1> NUL: && call :unzipExtractedApks
+REM 
+goto :eof
+
+
+:unzipExtractedApks
+REM 
+REM Syntax:
+REM 	call :unzipExtractedApks
+REM 
+rd /s /q "%SCRIPT_PATH%extracted_apks" 2> NUL:
+md "%SCRIPT_PATH%extracted_apks" 2> NUL:
+echo [INFO] Extracting APKs ...
+unzip -q -o -d "%SCRIPT_PATH%extracted_apks" "%SCRIPT_PATH%extracted.apks"
+SET UNZIP_RESULT=%ERRORLEVEL%
+IF "%UNZIP_RESULT%" == "0" DEL /F "%SCRIPT_PATH%extracted.apks"
+REM 
+goto :eof

--- a/debug_scripts/convert_bundle_to_apks.cmd
+++ b/debug_scripts/convert_bundle_to_apks.cmd
@@ -16,6 +16,7 @@ IF NOT EXIST "bundletool.jar" echo [INFO] Downloading [bundletool.jar] ... & wge
 IF NOT EXIST "bundletool.jar" echo [ERROR] Download [bundletool.jar] FAILED. & pause & goto :eof
 REM 
 REM Extract APKs from Android Bundle "AAB" file.
+DEL /F "%SCRIPT_PATH%extracted.apks"
 IF NOT EXIST "%SCRIPT_PATH%extracted.apks" echo [INFO] Extracting Android Bundle ... & java -jar "bundletool.jar" build-apks --bundle="..\app\build\outputs\bundle\release\app-release.aab" --output="%SCRIPT_PATH%extracted.apks" --ks="%SYNCTHING_RELEASE_STORE_FILE%" --ks-key-alias=%SYNCTHING_RELEASE_KEY_ALIAS%
 IF NOT EXIST "%SCRIPT_PATH%extracted.apks" echo [ERROR] Extracting Android Bundle FAILED. & pause & goto :eof
 REM 

--- a/debug_scripts/convert_bundle_to_apks.cmd
+++ b/debug_scripts/convert_bundle_to_apks.cmd
@@ -34,6 +34,6 @@ md "%SCRIPT_PATH%extracted_apks" 2> NUL:
 echo [INFO] Extracting APKs ...
 unzip -q -o -d "%SCRIPT_PATH%extracted_apks" "%SCRIPT_PATH%extracted.apks"
 SET UNZIP_RESULT=%ERRORLEVEL%
-IF "%UNZIP_RESULT%" == "0" DEL /F "%SCRIPT_PATH%extracted.apks"
+REM IF "%UNZIP_RESULT%" == "0" DEL /F "%SCRIPT_PATH%extracted.apks"
 REM 
 goto :eof

--- a/debug_scripts/install_apks_to_device.cmd
+++ b/debug_scripts/install_apks_to_device.cmd
@@ -1,0 +1,18 @@
+@echo off
+SET SCRIPT_PATH=%~dps0
+cd /d "%SCRIPT_PATH%"
+REM
+REM Runtime Variables.
+REM 
+where java 2>&1 1> NUL: || call ..\setenv.cmd
+REM 
+REM Download Google BundleTool from GitHub.
+IF NOT EXIST "bundletool.jar" echo [INFO] Downloading [bundletool.jar] ... & wget --no-check-certificate -q -O"bundletool.jar" "https://github.com/google/bundletool/releases/download/0.11.0/bundletool-all-0.11.0.jar" 2> NUL:
+IF NOT EXIST "bundletool.jar" echo [ERROR] Download [bundletool.jar] FAILED. & pause & goto :eof
+REM 
+REM Install ".apks" file which was previously extracted from ".aab" file.
+IF NOT EXIST "%SCRIPT_PATH%extracted.apks" echo [ERROR] Extracted ".apks" file not found. & pause & goto :eof
+echo [INFO] Installing APKs to device ... & java -jar "bundletool.jar" install-apks --apks="%SCRIPT_PATH%extracted.apks"
+REM 
+pause
+goto :eof

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
+android.bundle.enableUncompressedNativeLibs=false
 android.enableJetifier=true
 android.useAndroidX=true


### PR DESCRIPTION
Purpose:
- Step 1: Find a way to analyse the Android App Bundle (AAB) file generated by the "gradle bundleRelease" command - Done, commit #https://github.com/Catfriend1/syncthing-android/commit/7755299785aff0722daa580fa34b150f6d2a0243 .
- Step 2: Analyse the AAB and which APK's it produces for different devices architectures (arm-v7, arm_v8-64, x86_x64, ...)
- Step 3: Fix the wrong app bundling.

Releated issue: #536