### PR TITLE
Acquire MulticastLock for local discovery to work on Android 11 (fixes #735)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,6 +33,8 @@
     <uses-permission android:name="android.permission.CAMERA" />
     <!-- MANAGE_EXTERNAL_STORAGE is required on Android 11 "R" -->
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
+    <!-- CHANGE_WIFI_MULTICAST_STATE is required for local discovery to work on Android 11 "R" -->
+    <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE"/>
 
     <application
         android:allowBackup="false"

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
@@ -160,6 +160,7 @@ public class SyncthingRunnable implements Runnable {
             );
         }
 
+        MulticastLock multicastLock = null;
         Process process = null;
         try {
             if (wakeLock != null) {
@@ -168,7 +169,7 @@ public class SyncthingRunnable implements Runnable {
 
             // See issue #735: Android 11 blocks local discovery if we did not acquire MulticastLock.
             WifiManager wifi = (WifiManager) mContext.getSystemService(Context.WIFI_SERVICE);
-            MulticastLock multicastLock = wifi.createMulticastLock("multicastLock");
+            multicastLock = wifi.createMulticastLock("multicastLock");
             multicastLock.setReferenceCounted(true);
             multicastLock.acquire();
 

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
@@ -168,7 +168,7 @@ public class SyncthingRunnable implements Runnable {
             }
 
             // See issue #735: Android 11 blocks local discovery if we did not acquire MulticastLock.
-            WifiManager wifi = (WifiManager) mContext.getSystemService(Context.WIFI_SERVICE);
+            WifiManager wifi = (WifiManager) mContext.getApplicationContext().getSystemService(Context.WIFI_SERVICE);
             multicastLock = wifi.createMulticastLock("multicastLock");
             multicastLock.setReferenceCounted(true);
             multicastLock.acquire();


### PR DESCRIPTION
Purpose:
- Acquire MulticastLock for local discovery to work on Android 11 (fixes #735)

Solution:
- https://stackoverflow.com/questions/13221736/android-device-not-receiving-multicast-package