### PR TITLE
Use FragmentContainerView instead of the <fragment> tag (fixes #647)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     implementation 'com.android.volley:volley:1.1.1'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'androidx.documentfile:documentfile:1.0.1'
+    implementation "androidx.fragment:fragment:1.2.4"
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
     implementation "androidx.preference:preference:1.1.1"
     implementation 'com.google.dagger:dagger:2.26'

--- a/app/src/main/java/com/nutomic/syncthingandroid/fragments/NumberPickerFragment.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/fragments/NumberPickerFragment.java
@@ -28,10 +28,16 @@ public class NumberPickerFragment extends Fragment {
     }
 
     public void setOnValueChangedListener(NumberPicker.OnValueChangeListener onValueChangeListener){
+        if (mNumberPicker == null) {
+            return;
+        }
         mNumberPicker.setOnValueChangedListener(onValueChangeListener);
     }
 
     public void updateNumberPicker(int maxValue, int minValue, int currentValue){
+        if (mNumberPicker == null) {
+            return;
+        }
         mNumberPicker.setMaxValue(maxValue);
         mNumberPicker.setMinValue(minValue);
         mNumberPicker.setValue(currentValue);

--- a/app/src/main/res/layout/fragment_trashcan_versioning.xml
+++ b/app/src/main/res/layout/fragment_trashcan_versioning.xml
@@ -27,13 +27,14 @@
             android:layout_margin="10dp"
             android:textStyle="bold"/>
 
-        <fragment
+        <androidx.fragment.app.FragmentContainerView
             android:id="@+id/fragment"
             android:name="com.nutomic.syncthingandroid.fragments.NumberPickerFragment"
             android:layout_width="match_parent"
             android:layout_height="100dp"
             android:tag="numberpicker_trashcan_versioning"
-            tools:layout="@layout/numberpicker_fragment" />
+            tools:layout="@layout/numberpicker_fragment">
+        </androidx.fragment.app.FragmentContainerView>
 
         <TextView
             android:layout_width="match_parent"


### PR DESCRIPTION
Purpose:
- Use FragmentContainerView instead of the <fragment> tag (fixes #647)