### PR TITLE
Welcome assistant: Proceed to next slide if permissions were granted

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FirstStartActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FirstStartActivity.java
@@ -581,6 +581,7 @@ public class FirstStartActivity extends AppCompatActivity {
                     Toast.makeText(this, R.string.permission_granted, Toast.LENGTH_SHORT).show();
                     Log.i(TAG, "User granted ACCESS_COARSE_LOCATION permission.");
                     mNextButton.requestFocus();
+                    onBtnNextClick();
                 }
                 break;
             case REQUEST_BACKGROUND_LOCATION:
@@ -591,6 +592,7 @@ public class FirstStartActivity extends AppCompatActivity {
                     Toast.makeText(this, R.string.permission_granted, Toast.LENGTH_SHORT).show();
                     Log.i(TAG, "User granted ACCESS_BACKGROUND_LOCATION permission.");
                     mNextButton.requestFocus();
+                    onBtnNextClick();
                 }
                 break;
             case REQUEST_FINE_LOCATION:
@@ -621,8 +623,10 @@ public class FirstStartActivity extends AppCompatActivity {
                     Log.i(TAG, "User granted WRITE_EXTERNAL_STORAGE permission.");
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                         requestAllFilesAccessPermission();
+                        mNextButton.requestFocus();
+                        return;
                     }
-                    mNextButton.requestFocus();
+                    onBtnNextClick();
                 }
                 break;
             default:

--- a/app/src/main/play/release-notes/en-GB/beta.txt
+++ b/app/src/main/play/release-notes/en-GB/beta.txt
@@ -9,3 +9,4 @@ Enhanced
 --
 - Always show all actions in the menu
 - Removed unnecessary restarts (#698)
+- Welcome assistant: Proceed to next slide if permissions were granted (#701)


### PR DESCRIPTION
Purpose:
- Welcome assistant: Proceed to next slide if permissions were granted
- There's no need to let the user click "Next" after he read and accepted the permission already. = "no double work"

Testing:
- Verified working on AVD 9, 10, 11
