### PR TITLE
Trigger sync window after share-to-Syncthing (fixes #574)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/DaggerComponent.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/DaggerComponent.java
@@ -7,6 +7,7 @@ import com.nutomic.syncthingandroid.activities.FolderPickerActivity;
 import com.nutomic.syncthingandroid.activities.MainActivity;
 import com.nutomic.syncthingandroid.activities.SettingsActivity;
 import com.nutomic.syncthingandroid.activities.PhotoShootActivity;
+import com.nutomic.syncthingandroid.activities.ShareActivity;
 import com.nutomic.syncthingandroid.activities.SyncConditionsActivity;
 import com.nutomic.syncthingandroid.fragments.DeviceListFragment;
 import com.nutomic.syncthingandroid.fragments.FolderListFragment;
@@ -42,6 +43,7 @@ public interface DaggerComponent {
     void inject(RestApi restApi);
     void inject(RunConditionMonitor runConditionMonitor);
     void inject(SettingsActivity.SettingsFragment fragment);
+    void inject(ShareActivity activity);
     void inject(StatusFragment fragment);
     void inject(SyncConditionsActivity activity);
     void inject(SyncthingApp app);

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
@@ -156,7 +156,7 @@ public class Constants {
      * If the user enabled hourly one-time shot sync, the following
      * parameters are effective.
      */
-    public static final int WAIT_FOR_NEXT_SYNC_DELAY_SECS       = isRunningOnEmulator() ? 10 : 3600;
+    public static final int WAIT_FOR_NEXT_SYNC_DELAY_SECS       = isRunningOnEmulator() ? 180 : 3600;
     public static final int TRIGGERED_SYNC_DURATION_SECS        = isRunningOnEmulator() ? 20 : 300;
 
     /**


### PR DESCRIPTION
Purpose:
- [FR] Run according to time schedule: Trigger sync window after share-to-Syncthing (fixes #574)

Testing:
- Verified working on AVD 9.x emulator at commit #https://github.com/Catfriend1/syncthing-android/pull/575/commits/0427afd7182ba470a5c8c5d903ad01ca86e70e69 .
- Verified working by user @rakshazi 