### PR TITLE
Fix missing visual indicator for selected menu item (#556)

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -17,7 +17,7 @@
     <style name="Widget.Syncthing.TextView" />
 
     <style name="Widget.Syncthing.TextView.Label" parent="@android:style/Widget.TextView">
-        <item name="background">?selectableItemBackground</item>
+        <item name="android:background">?selectableItemBackground</item>
         <item name="android:drawablePadding">32dp</item>
         <item name="android:gravity">start|center_vertical</item>
         <item name="android:textAppearance">@style/TextAppearance.AppCompat.Body1</item>


### PR DESCRIPTION
Caused By:
- PR https://github.com/Catfriend1/syncthing-android/pull/488

> Last good version was 1020203 (1.2.2.3)
1020204 (1.2.2.4) was broken

Verified working on a virtual Android TV device.