### PR TITLE
Rename "libsyncthing.so" to "syncthing.so" (fixes #589)

### DIFF
--- a/App_build_and_release.cmd
+++ b/App_build_and_release.cmd
@@ -3,36 +3,36 @@ setlocal enabledelayedexpansion
 SET SCRIPT_PATH=%~dps0
 cd /d "%SCRIPT_PATH%"
 cls
-REM 
+REM
 REM Script Consts.
 SET CLEANUP_BEFORE_BUILD=1
 SET SKIP_RELEASE_BUILD=0
 REM
 REM Runtime Variables.
-REM 
+REM
 REM SET SYNCTHING_RELEASE_PLAY_ACCOUNT_CONFIG_FILE=%userprofile%\.android\play_key.json"
 REM SET SYNCTHING_RELEASE_STORE_FILE="%userprofile%\.android\signing_key.jks"
 SET SYNCTHING_RELEASE_KEY_ALIAS=Syncthing-Fork
 title %SYNCTHING_RELEASE_KEY_ALIAS% - Build Debug and Release APK
-REM 
+REM
 SET GIT_INSTALL_DIR=%ProgramFiles%\Git
 SET GIT_BIN="%GIT_INSTALL_DIR%\bin\git.exe"
-REM 
+REM
 SET PATH=C:\Program Files\Android\Android Studio\jre\bin;"%GIT_INSTALL_DIR%\bin";%PATH%
-REM 
+REM
 echo [INFO] Checking if SyncthingNative was built before starting this script ...
 SET LIBCOUNT=
-for /f "tokens=*" %%A IN ('dir /s /a "%SCRIPT_PATH%app\src\main\jniLibs\*" 2^>NUL: ^| find /C "libsyncthing.so"') DO SET LIBCOUNT=%%A
-IF NOT "%LIBCOUNT%" == "4" echo [ERROR] SyncthingNative[s] "libsyncthing.so" are missing. Please run "gradlew buildNative" first. & goto :eos
-REM 
+for /f "tokens=*" %%A IN ('dir /s /a "%SCRIPT_PATH%app\src\main\jniLibs\*" 2^>NUL: ^| find /C "syncthing.so"') DO SET LIBCOUNT=%%A
+IF NOT "%LIBCOUNT%" == "4" echo [ERROR] SyncthingNative[s] "syncthing.so" are missing. Please run "gradlew buildNative" first. & goto :eos
+REM
 REM Check if we should skip the release build and just make a debug build.
 IF "%SKIP_RELEASE_BUILD%" == "1" goto :absLint
 REM
 echo [INFO] Let's prepare a new "%SYNCTHING_RELEASE_KEY_ALIAS%" GPlay release.
-REM 
+REM
 echo [INFO] Checking release prerequisites ...
 IF NOT EXIST "%SYNCTHING_RELEASE_PLAY_ACCOUNT_CONFIG_FILE%" echo [ERROR] SYNCTHING_RELEASE_PLAY_ACCOUNT_CONFIG_FILE env var not set or file does not exist. & goto :eos
-REM 
+REM
 REM User has to enter the signing password if it is not filled in here.
 SET SIGNING_PASSWORD=
 IF DEFINED SIGNING_PASSWORD goto :absLint
@@ -44,21 +44,21 @@ set "psCommand=powershell -Command "$pword = read-host 'Enter signing password' 
 for /f "usebackq delims=" %%p in (`%psCommand%`) do SET SIGNING_PASSWORD=%%p
 setlocal EnableDelayedExpansion
 IF NOT DEFINED SIGNING_PASSWORD echo [ERROR] Signing password is required. Please retry. & goto :enterSigningPassword
-REM 
+REM
 :absLint
-REM 
+REM
 echo [INFO] Running lint before building ...
 call gradlew --quiet lint
 SET RESULT=%ERRORLEVEL%
 IF NOT "%RESULT%" == "0" echo [ERROR] "gradlew lint" exited with code #%RESULT%. & goto :eos
-REM 
+REM
 echo [INFO] Building Android APK variant "debug" ...
 IF "%CLEANUP_BEFORE_BUILD%" == "1" del /f "%SCRIPT_PATH%app\build\outputs\apk\debug\app-debug.apk" 2> NUL:
 call gradlew --quiet assembleDebug
 SET RESULT=%ERRORLEVEL%
 IF NOT "%RESULT%" == "0" echo [ERROR] "gradlew assembleDebug" exited with code #%RESULT%. & goto :eos
 type "app\build\intermediates\merged_manifests\debug\AndroidManifest.xml" | findstr /i "android:version"
-REM 
+REM
 REM Check if we should skip the release build and just make a debug build.
 IF "%SKIP_RELEASE_BUILD%" == "1" goto :absPostBuildScript
 REM
@@ -68,45 +68,45 @@ call gradlew --quiet assembleRelease
 SET RESULT=%ERRORLEVEL%
 IF NOT "%RESULT%" == "0" echo [ERROR] "gradlew assembleRelease" exited with code #%RESULT%. & goto :eos
 type "app\build\intermediates\merged_manifests\release\AndroidManifest.xml" | findstr /i "android:version"
-REM 
+REM
 IF "%CLEANUP_BEFORE_BUILD%" == "1" del /f "%SCRIPT_PATH%app\build\outputs\bundle\release\app-release.aab" 2> NUL:
 echo [INFO] Building Android BUNDLE variant "release" ...
 call gradlew --quiet bundleRelease
 SET RESULT=%ERRORLEVEL%
 IF NOT "%RESULT%" == "0" echo [ERROR] "gradlew bundleRelease" exited with code #%RESULT%. & goto :eos
-REM 
+REM
 :absPostBuildScript
-REM 
+REM
 echo [INFO] Running OPTIONAL post build script ...
 call gradlew --quiet postBuildScript
-REM 
+REM
 echo [INFO] Deleting unsupported play translations ...
 call gradlew --quiet deleteUnsupportedPlayTranslations
 SET RESULT=%ERRORLEVEL%
 IF NOT "%RESULT%" == "0" echo [ERROR] "gradlew deleteUnsupportedPlayTranslations" exited with code #%RESULT%. & goto :eos
-REM 
+REM
 REM Copy build artifacts with correct file name to upload folder.
 call "%SCRIPT_PATH%postbuild_copy_apk.cmd"
-REM 
+REM
 REM Check if we should skip the release upload and finish here.
 IF "%SKIP_RELEASE_BUILD%" == "1" goto :eos
-REM 
+REM
 :askUserReadyToPublish
 SET UI_ANSWER=
 SET /p UI_ANSWER=Are you ready to publish this release to GPlay? [y/n]
 IF NOT "%UI_ANSWER%" == "y" goto :askUserReadyToPublish
-REM 
+REM
 REM Workaround for play-publisher issue, see https://github.com/Triple-T/gradle-play-publisher/issues/597
 :clearPlayPublisherCache
 IF EXIST "app\build\generated\gpp" rd /s /q "app\build\generated\gpp"
 IF EXIST "app\build\generated\gpp" TASKKILL /F /IM java.exe & sleep 1 & goto :clearPlayPublisherCache
-REM 
+REM
 REM Publish text and image resources to GPlay
 echo [INFO] Publishing descriptive resources to GPlay ...
 call gradlew --quiet publishReleaseListing
 SET RESULT=%ERRORLEVEL%
 IF NOT "%RESULT%" == "0" echo [ERROR] "gradlew publishReleaseListing" exited with code #%RESULT%. & goto :eos
-REM 
+REM
 REM Publish APK to GPlay
 echo [INFO] Publishing APK to GPlay ...
 REM call gradlew --quiet publishRelease
@@ -115,13 +115,11 @@ REM IF NOT "%RESULT%" == "0" echo [ERROR] "gradlew publishRelease" exited with c
 call gradlew --quiet publishBundle
 SET RESULT=%ERRORLEVEL%
 IF NOT "%RESULT%" == "0" echo [ERROR] "gradlew publishBundle" exited with code #%RESULT%. & goto :eos
-REM 
+REM
 goto :eos
 :eos
-REM 
+REM
 echo [INFO] End of Script.
 REM
 pause
 goto :eof
-
-

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: MPLv2](https://img.shields.io/badge/License-MPLv2-blue.svg)](https://opensource.org/licenses/MPL-2.0)
 <a href="https://github.com/Catfriend1/syncthing-android/releases" alt="GitHub release"><img src="https://img.shields.io/github/release/Catfriend1/syncthing-android/all.svg" /></a>
 <a href="https://f-droid.org/packages/com.github.catfriend1.syncthingandroid" alt="F-Droid release"><img src="https://img.shields.io/f-droid/v/com.github.catfriend1.syncthingandroid.svg" /></a>
-<a href="https://play.google.com/store/apps/details?id=com.github.catfriend1.syncthingandroid" alt="G-Play release"><img src="https://img.shields.io/badge/g--play-1.3.3.3-blue.svg" /></a>
+<a href="https://play.google.com/store/apps/details?id=com.github.catfriend1.syncthingandroid" alt="G-Play release"><img src="https://img.shields.io/badge/g--play-1.3.3.4-blue.svg" /></a>
 <a href="https://liberapay.com/~1534877" alt="LiberaPay"><img src="https://img.shields.io/liberapay/patrons/Syncthing-Fork.svg?style=social" /></a>
 <a href="https://www.somsubhra.com/github-release-stats/?username=Catfriend1&repository=syncthing-android" alt="GitHub Stats"><img src="https://img.shields.io/github/downloads/Catfriend1/syncthing-android/total.svg" /></a>
 <a href="https://www.youtube.com/watch?v=rYHQzqSjKWQ" alt="Tutorial: Youtube-Video"><img src="https://img.shields.io/badge/Tutorial-Youtube--Video-blueviolet" /></a>

--- a/SyncthingNative_update_and_build.cmd
+++ b/SyncthingNative_update_and_build.cmd
@@ -2,9 +2,9 @@
 setlocal enabledelayedexpansion
 SET SCRIPT_PATH=%~dps0
 cd /d "%SCRIPT_PATH%"
-title Update and Build SyncthingNative "libsyncthing.so"
+title Update and Build SyncthingNative "syncthing.so"
 cls
-REM 
+REM
 REM Script Consts.
 SET CLEAN_BEFORE_BUILD=1
 SET SKIP_CHECKOUT_SRC=0
@@ -16,67 +16,67 @@ REM Runtime Variables.
 SET PATH=%PATH%;"%ProgramFiles%\Git\cmd"
 REM
 echo [INFO] Checking prerequisites ...
-REM 
+REM
 IF NOT EXIST "%ProgramFiles%\Git\cmd\git.exe" echo [ERROR] git not found. Install "Git for Windows" first. Maybe you have to update the path in the batch file. & goto :eos
-REM 
+REM
 where /q sed
 IF NOT "%ERRORLEVEL%" == "0" echo [ERROR] sed.exe not found on PATH. & goto :eos
-REM 
-IF "%CLEAN_BEFORE_BUILD%" == "1" call :cleanBeforeBuild 
-REM 
+REM
+IF "%CLEAN_BEFORE_BUILD%" == "1" call :cleanBeforeBuild
+REM
 IF "%SKIP_CHECKOUT_SRC%" == "1" goto :afterCheckoutSrc
-REM 
+REM
 echo [INFO] Fetching submodule "Syncthing" 1/2 ...
 md "%SCRIPT_PATH%syncthing\src\github.com\syncthing\syncthing" 2> NUL:
 git submodule init
 SET RESULT=%ERRORLEVEL%
 IF NOT "%RESULT%" == "0" echo [ERROR] git submodule init FAILED. & goto :eos
-REM 
+REM
 echo [INFO] Fetching submodule "Syncthing" 2/2 ...
 git submodule update --init --recursive --quiet
 SET RESULT=%ERRORLEVEL%
 IF NOT "%RESULT%" == "0" echo [ERROR] git submodule update FAILED. & goto :eos
-REM 
+REM
 cd /d "%SCRIPT_PATH%syncthing\src\github.com\syncthing\syncthing"
 echo [INFO] Fetching GitHub tags ...
 git fetch --quiet --all
 SET RESULT=%ERRORLEVEL%
 IF NOT "%RESULT%" == "0" echo [ERROR] git fetch FAILED. & goto :eos
-REM 
+REM
 echo [INFO] Checking out syncthing_%DESIRED_SUBMODULE_VERSION% ...
 git checkout %DESIRED_SUBMODULE_VERSION% 2>&1 | find /i "HEAD is now at"
 SET RESULT=%ERRORLEVEL%
 IF NOT "%RESULT%" == "0" echo [ERROR] git checkout FAILED. & goto :eos
-REM 
+REM
 :afterCheckoutSrc
 cd /d "%SCRIPT_PATH%"
 REM
 IF "%USE_GO_DEV%" == "1" call :applyGoDev
-REM 
+REM
 echo [INFO] Building submodule syncthing_%DESIRED_SUBMODULE_VERSION% ...
 call gradlew %GRADLEW_PARAMS% buildNative
 SET RESULT=%ERRORLEVEL%
 IF "%USE_GO_DEV%" == "1" call :revertGoDev
 IF NOT "%RESULT%" == "0" echo [ERROR] gradlew buildNative FAILED. & goto :eos
-REM 
+REM
 echo [INFO] Reverting "go.mod" to checkout state ...
 cd /d "%SCRIPT_PATH%syncthing\src\github.com\syncthing\syncthing"
 git checkout -- go.mod
 cd /d "%SCRIPT_PATH%"
-REM 
+REM
 echo [INFO] Checking if SyncthingNative was built successfully ...
-REM 
+REM
 SET LIBCOUNT=
-for /f "tokens=*" %%A IN ('dir /s /a "%SCRIPT_PATH%app\src\main\jniLibs\*" 2^>NUL: ^| find /C "libsyncthing.so"') DO SET LIBCOUNT=%%A
-IF NOT "%LIBCOUNT%" == "4" echo [ERROR] SyncthingNative[s] "libsyncthing.so" are missing. You should fix that first. & goto :eos
-REM 
+for /f "tokens=*" %%A IN ('dir /s /a "%SCRIPT_PATH%app\src\main\jniLibs\*" 2^>NUL: ^| find /C "syncthing.so"') DO SET LIBCOUNT=%%A
+IF NOT "%LIBCOUNT%" == "4" echo [ERROR] SyncthingNative[s] "syncthing.so" are missing. You should fix that first. & goto :eos
+REM
 goto :eos
 
 :cleanBeforeBuild
-REM 
+REM
 REM Syntax:
 REM 	call :cleanBeforeBuild
-REM 
+REM
 echo [INFO] Performing cleanup ...
 rd /s /q "app\src\main\jniLibs" 2> NUL:
 IF NOT "%SKIP_CHECKOUT_SRC%" == "1" rd /s /q "syncthing\src\github.com\syncthing\syncthing" 2> NUL:
@@ -84,10 +84,10 @@ REM
 goto :eof
 
 :applyGoDev
-REM 
+REM
 REM Syntax:
 REM 	call :applyGoDev
-REM 
+REM
 echo [INFO] Using go-dev instead of go-stable for this build ...
 sed -e "s/GO_EXPECTED_SHASUM_WINDOWS = '2f4849b512fffb2cf2028608aa066cc1b79e730fd146c7b89015797162f08ec5'/GO_EXPECTED_SHASUM_WINDOWS = '2fff556d0adaa6fda8300b0751a91a593c359f27265bc0fc7594f9eba794f907'/g" "syncthing\build-syncthing.py" > "%TEMP%\build-syncthing.py.tmp"
 move /y "%TEMP%\build-syncthing.py.tmp" "syncthing\build-syncthing.py" 1> NUL:
@@ -95,10 +95,10 @@ REM
 goto :eof
 
 :revertGoDev
-REM 
+REM
 REM Syntax:
 REM 	call :revertGoDev
-REM 
+REM
 echo [INFO] Reverting to go-stable ...
 git checkout -- "syncthing\build-syncthing.py"
 SET TMP_RESULT=%ERRORLEVEL%
@@ -107,17 +107,17 @@ REM
 goto :eof
 
 :applyGoDevByCommit
-REM 
+REM
 REM [UNUSED-FUNC]
-REM 
+REM
 REM Syntax:
 REM 	call :applyGoDevByCommit [commit/revert]
-REM 
+REM
 REM Consts.
 SET GO_DEV_COMMIT=032c562105b871c2a77e59e3be3de2ada26a365d
-REM 
+REM
 IF "%1" == "commit" echo [INFO] Using go-dev instead of go-stable for this build ... & git cherry-pick --quiet %GO_DEV_COMMIT% & goto :eof
-REM 
+REM
 REM Revert without leaving a commit on the master.
 SET TMP_GODEV_COMMIT_CNT=0
 for /f "delims= " %%A IN ('git log -1 --pretty^=oneline 2^>^&1 ^| findstr /I /C:"Build with godev"') do SET TMP_GODEV_COMMIT_CNT=1
@@ -130,9 +130,8 @@ REM
 goto :eof
 
 :eos
-REM 
+REM
 echo [INFO] End of Script.
 REM
 pause
 goto :eof
-

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
@@ -13,7 +13,7 @@ public class Constants {
     // Always set ENABLE_TEST_DATA to false before building debug or release APK's.
     public static final Boolean ENABLE_TEST_DATA = false;
 
-    public static final String FILENAME_SYNCTHING_BINARY        = "libsyncthing.so";
+    public static final String FILENAME_SYNCTHING_BINARY        = "syncthing.so";
     public static final String FILENAME_STIGNORE                = ".stignore";
 
     // Preferences - Run conditions

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
@@ -86,7 +86,7 @@ public class SyncthingRunnable implements Runnable {
         ((SyncthingApp) context.getApplicationContext()).component().inject(this);
         ENABLE_VERBOSE_LOG = AppPrefs.getPrefVerboseLog(mPreferences);
         mContext = context;
-        // Example: mSyncthingBinary="/data/app/com.github.catfriend1.syncthingandroid.debug-8HsN-IsVtZXc8GrE5-Hepw==/lib/x86/libsyncthing.so"
+        // Example: mSyncthingBinary="/data/app/com.github.catfriend1.syncthingandroid.debug-8HsN-IsVtZXc8GrE5-Hepw==/lib/x86/syncthing.so"
         mSyncthingBinary = Constants.getSyncthingBinary(mContext);
         mLogFile = Constants.getLogFile(mContext);
 
@@ -286,7 +286,7 @@ public class SyncthingRunnable implements Runnable {
     }
 
     /**
-     * Look for running libsyncthing.so processes and return an array
+     * Look for running syncthing.so processes and return an array
      * containing the PIDs of found instances.
      */
     private List<String> getSyncthingPIDs(Boolean enableLog) {
@@ -335,7 +335,7 @@ public class SyncthingRunnable implements Runnable {
     }
 
     /**
-     * Look for a running libsyncthing.so process and nice its IO.
+     * Look for a running syncthing.so process and nice its IO.
      */
     private void niceSyncthing() {
         if (!mUseRoot) {
@@ -363,7 +363,7 @@ public class SyncthingRunnable implements Runnable {
     }
 
     /**
-     * Look for running libsyncthing.so processes and end them gracefully.
+     * Look for running syncthing.so processes and end them gracefully.
      */
     public void killSyncthing() {
         int exitCode;
@@ -504,7 +504,7 @@ public class SyncthingRunnable implements Runnable {
     }
 
     private Process setupAndLaunch(HashMap<String, String> env) throws IOException, ExecutableNotFoundException {
-        // Check if "libSyncthing.so" exists.
+        // Check if "syncthing.so" exists.
         if (mCommand.length > 0) {
             File libSyncthing = new File(mCommand[0]);
             if (!libSyncthing.exists()) {

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
@@ -608,7 +608,7 @@ public class SyncthingService extends Service {
         Thread.UncaughtExceptionHandler syncthingRunnableThreadExceptionHandler = new Thread.UncaughtExceptionHandler() {
                 public void uncaughtException(Thread syncthingRunnableThread, Throwable ex) {
                     Log.e(TAG, "mSyncthingRunnableThread: Uncaught exception [ExecutableNotFoundException]");
-                    mNotificationHandler.showCrashedNotification(R.string.executable_not_found, "libsyncthing.so");
+                    mNotificationHandler.showCrashedNotification(R.string.executable_not_found, Constants.FILENAME_SYNCTHING_BINARY);
                 }
         };
         mSyncthingRunnableThread = new Thread(mSyncthingRunnable);

--- a/app/src/main/play/release-notes/en-GB/beta.txt
+++ b/app/src/main/play/release-notes/en-GB/beta.txt
@@ -6,6 +6,7 @@
 Fixed
 -
 - SyncthingNative not running on x86_64 arch (#583)
+- Rename "libsyncthing.so" to "syncthing.so" (#590)
 
 Enhanced
 -

--- a/app/versions.gradle
+++ b/app/versions.gradle
@@ -2,5 +2,5 @@ ext {
     versionMajor = 1
     versionMinor = 3
     versionPatch = 3
-    versionWrapper = 3
+    versionWrapper = 4
 }

--- a/syncthing/build-syncthing.py
+++ b/syncthing/build-syncthing.py
@@ -15,6 +15,7 @@ SUPPORTED_PYTHON_PLATFORMS = ['Windows', 'Linux', 'Darwin']
 
 # Leave empty to auto-detect version by 'git describe'.
 FORCE_DISPLAY_SYNCTHING_VERSION = 'v1.3.3-preview.1'
+FILENAME_SYNCTHING_BINARY = 'syncthing.so'
 
 GO_VERSION = '1.13.5'
 GO_EXPECTED_SHASUM_LINUX = '512103d7ad296467814a6e3f635631bd35574cab3369a97a323c9a585ccaa569'
@@ -419,7 +420,7 @@ for target in BUILD_TARGETS:
     target_dir = os.path.join(project_dir, 'app', 'src', 'main', 'jniLibs', target['jni_dir'])
     if not os.path.isdir(target_dir):
         os.makedirs(target_dir)
-    target_artifact = os.path.join(target_dir, 'libsyncthing.so')
+    target_artifact = os.path.join(target_dir, FILENAME_SYNCTHING_BINARY)
     if os.path.exists(target_artifact):
         os.unlink(target_artifact)
     os.rename(os.path.join(syncthing_dir, 'syncthing'), target_artifact)
@@ -430,7 +431,7 @@ print('Copy x86 artifact to x86_64 folder, workaround for issue #583')
 target_dir = os.path.join(project_dir, 'app', 'src', 'main', 'jniLibs', 'x86_64')
 if not os.path.isdir(target_dir):
     os.makedirs(target_dir)
-shutil.copy(os.path.join(project_dir, 'app', 'src', 'main', 'jniLibs', 'x86', 'libsyncthing.so'),
-        os.path.join(target_dir, 'libsyncthing.so'))
+shutil.copy(os.path.join(project_dir, 'app', 'src', 'main', 'jniLibs', 'x86', FILENAME_SYNCTHING_BINARY),
+        os.path.join(target_dir, FILENAME_SYNCTHING_BINARY))
 
 print('All builds finished')

--- a/wiki/SD-card-write-access.md
+++ b/wiki/SD-card-write-access.md
@@ -17,7 +17,7 @@ To sum up:
 
 To ease your technical understanding of the issue and prevent the opening of tickets caused by misunderstandings:
 * Syncthing-Fork consists of two components:
-1. "libSyncthing.so" - A cross-compiled linux binary which we often call "SyncthingNative". It contains all synchronization functionality and carries out everything required to read, transfer and store files.
+1. "syncthing.so" - A cross-compiled linux binary which we often call "SyncthingNative". It contains all synchronization functionality and carries out everything required to read, transfer and store files.
 2. The wrapper which represents the UI. It mainly controls the start and stop of the SyncthingNative binary to save your battery and monitor health of the syncing process.
 
 Android forces SD card access to be read only upon SyncthingNative outside the above mentioned directory paths. People often asked on the issue tracker and forum why the Syncthing-Fork app refrains from asking for SD card directory tree permission using the WRITE_EXTERNAL_STORAGE permission. It might disappoint you, but this was already tried. If the Java app (2.) asks for permission and the user grants it, Android still forces the SD card paths to be accessed read-only by SyncthingNative (1.). This is why we don't ask the user for a directory tree permission like for example file manager 3rd party apps would have done it. File manager apps are technically different from Syncthing because they run as Java code and not as Native code.


### PR DESCRIPTION
Purpose:
- Rename "libsyncthing.so" to "syncthing.so" (fixes #589)

Testing:
- Changed web UI port to 10000 and data port to 20000 in Syncthing-Fork app.
- Installed "Syncthing Android" (official) app and launched it.
- OK - both apps work fine when run in parallel.