### PR TITLE
Fix bug on Huawei devices running Android 7, returning wrong external path (fixes #541)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/PhotoShootActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/PhotoShootActivity.java
@@ -158,6 +158,10 @@ public class PhotoShootActivity extends AppCompatActivity {
         File photoFile = null;
         try {
             photoFile = createImageFile();
+            if (photoFile == null) {
+                Log.e(TAG, "openCameraIntent: photoFile == null");
+                return;
+            }
         } catch (IOException ex) {
             Log.e(TAG, "Error occurred while creating the temp image file");
             return;
@@ -183,7 +187,11 @@ public class PhotoShootActivity extends AppCompatActivity {
                           Locale.getDefault()).format(new Date());
         String imageFileName = "IMG_" + timeStamp + "_";
         File storageDir =
-                    getExternalFilesDir(Environment.DIRECTORY_PICTURES);
+                    this.getExternalFilesDir(this, Environment.DIRECTORY_PICTURES);
+        if (storageDir == null) {
+            Log.e(TAG, "createImageFile: storageDir == null");
+            return null;
+        }
         File image = File.createTempFile(
                         imageFileName,  /* prefix */
                         ".jpg",         /* suffix */
@@ -275,5 +283,17 @@ public class PhotoShootActivity extends AppCompatActivity {
     private void updateButtons() {
         mBtnGrantCameraPerm.setVisibility(haveCameraPermission() ? View.GONE : View.VISIBLE);
         mBtnGrantStoragePerm.setVisibility(haveStoragePermission() ? View.GONE : View.VISIBLE);
+    }
+
+    public static File getExternalFilesDir(Context context, String type) {
+    	// There is a bug on Huawei devices running Android 7, which returns the wrong external path.
+        // See https://github.com/Catfriend1/syncthing-android/issues/541
+    	// ... and: https://stackoverflow.com/questions/39895579/fileprovider-error-onhuawei-devices
+        File[] externalFilesDirs = ContextCompat.getExternalFilesDirs(context, type);
+        if (externalFilesDirs.length > 0) {
+            return externalFilesDirs[0];
+        } else {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
Purpose:
- Fix bug on Huawei devices running Android 7, returning wrong external path (fixes #541)

Testing:
- Emulated Pixel device running Android 9, don't own a Huwaei device running Android 7 :-(.