### PR TITLE
model: Update [folder]/[versioning] for compatibility with Syncthing v1.8.0

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
@@ -706,6 +706,7 @@ public class FolderActivity extends SyncthingActivity {
         mFolder.versioning = new Folder.Versioning();
         mFolder.versioning.type = "trashcan";
         mFolder.versioning.params.put("cleanoutDays", Integer.toString(14));
+        mFolder.versioning.cleanupIntervalS = 0;
     }
 
     private void addEmptyDeviceListView() {

--- a/app/src/main/java/com/nutomic/syncthingandroid/model/Folder.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/model/Folder.java
@@ -69,6 +69,7 @@ public class Folder {
 
     public static class Versioning implements Serializable {
         public String type;
+        public int cleanupIntervalS;
         public Map<String, String> params = new HashMap<>();
     }
 

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/ConfigXml.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/ConfigXml.java
@@ -517,12 +517,14 @@ public class ConfigXml {
             <versioning></versioning>
             <versioning type="trashcan">
                 <param key="cleanoutDays" val="90"></param>
+                <cleanupIntervalS>0</cleanupIntervalS>
             </versioning>
             */
             folder.versioning = new Folder.Versioning();
             Element elementVersioning = (Element) r.getElementsByTagName("versioning").item(0);
             if (elementVersioning != null) {
                 folder.versioning.type = getAttributeOrDefault(elementVersioning, "type", "");
+                folder.versioning.cleanupIntervalS = getAttributeOrDefault(elementVersioning, "cleanupIntervalS", 0);
                 NodeList nodeVersioningParam = elementVersioning.getElementsByTagName("param");
                 for (int j = 0; j < nodeVersioningParam.getLength(); j++) {
                     Element elementVersioningParam = (Element) nodeVersioningParam.item(j);
@@ -628,13 +630,6 @@ public class ConfigXml {
 
                 // Versioning
                 // Pass 1: Remove all versioning nodes from XML (usually one)
-                /*
-                NodeList nlVersioning = r.getElementsByTagName("versioning");
-                for (int j = nlVersioning.getLength() - 1; j >= 0; j--) {
-                    Log.v(TAG, "updateFolder: nodeVersioning: Removing versioning node");
-                    removeChildElementFromTextNode(r, (Element) nlVersioning.item(j));
-                }
-                */
                 Element elementVersioning = (Element) r.getElementsByTagName("versioning").item(0);
                 if (elementVersioning != null) {
                     Log.d(TAG, "updateFolder: nodeVersioning: Removing versioning node");
@@ -647,6 +642,7 @@ public class ConfigXml {
                 elementVersioning = (Element) nodeVersioning;
                 if (!TextUtils.isEmpty(folder.versioning.type)) {
                     elementVersioning.setAttribute("type", folder.versioning.type);
+                    elementVersioning.setAttribute("cleanupIntervalS", Integer.toString(folder.versioning.cleanupIntervalS));
                     for (Map.Entry<String, String> param : folder.versioning.params.entrySet()) {
                         Log.d(TAG, "updateFolder: nodeVersioning: Adding param key=" + param.getKey() + ", val=" + param.getValue());
                         Node nodeParam = mConfig.createElement("param");
@@ -1360,6 +1356,7 @@ public class ConfigXml {
         folder.versioning = new Folder.Versioning();
         folder.versioning.type = "trashcan";
         folder.versioning.params.put("cleanoutDays", Integer.toString(14));
+        folder.versioning.cleanupIntervalS = 0;
 
         // Add folder to config.
         LogV("addSyncthingCameraFolder: Adding folder to config ...");


### PR DESCRIPTION
Purpose:
- model: Update [folder]/[versioning] for compatibility with Syncthing v1.8.0

Upstream:
- https://github.com/syncthing/syncthing/pull/6834

Notes:
- This will not expose the "cleanupIntervalS" on the wrapper UI. If you'd like to edit, head to SyncthingNative's Web UI and change it. The wrapper will preserve it with this PR.

Testing:
- Verified working on AVD 9

Screenshots:
![image](https://user-images.githubusercontent.com/16361913/89930141-8eb17680-dc0a-11ea-8a5f-55c35ab20a22.png)
