### PR TITLE
Show last outgoing file on folder tab (fixes #634)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/service/EventProcessor.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/EventProcessor.java
@@ -214,6 +214,10 @@ public class EventProcessor implements  Runnable, RestApi.OnReceiveEventListener
                     Log.w(TAG, "ItemFinished: Failed to determine folder.path for folder.id=\"" + (TextUtils.isEmpty(folderId) ? "" : folderId) + "\"");
                 }
                 break;
+            case "LocalIndexUpdated":
+                LogV("Event " + event.type + ", data " + event.data);
+                onLocalIndexUpdated(json, (String) event.data.get("folder"), event.time);
+                break;
             case "Ping":
                 // Ignored.
                 break;
@@ -229,7 +233,6 @@ public class EventProcessor implements  Runnable, RestApi.OnReceiveEventListener
             case "FolderWatchStateChanged":
             case "ItemStarted":
             case "ListenAddressesChanged":
-            case "LocalIndexUpdated":
             case "LoginAttempt":
             case "RemoteDownloadProgress":
             case "RemoteIndexUpdated":
@@ -388,6 +391,37 @@ public class EventProcessor implements  Runnable, RestApi.OnReceiveEventListener
                 break;
             default:
                 Log.w(TAG, "onItemFinished: Unhandled action \"" + action + "\"");
+        }
+    }
+
+    private void onLocalIndexUpdated(final JsonElement json,
+                                            final String folderId,
+                                            final String dateTimeStamp) {
+        JsonElement data = ((JsonObject) json).get("data");
+        if (data == null) {
+            Log.e(TAG, "onLocalIndexUpdated: data == null");
+            return;
+        }
+        JsonArray filenames = (JsonArray) ((JsonObject) data).get("filenames");
+        if (filenames == null) {
+            Log.e(TAG, "onLocalIndexUpdated: filenames == null");
+            return;
+        }
+        for (int i = 0; i < filenames.size(); i++) {
+            String filename = ((JsonElement) filenames.get(i)).toString();
+            if (!TextUtils.isEmpty(filename)) {
+                filename = filename.replaceAll("^\"|\"$", "");
+                LogV("onLocalIndexUpdated: filename=[" + filename + "], time=[" + dateTimeStamp + "]");
+                if (i == filenames.size() - 1) {
+                    // Send the last (latest) local change to the UI.
+                    mRestApi.setLocalFolderLastItemFinished(
+                            folderId,
+                            "update",
+                            filename,
+                            dateTimeStamp
+                    );
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Purpose:
- Show last outgoing file on folder tab (fixes #634)

Screenshots:
![image](https://user-images.githubusercontent.com/16361913/79117136-9e1ed100-7d8a-11ea-88b0-4639093a8caf.png)

Log from test:
```
2020-04-13 13:21:40.469 15549-15549/com.github.catfriend1.syncthingandroid.debug V/EventProcessor: Event LocalIndexUpdated, data {filenames=[Camera/IMG_20200413_131047_1.jpg, Camera/IMG_20200413_131048.jpg, Camera/IMG_20200413_131048_1.jpg, Camera/IMG_20200413_130943.jpg, Camera/IMG_20200413_131033.jpg, Camera/IMG_20200413_131034.jpg, Camera/IMG_20200413_131035.jpg, Camera/IMG_20200413_131047.jpg, Camera/IMG_20200413_131049.jpg, Camera/IMG_20200413_131050.jpg, Camera/IMG_20200413_131036.jpg, Camera/IMG_20200413_131053.jpg, Camera/IMG_20200413_131054.jpg], folder=android_sdk_built_for_x86_ej1p-Bilder, items=13.0, version=117.0}
2020-04-13 13:21:40.470 15549-15549/com.github.catfriend1.syncthingandroid.debug V/EventProcessor: onLocalIndexUpdated: filename=[Camera/IMG_20200413_131047_1.jpg], time=[2020-04-13T11:21:36.31285334Z]
2020-04-13 13:21:40.470 15549-15549/com.github.catfriend1.syncthingandroid.debug V/EventProcessor: onLocalIndexUpdated: filename=[Camera/IMG_20200413_131048.jpg], time=[2020-04-13T11:21:36.31285334Z]
2020-04-13 13:21:40.470 15549-15549/com.github.catfriend1.syncthingandroid.debug V/EventProcessor: onLocalIndexUpdated: filename=[Camera/IMG_20200413_131048_1.jpg], time=[2020-04-13T11:21:36.31285334Z]
2020-04-13 13:21:40.471 15549-15549/com.github.catfriend1.syncthingandroid.debug V/EventProcessor: onLocalIndexUpdated: filename=[Camera/IMG_20200413_130943.jpg], time=[2020-04-13T11:21:36.31285334Z]
2020-04-13 13:21:40.471 15549-15549/com.github.catfriend1.syncthingandroid.debug V/EventProcessor: onLocalIndexUpdated: filename=[Camera/IMG_20200413_131033.jpg], time=[2020-04-13T11:21:36.31285334Z]
2020-04-13 13:21:40.471 15549-15549/com.github.catfriend1.syncthingandroid.debug V/EventProcessor: onLocalIndexUpdated: filename=[Camera/IMG_20200413_131034.jpg], time=[2020-04-13T11:21:36.31285334Z]
2020-04-13 13:21:40.471 15549-15549/com.github.catfriend1.syncthingandroid.debug V/EventProcessor: onLocalIndexUpdated: filename=[Camera/IMG_20200413_131035.jpg], time=[2020-04-13T11:21:36.31285334Z]
2020-04-13 13:21:40.472 15549-15549/com.github.catfriend1.syncthingandroid.debug V/EventProcessor: onLocalIndexUpdated: filename=[Camera/IMG_20200413_131047.jpg], time=[2020-04-13T11:21:36.31285334Z]
2020-04-13 13:21:40.472 15549-15549/com.github.catfriend1.syncthingandroid.debug V/EventProcessor: onLocalIndexUpdated: filename=[Camera/IMG_20200413_131049.jpg], time=[2020-04-13T11:21:36.31285334Z]
2020-04-13 13:21:40.473 15549-15549/com.github.catfriend1.syncthingandroid.debug V/EventProcessor: onLocalIndexUpdated: filename=[Camera/IMG_20200413_131050.jpg], time=[2020-04-13T11:21:36.31285334Z]
2020-04-13 13:21:40.474 15549-15549/com.github.catfriend1.syncthingandroid.debug V/EventProcessor: onLocalIndexUpdated: filename=[Camera/IMG_20200413_131036.jpg], time=[2020-04-13T11:21:36.31285334Z]
2020-04-13 13:21:40.474 15549-15549/com.github.catfriend1.syncthingandroid.debug V/EventProcessor: onLocalIndexUpdated: filename=[Camera/IMG_20200413_131053.jpg], time=[2020-04-13T11:21:36.31285334Z]
2020-04-13 13:21:40.475 15549-15549/com.github.catfriend1.syncthingandroid.debug V/EventProcessor: onLocalIndexUpdated: filename=[Camera/IMG_20200413_131054.jpg], time=[2020-04-13T11:21:36.31285334Z]
2020-04-13 13:21:45.538 15549-15549/com.github.catfriend1.syncthingandroid.debug V/EventProcessor: Reading events starting with id 57
```