### PR TITLE
RecentChangesDialog: Encode "#" character so Uri.parse works correctly (fixes #651)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/RecentChangesActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/RecentChangesActivity.java
@@ -276,7 +276,7 @@ public class RecentChangesActivity extends SyncthingActivity
         // + "document1.txt"
         fakeDiskEvent.id = --id;
         fakeDiskEvent.data.action = "added";
-        fakeDiskEvent.data.path = "#document1.txt";
+        fakeDiskEvent.data.path = "document1.txt";
         fakeDiskEvent.time = "2018-10-29T17:08:00.6183215+01:00";
         addFakeDiskEvent(diskEvents, fakeDiskEvent);
 

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/RecentChangesActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/RecentChangesActivity.java
@@ -276,7 +276,7 @@ public class RecentChangesActivity extends SyncthingActivity
         // + "document1.txt"
         fakeDiskEvent.id = --id;
         fakeDiskEvent.data.action = "added";
-        fakeDiskEvent.data.path = "document1.txt";
+        fakeDiskEvent.data.path = "#document1.txt";
         fakeDiskEvent.time = "2018-10-29T17:08:00.6183215+01:00";
         addFakeDiskEvent(diskEvents, fakeDiskEvent);
 

--- a/app/src/main/java/com/nutomic/syncthingandroid/views/ChangeListAdapter.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/views/ChangeListAdapter.java
@@ -91,8 +91,11 @@ public class ChangeListAdapter extends RecyclerView.Adapter<ChangeListAdapter.Vi
     public void onBindViewHolder(ViewHolder viewHolder, final int position) {
         DiskEvent diskEvent = mChangeData.get(position);
 
+        // Encode "#" character so Uri.parse can handle it. See issue syncthing-android/651
+        String uriParsePathInput = diskEvent.data.path.replace("#", Uri.encode("#"));
+
         // Separate path and filename.
-        Uri uri = Uri.parse(diskEvent.data.path);
+        Uri uri = Uri.parse(uriParsePathInput);
         String filename = uri.getLastPathSegment();
         String path = getPathFromFullFN(diskEvent.data.path);
 


### PR DESCRIPTION
Purpose:
- 

Testing:
- Verified working on AVD 9

Screenshot:
![image](https://user-images.githubusercontent.com/16361913/89933920-151c8700-dc10-11ea-8834-8e0d9e60f5da.png)
