### PR TITLE
Update a link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A wrapper of [Syncthing](https://github.com/syncthing/syncthing) for Android. He
 - Android 8 to 11 support.
 
 # Privacy Policy
-See our document on privacy: [privacy-policy.md](https://github.com/Catfriend1/syncthing-android/blob/master/privacy-policy.md).
+See our document on privacy: [privacy-policy.md](https://github.com/Catfriend1/syncthing-android/blob/main/privacy-policy.md).
 
 # Goal of the forked version
 - Develop and try out enhancements together


### PR DESCRIPTION
Update a broken link which pointed to the master branch but we use main instead now.

We were actually able to access the right file since GitHub would detect master branch was missing and automatically redirect to the main branch, but a correct link would be better still.