### PR TITLE
Make Syncthing Camera open on Android 11 (fixes #785)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -256,4 +256,10 @@
         </service>
     </application>
 
+    <queries>
+        <intent>
+            <action android:name="android.media.action.IMAGE_CAPTURE" />
+        </intent>
+    </queries>
+
 </manifest>

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/PhotoShootActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/PhotoShootActivity.java
@@ -152,6 +152,11 @@ public class PhotoShootActivity extends AppCompatActivity {
         Intent pictureIntent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
         if (pictureIntent.resolveActivity(getPackageManager()) == null) {
             Log.e(TAG, "This system does not support the ACTION_IMAGE_CAPTURE intent.");
+            Toast.makeText(
+                    PhotoShootActivity.this,
+                    "This system does not support the ACTION_IMAGE_CAPTURE intent.", Toast.LENGTH_LONG
+            ).show();
+            finish();
             return;
         }
 


### PR DESCRIPTION
Purpose:
- Make Syncthing Camera open on Android 11 (fixes #785)
- 