### PR TITLE
Android 11: keep synced user data when app is uninstalled and reinstalled (fixes #802)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -50,6 +50,7 @@
         android:hardwareAccelerated="true"
         android:requestLegacyExternalStorage="true"
         android:preserveLegacyExternalStorage="true"
+        android:hasFragileUserData="true"
 
         android:networkSecurityConfig="@xml/network_security_config">
         <activity

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/FileUtils.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/FileUtils.java
@@ -180,7 +180,7 @@ public class FileUtils {
              * e.g. "/storage/abcd-efgh/Android/[PACKAGE_NAME]/files"
              */
             ArrayList<File> externalFilesDir = new ArrayList<>();
-            switch(extDirType ){
+            switch(extDirType){
                 case DATA:
                     externalFilesDir.addAll(Arrays.asList(context.getExternalFilesDirs(null)));
                     externalFilesDir.remove(context.getExternalFilesDir(null));


### PR DESCRIPTION
Purpose:
- Keep synced user data on uninstall (and possible reinstall) (fixes #802)

Screenshots:
![image](https://user-images.githubusercontent.com/16361913/119537035-f09e2f80-bd89-11eb-9354-2bc98901f855.png)
