### PR TITLE
Hide notification from lock screen (fixes #790)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/service/NotificationHandler.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/NotificationHandler.java
@@ -60,6 +60,7 @@ public class NotificationHandler {
             mPersistentChannel.enableVibration(false);
             mPersistentChannel.setSound(null, null);
             mPersistentChannel.setShowBadge(false);
+            mPersistentChannel.setLockscreenVisibility(NotificationCompat.VISIBILITY_SECRET);
             mNotificationManager.createNotificationChannel(mPersistentChannel);
 
             mPersistentChannelWaiting = new NotificationChannel(
@@ -69,6 +70,7 @@ public class NotificationHandler {
             mPersistentChannelWaiting.enableVibration(false);
             mPersistentChannelWaiting.setSound(null, null);
             mPersistentChannelWaiting.setShowBadge(false);
+            mPersistentChannel.setLockscreenVisibility(NotificationCompat.VISIBILITY_SECRET);
             mNotificationManager.createNotificationChannel(mPersistentChannelWaiting);
 
             mInfoChannel = new NotificationChannel(


### PR DESCRIPTION
Purpose:
- Hide notification from lock screen (fixes #790)

Retains "crash" and "consent" notifications on lock screen while hiding the "running/sleeping" notifications.

![image](https://user-images.githubusercontent.com/16361913/118404487-63fdbe00-b673-11eb-8f2e-d6684f56bb84.png)

![image](https://user-images.githubusercontent.com/16361913/118404488-6829db80-b673-11eb-950d-5109e7a3a19e.png)
