### PR TITLE
model: Add [folder]/copyRangeMethod for compatibility with Syncthing v1.8.0 (fixes #674)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/model/Folder.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/model/Folder.java
@@ -64,6 +64,10 @@ public class Folder {
     // see PR #6573
     public int maxConcurrentWrites = 2;
 
+    // Since v1.8.0
+    // see PR #6746: "all", "copy_file_range", "duplicate_extents", "ioctl", "sendfile", "standard"
+    public String copyRangeMethod = "standard";
+
     // Folder Status
     public String invalid;
 

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/ConfigXml.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/ConfigXml.java
@@ -481,6 +481,7 @@ public class ConfigXml {
             folder.blockPullOrder = getContentOrDefault(r.getElementsByTagName("blockPullOrder").item(0), folder.blockPullOrder);
             folder.disableFsync = getContentOrDefault(r.getElementsByTagName("disableFsync").item(0), folder.disableFsync);
             folder.maxConcurrentWrites = getContentOrDefault(r.getElementsByTagName("maxConcurrentWrites").item(0), folder.maxConcurrentWrites);
+            folder.copyRangeMethod = getContentOrDefault(r.getElementsByTagName("copyRangeMethod").item(0), folder.copyRangeMethod);
 
             // Devices
             /*
@@ -585,6 +586,7 @@ public class ConfigXml {
                 setConfigElement(r, "blockPullOrder", folder.blockPullOrder);
                 setConfigElement(r, "disableFsync", Boolean.toString(folder.disableFsync));
                 setConfigElement(r, "maxConcurrentWrites", Integer.toString(folder.maxConcurrentWrites));
+                setConfigElement(r, "copyRangeMethod", folder.copyRangeMethod);
 
                 // Update devices that share this folder.
                 // Pass 1: Remove all devices below that folder in XML except the local device.


### PR DESCRIPTION
Purpose:
- model: Add [folder]/copyRangeMethod for compatibility with Syncthing v1.8.0

Ref.:
- syncthing/syncthing#6746