### PR TITLE
Recent Changes dialog - Filter unnecessary rows (fixes #383)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/DaggerComponent.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/DaggerComponent.java
@@ -7,6 +7,7 @@ import com.nutomic.syncthingandroid.activities.FolderPickerActivity;
 import com.nutomic.syncthingandroid.activities.MainActivity;
 import com.nutomic.syncthingandroid.activities.SettingsActivity;
 import com.nutomic.syncthingandroid.activities.PhotoShootActivity;
+import com.nutomic.syncthingandroid.activities.RecentChangesActivity;
 import com.nutomic.syncthingandroid.activities.ShareActivity;
 import com.nutomic.syncthingandroid.activities.SyncConditionsActivity;
 import com.nutomic.syncthingandroid.fragments.DeviceListFragment;
@@ -41,6 +42,7 @@ public interface DaggerComponent {
     void inject(NotificationHandler notificationHandler);
     void inject(PhotoShootActivity photoShootActivity);
     void inject(RestApi restApi);
+    void inject(RecentChangesActivity recentChangesActivity);
     void inject(RunConditionMonitor runConditionMonitor);
     void inject(SettingsActivity.SettingsFragment fragment);
     void inject(ShareActivity activity);

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/RecentChangesActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/RecentChangesActivity.java
@@ -206,6 +206,14 @@ public class RecentChangesActivity extends SyncthingActivity
 
     private void getTestData(List<DiskEvent> diskEvents) {
         Random random = new Random();
+        /*
+        if (random.nextInt(2) == 0) {
+            diskEvents.clear();
+            return;
+        }
+        */
+
+        int id = 13;
         DiskEvent fakeDiskEvent = new DiskEvent();
         fakeDiskEvent.globalID = 84;
         fakeDiskEvent.type = "RemoteChangeDetected";
@@ -215,29 +223,40 @@ public class RecentChangesActivity extends SyncthingActivity
         fakeDiskEvent.data.modifiedBy = "SRV01";
         fakeDiskEvent.data.type = "file";
 
+        // - "document2.txt"
+        fakeDiskEvent.id = --id;
+        fakeDiskEvent.data.action = "deleted";
+        fakeDiskEvent.data.path = "document2.txt";
+        fakeDiskEvent.time = "2020-04-13T15:01:00.6183215+01:00";
+        addFakeDiskEvent(diskEvents, fakeDiskEvent);
+
+        // + "document2.txt"
+        fakeDiskEvent.id = --id;
+        fakeDiskEvent.data.action = "added";
+        fakeDiskEvent.time = "2020-04-13T15:00:00.6183215+01:00";
+        addFakeDiskEvent(diskEvents, fakeDiskEvent);
+
         // + "document1.txt"
-        fakeDiskEvent.id = 10;
+        fakeDiskEvent.id = --id;
         fakeDiskEvent.data.action = "added";
         fakeDiskEvent.data.path = "document1.txt";
-        fakeDiskEvent.time = "2018-10-29T17:08:" +
-                String.format(Locale.getDefault(), "%02d", random.nextInt(60)) +
-                ".6183215+01:00";
-        diskEvents.add(fakeDiskEvent);
+        fakeDiskEvent.time = "2018-10-29T17:08:00.6183215+01:00";
+        addFakeDiskEvent(diskEvents, fakeDiskEvent);
 
         // - "document1.txt"
-        for (int i = 9; i > 0; i--) {
-            fakeDiskEvent = deepCopy(fakeDiskEvent, new TypeToken<DiskEvent>(){}.getType());
+        for (int i = --id; i > 0; i--) {
             fakeDiskEvent.id = i;
             fakeDiskEvent.data.action = "deleted";
             fakeDiskEvent.time = "2018-10-28T14:08:" +
                     String.format(Locale.getDefault(), "%02d", random.nextInt(60)) +
                     ".6183215+01:00";
-            diskEvents.add(fakeDiskEvent);
+            addFakeDiskEvent(diskEvents, fakeDiskEvent);
         }
+    }
 
-        if (random.nextInt(2) == 0) {
-            diskEvents.clear();
-        }
+    private void addFakeDiskEvent(List<DiskEvent> diskEvents,
+                                        final DiskEvent fakeDiskEvent) {
+        diskEvents.add(deepCopy(fakeDiskEvent, new TypeToken<DiskEvent>(){}.getType()));
     }
 
     /**

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/RecentChangesActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/RecentChangesActivity.java
@@ -217,7 +217,7 @@ public class RecentChangesActivity extends SyncthingActivity
         }
         */
 
-        int id = 8;
+        int id = 11;
         DiskEvent fakeDiskEvent = new DiskEvent();
         fakeDiskEvent.globalID = 84;
         fakeDiskEvent.type = "RemoteChangeDetected";
@@ -225,19 +225,35 @@ public class RecentChangesActivity extends SyncthingActivity
         fakeDiskEvent.data.folderID = "abcd-efgh";
         fakeDiskEvent.data.label = "label_abcd-efgh";
         fakeDiskEvent.data.modifiedBy = "SRV01";
-        fakeDiskEvent.data.type = "file";
+
+        // - "Camera - Copy" folder
+        fakeDiskEvent.id = --id;
+        fakeDiskEvent.data.action = "deleted";
+        fakeDiskEvent.data.path = "Camera - Copy";
+        fakeDiskEvent.data.type = "dir";
+        fakeDiskEvent.time = "2018-10-29T15:18:52.6183215+01:00";
+        addFakeDiskEvent(diskEvents, fakeDiskEvent);
 
         // - "document2.txt"
         fakeDiskEvent.id = --id;
         fakeDiskEvent.data.action = "deleted";
         fakeDiskEvent.data.path = "document2.txt";
+        fakeDiskEvent.data.type = "file";
         fakeDiskEvent.time = "2020-04-13T15:01:00.6183215+01:00";
         addFakeDiskEvent(diskEvents, fakeDiskEvent);
 
-        // + "document2.txt"
+        // + "document2.txt" - to be removed by Pass 2
         fakeDiskEvent.id = --id;
         fakeDiskEvent.data.action = "added";
+        fakeDiskEvent.data.path = "document2.txt";
         fakeDiskEvent.time = "2020-04-13T15:00:00.6183215+01:00";
+        addFakeDiskEvent(diskEvents, fakeDiskEvent);
+
+        // - "Camera - Copy/IMG_20200413_130936.jpg"
+        fakeDiskEvent.id = --id;
+        fakeDiskEvent.data.action = "deleted";
+        fakeDiskEvent.data.path = "Camera - Copy/IMG_20200413_130936.jpg";
+        fakeDiskEvent.time = "2018-10-29T15:18:50.6183215+01:00";
         addFakeDiskEvent(diskEvents, fakeDiskEvent);
 
         // + "document1.txt"
@@ -247,10 +263,25 @@ public class RecentChangesActivity extends SyncthingActivity
         fakeDiskEvent.time = "2018-10-29T17:08:00.6183215+01:00";
         addFakeDiskEvent(diskEvents, fakeDiskEvent);
 
+        // - "Camera - Copy/IMG_20200413_132532.jpg"
+        fakeDiskEvent.id = --id;
+        fakeDiskEvent.data.action = "deleted";
+        fakeDiskEvent.data.path = "Camera - Copy/IMG_20200413_132532.jpg";
+        fakeDiskEvent.time = "2018-10-29T15:18:50.6183215+01:00";
+        addFakeDiskEvent(diskEvents, fakeDiskEvent);
+
+        // - "Camera - Copy/IMG_20200413_132049.jpg"
+        fakeDiskEvent.id = --id;
+        fakeDiskEvent.data.action = "deleted";
+        fakeDiskEvent.data.path = "Camera - Copy/IMG_20200413_132049.jpg";
+        fakeDiskEvent.time = "2018-10-29T15:18:50.6183215+01:00";
+        addFakeDiskEvent(diskEvents, fakeDiskEvent);
+
         // - "document1.txt"
         for (int i = --id; i > 0; i--) {
             fakeDiskEvent.id = i;
             fakeDiskEvent.data.action = "deleted";
+            fakeDiskEvent.data.path = "document1.txt";
             fakeDiskEvent.time = "2018-10-28T14:08:" +
                     String.format(Locale.getDefault(), "%02d", random.nextInt(60)) +
                     ".6183215+01:00";

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/RecentChangesActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/RecentChangesActivity.java
@@ -335,11 +335,11 @@ public class RecentChangesActivity extends SyncthingActivity
                 DiskEvent diskEvent2 = it2.next();
                 if (diskEvent2.id > diskEvent.id) {
                     // diskEvent2 occured after diskEvent.
-                    LogV("removeUselessDiskEvents: Pass 2: curId=" + diskEvent.id + ", foundId=" + diskEvent2.id);
+                    // LogV("removeUselessDiskEvents: Pass 2: curId=" + diskEvent.id + ", foundId=" + diskEvent2.id);
                     if (diskEvent2.data.path.equals(diskEvent.data.path) &&
                             diskEvent.data.action.equals("added") &&
                             diskEvent2.data.action.equals("deleted")) {
-                        Log.d(TAG, "removeUselessDiskEvents: Pass 2: Removing \"added\" event because file was deleted afterwards, path=[" + diskEvent.data.path + "]");
+                        LogV("removeUselessDiskEvents: Pass 2: Removing \"added\" event because file was deleted afterwards, path=[" + diskEvent.data.path + "]");
                         it.remove();
                         break;
                     }
@@ -358,11 +358,11 @@ public class RecentChangesActivity extends SyncthingActivity
                 DiskEvent diskEvent2 = it2.next();
                 if (diskEvent2.id > diskEvent.id) {
                     // diskEvent2 occured after diskEvent.
-                    LogV("removeUselessDiskEvents: Pass 3: curId=" + diskEvent.id + ", foundId=" + diskEvent2.id);
+                    // LogV("removeUselessDiskEvents: Pass 3: curId=" + diskEvent.id + ", foundId=" + diskEvent2.id);
                     if (diskEvent2.data.type.equals("dir") &&
                             diskEvent2.data.action.equals("deleted") &&
                             diskEvent.data.path.startsWith(diskEvent2.data.path + "/")) {
-                        Log.d(TAG, "removeUselessDiskEvents: Pass 3: Removing event because folder was deleted afterwards, path=[" + diskEvent.data.path + "]");
+                        LogV("removeUselessDiskEvents: Pass 3: Removing event because folder was deleted afterwards, path=[" + diskEvent.data.path + "]");
                         it.remove();
                         break;
                     }

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/RecentChangesActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/RecentChangesActivity.java
@@ -350,7 +350,7 @@ public class RecentChangesActivity extends SyncthingActivity
         /**
          * Pass 3
          * Check if a folder has been removed.
-         * We can remove prior file events corresponding to the folder.
+         * We can remove prior events corresponding to the folder.
          */
         for (Iterator<DiskEvent> it = diskEvents.iterator(); it.hasNext();) {
             DiskEvent diskEvent = it.next();

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/RecentChangesActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/RecentChangesActivity.java
@@ -217,6 +217,12 @@ public class RecentChangesActivity extends SyncthingActivity
         }
         */
 
+        /**
+         * Items on UI without "removeUselessDiskEvents"
+         *  10
+         * Items on UI after "removeUselessDiskEvents"
+         *  6
+         */
         int id = 11;
         DiskEvent fakeDiskEvent = new DiskEvent();
         fakeDiskEvent.globalID = 84;
@@ -249,7 +255,7 @@ public class RecentChangesActivity extends SyncthingActivity
         fakeDiskEvent.time = "2020-04-13T15:00:00.6183215+01:00";
         addFakeDiskEvent(diskEvents, fakeDiskEvent);
 
-        // - "Camera - Copy/IMG_20200413_130936.jpg"
+        // - "Camera - Copy/IMG_20200413_130936.jpg" - to be removed by Pass 3
         fakeDiskEvent.id = --id;
         fakeDiskEvent.data.action = "deleted";
         fakeDiskEvent.data.path = "Camera - Copy/IMG_20200413_130936.jpg";
@@ -263,14 +269,14 @@ public class RecentChangesActivity extends SyncthingActivity
         fakeDiskEvent.time = "2018-10-29T17:08:00.6183215+01:00";
         addFakeDiskEvent(diskEvents, fakeDiskEvent);
 
-        // - "Camera - Copy/IMG_20200413_132532.jpg"
+        // - "Camera - Copy/IMG_20200413_132532.jpg" - to be removed by Pass 3
         fakeDiskEvent.id = --id;
         fakeDiskEvent.data.action = "deleted";
         fakeDiskEvent.data.path = "Camera - Copy/IMG_20200413_132532.jpg";
         fakeDiskEvent.time = "2018-10-29T15:18:50.6183215+01:00";
         addFakeDiskEvent(diskEvents, fakeDiskEvent);
 
-        // - "Camera - Copy/IMG_20200413_132049.jpg"
+        // - "Camera - Copy/IMG_20200413_132049.jpg" - to be removed by Pass 3
         fakeDiskEvent.id = --id;
         fakeDiskEvent.data.action = "deleted";
         fakeDiskEvent.data.path = "Camera - Copy/IMG_20200413_132049.jpg";
@@ -323,6 +329,29 @@ public class RecentChangesActivity extends SyncthingActivity
                             diskEvent.data.action.equals("added") &&
                             diskEvent2.data.action.equals("deleted")) {
                         Log.d(TAG, "removeUselessDiskEvents: Pass 2: Removing \"added\" event because file was deleted afterwards, path=[" + diskEvent.data.path + "]");
+                        it.remove();
+                        break;
+                    }
+                }
+            }
+        }
+
+        /**
+         * Pass 3
+         * Check if a folder has been removed.
+         * We can remove prior file events corresponding to the folder.
+         */
+        for (Iterator<DiskEvent> it = diskEvents.iterator(); it.hasNext();) {
+            DiskEvent diskEvent = it.next();
+            for (Iterator<DiskEvent> it2 = diskEvents.iterator(); it2.hasNext();) {
+                DiskEvent diskEvent2 = it2.next();
+                if (diskEvent2.id > diskEvent.id) {
+                    // diskEvent2 occured after diskEvent.
+                    Log.v(TAG, "removeUselessDiskEvents: Pass 3: curId=" + diskEvent.id + ", foundId=" + diskEvent2.id);
+                    if (diskEvent2.data.type.equals("dir") &&
+                            diskEvent2.data.action.equals("deleted") &&
+                            diskEvent.data.path.startsWith(diskEvent2.data.path + "/")) {
+                        Log.d(TAG, "removeUselessDiskEvents: Pass 3: Removing event because folder was deleted afterwards, path=[" + diskEvent.data.path + "]");
                         it.remove();
                         break;
                     }

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/RecentChangesActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/RecentChangesActivity.java
@@ -67,11 +67,11 @@ public class RecentChangesActivity extends SyncthingActivity
             new ItemClickListener() {
                 @Override
                 public void onItemClick(DiskEvent diskEvent) {
-                    Log.v(TAG, "User clicked item with title \'" + diskEvent.data.path + "\'");
                     switch (diskEvent.data.action) {
                         case "deleted":
                             return;
                     }
+                    Log.v(TAG, "User clicked item with title \'" + diskEvent.data.path + "\'");
                     if (mServiceState != SyncthingService.State.ACTIVE) {
                         return;
                     }

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/RecentChangesActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/RecentChangesActivity.java
@@ -180,32 +180,7 @@ public class RecentChangesActivity extends SyncthingActivity
         }
 
         if (ENABLE_TEST_DATA) {
-            DiskEvent fakeDiskEvent = new DiskEvent();
-            fakeDiskEvent.id = 10;
-            fakeDiskEvent.globalID = 84;
-            fakeDiskEvent.time = "2018-10-28T14:08:" +
-                    String.format(Locale.getDefault(), "%02d", new Random().nextInt(60)) +
-                    ".6183215+01:00";
-            fakeDiskEvent.type = "RemoteChangeDetected";
-            fakeDiskEvent.data.action = "added";
-            fakeDiskEvent.data.folder = "abcd-efgh";
-            fakeDiskEvent.data.folderID = "abcd-efgh";
-            fakeDiskEvent.data.label = "label_abcd-efgh";
-            fakeDiskEvent.data.modifiedBy = "SRV01";
-            fakeDiskEvent.data.path = "document1.txt";
-            fakeDiskEvent.data.type = "file";
-            diskEvents.add(fakeDiskEvent);
-
-            for (int i = 9; i > 0; i--) {
-                fakeDiskEvent = deepCopy(fakeDiskEvent, new TypeToken<DiskEvent>(){}.getType());
-                fakeDiskEvent.id = i;
-                fakeDiskEvent.data.action = "deleted";
-                diskEvents.add(fakeDiskEvent);
-            }
-
-            if (new Random().nextInt(2) == 0) {
-                diskEvents.clear();
-            }
+            getTestData(diskEvents);
         }
 
         // Show text if the list is empty.
@@ -227,6 +202,42 @@ public class RecentChangesActivity extends SyncthingActivity
             }
         }
         mRecentChangeAdapter.notifyDataSetChanged();
+    }
+
+    private void getTestData(List<DiskEvent> diskEvents) {
+        Random random = new Random();
+        DiskEvent fakeDiskEvent = new DiskEvent();
+        fakeDiskEvent.globalID = 84;
+        fakeDiskEvent.type = "RemoteChangeDetected";
+        fakeDiskEvent.data.folder = "abcd-efgh";
+        fakeDiskEvent.data.folderID = "abcd-efgh";
+        fakeDiskEvent.data.label = "label_abcd-efgh";
+        fakeDiskEvent.data.modifiedBy = "SRV01";
+        fakeDiskEvent.data.type = "file";
+
+        // + "document1.txt"
+        fakeDiskEvent.id = 10;
+        fakeDiskEvent.data.action = "added";
+        fakeDiskEvent.data.path = "document1.txt";
+        fakeDiskEvent.time = "2018-10-29T17:08:" +
+                String.format(Locale.getDefault(), "%02d", random.nextInt(60)) +
+                ".6183215+01:00";
+        diskEvents.add(fakeDiskEvent);
+
+        // - "document1.txt"
+        for (int i = 9; i > 0; i--) {
+            fakeDiskEvent = deepCopy(fakeDiskEvent, new TypeToken<DiskEvent>(){}.getType());
+            fakeDiskEvent.id = i;
+            fakeDiskEvent.data.action = "deleted";
+            fakeDiskEvent.time = "2018-10-28T14:08:" +
+                    String.format(Locale.getDefault(), "%02d", random.nextInt(60)) +
+                    ".6183215+01:00";
+            diskEvents.add(fakeDiskEvent);
+        }
+
+        if (random.nextInt(2) == 0) {
+            diskEvents.clear();
+        }
     }
 
     /**

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
@@ -11,7 +11,7 @@ import java.util.concurrent.TimeUnit;
 public class Constants {
 
     // Always set ENABLE_TEST_DATA to false before building debug or release APK's.
-    public static final Boolean ENABLE_TEST_DATA = true;
+    public static final Boolean ENABLE_TEST_DATA = false;
 
     public static final String FILENAME_SYNCTHING_BINARY        = "libsyncthingnative.so";
     public static final String FILENAME_STIGNORE                = ".stignore";

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
@@ -11,7 +11,7 @@ import java.util.concurrent.TimeUnit;
 public class Constants {
 
     // Always set ENABLE_TEST_DATA to false before building debug or release APK's.
-    public static final Boolean ENABLE_TEST_DATA = false;
+    public static final Boolean ENABLE_TEST_DATA = true;
 
     public static final String FILENAME_SYNCTHING_BINARY        = "libsyncthingnative.so";
     public static final String FILENAME_STIGNORE                = ".stignore";


### PR DESCRIPTION
Purpose:
- Recent Changes dialog - Filter unnecessary rows (fixes #383)

Screenshots:
- Case 1 --> PASS2 clears "added" events if a "delete" event came afterwards
![image](https://user-images.githubusercontent.com/16361913/79118921-69f9df00-7d8f-11ea-933d-2c1e0bf44d97.png)
![image](https://user-images.githubusercontent.com/16361913/79122991-62d7ce80-7d99-11ea-95dd-e6d8bfc2fe1d.png)

- Case 2 --> PASS 3 clears file/folder events if a folder above delete event is found afterwards
![image](https://user-images.githubusercontent.com/16361913/79126144-ac2b1c80-7d9f-11ea-9d7a-3b3842bb089e.png)
```
2020-04-13 15:57:56.385 23030-23030/com.github.catfriend1.syncthingandroid.debug V/RecentChangesActivity: onServiceStateChange(ACTIVE)
2020-04-13 15:57:56.389 23030-23030/com.github.catfriend1.syncthingandroid.debug V/RecentChangesActivity: Querying disk events
2020-04-13 15:57:56.394 23030-23030/com.github.catfriend1.syncthingandroid.debug V/RecentChangesActivity: onReceiveDiskEvents
2020-04-13 15:57:56.416 23030-23030/com.github.catfriend1.syncthingandroid.debug V/RecentChangesActivity: removeUselessDiskEvents: Pass 2: Removing "added" event because file was deleted afterwards, path=[document2.txt]
2020-04-13 15:57:56.416 23030-23030/com.github.catfriend1.syncthingandroid.debug V/RecentChangesActivity: removeUselessDiskEvents: Pass 3: Removing event because folder was deleted afterwards, path=[Camera - Copy/IMG_20200413_130936.jpg]
2020-04-13 15:57:56.416 23030-23030/com.github.catfriend1.syncthingandroid.debug V/RecentChangesActivity: removeUselessDiskEvents: Pass 3: Removing event because folder was deleted afterwards, path=[Camera - Copy/IMG_20200413_132532.jpg]
2020-04-13 15:57:56.417 23030-23030/com.github.catfriend1.syncthingandroid.debug V/RecentChangesActivity: removeUselessDiskEvents: Pass 3: Removing event because folder was deleted afterwards, path=[Camera - Copy/IMG_20200413_132049.jpg]
```