### PR TITLE
PhotoShootActivity: Move getExternalFilesDir to FileUtils (fixes #759)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FirstStartActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FirstStartActivity.java
@@ -40,6 +40,8 @@ import com.nutomic.syncthingandroid.SyncthingApp;
 import com.nutomic.syncthingandroid.service.Constants;
 import com.nutomic.syncthingandroid.service.SyncthingRunnable.ExecutableNotFoundException;
 import com.nutomic.syncthingandroid.util.ConfigXml;
+import com.nutomic.syncthingandroid.util.FileUtils;
+import com.nutomic.syncthingandroid.util.FileUtils.ExternalStorageDirType;
 import com.nutomic.syncthingandroid.util.Util;
 import com.nutomic.syncthingandroid.views.CustomViewPager;
 
@@ -396,20 +398,15 @@ public class FirstStartActivity extends AppCompatActivity {
                     @Override
                     public void onClick(View v) {
                         // Get app specific /Android/media directory.
-                        ArrayList<File> externalFilesDir = new ArrayList<>();
-                        externalFilesDir.addAll(Arrays.asList(getExternalMediaDirs()));
-                        if (externalFilesDir.size() > 0) {
-                            externalFilesDir.remove(externalFilesDir.get(0));
-                        }
-                        externalFilesDir.remove(null);      // getExternalFilesDirs may return null for an ejected SDcard.
-                        if (externalFilesDir.size() == 0) {
+                        File externalFilesDir = FileUtils.getExternalFilesDir(FirstStartActivity.this, ExternalStorageDirType.MEDIA, null);
+                        if (externalFilesDir == null) {
                             Log.w(TAG, "Failed to export config. Could not determine app's private files directory on external storage.");
                             Toast.makeText(FirstStartActivity.this,
                                     getString(R.string.config_export_failed),
                                     Toast.LENGTH_LONG).show();
                             return;
                         }
-                        final String exportToMediaPath = externalFilesDir.get(0).getAbsolutePath();
+                        final String exportToMediaPath = externalFilesDir.getAbsolutePath();
                         if (!exportConfig(exportToMediaPath)) {
                             Toast.makeText(FirstStartActivity.this,
                                     getString(R.string.config_export_failed),

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/PhotoShootActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/PhotoShootActivity.java
@@ -292,16 +292,4 @@ public class PhotoShootActivity extends AppCompatActivity {
         mBtnGrantCameraPerm.setVisibility(haveCameraPermission() ? View.GONE : View.VISIBLE);
         mBtnGrantStoragePerm.setVisibility(haveStoragePermission() ? View.GONE : View.VISIBLE);
     }
-
-    public static File getExternalFilesDir(Context context, String type) {
-    	// There is a bug on Huawei devices running Android 7, which returns the wrong external path.
-        // See https://github.com/Catfriend1/syncthing-android/issues/541
-    	// ... and: https://stackoverflow.com/questions/39895579/fileprovider-error-onhuawei-devices
-        File[] externalFilesDirs = ContextCompat.getExternalFilesDirs(context, type);
-        if (externalFilesDirs.length > 0) {
-            return externalFilesDirs[0];
-        } else {
-            return null;
-        }
-    }
 }

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/PhotoShootActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/PhotoShootActivity.java
@@ -26,6 +26,7 @@ import androidx.core.content.FileProvider;
 import com.nutomic.syncthingandroid.R;
 import com.nutomic.syncthingandroid.SyncthingApp;
 import com.nutomic.syncthingandroid.service.Constants;
+import com.nutomic.syncthingandroid.util.FileUtils;
 
 import java.io.IOException;
 import java.io.File;
@@ -193,7 +194,7 @@ public class PhotoShootActivity extends AppCompatActivity {
                           Locale.getDefault()).format(new Date());
         String imageFileName = "IMG_" + timeStamp + "_";
         File storageDir =
-                    this.getExternalFilesDir(this, Environment.DIRECTORY_PICTURES);
+                    FileUtils.getExternalFilesDir(this, Environment.DIRECTORY_PICTURES);
         if (storageDir == null) {
             Log.e(TAG, "createImageFile: storageDir == null");
             return null;

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/PhotoShootActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/PhotoShootActivity.java
@@ -193,8 +193,7 @@ public class PhotoShootActivity extends AppCompatActivity {
              new SimpleDateFormat("yyyyMMdd_HHmmss",
                           Locale.getDefault()).format(new Date());
         String imageFileName = "IMG_" + timeStamp + "_";
-        File storageDir =
-                    FileUtils.getExternalFilesDir(this, Environment.DIRECTORY_PICTURES);
+        File storageDir = FileUtils.getExternalFilesDir(this, Environment.DIRECTORY_PICTURES);
         if (storageDir == null) {
             Log.e(TAG, "createImageFile: storageDir == null");
             return null;

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
@@ -5,6 +5,8 @@ import android.os.Build;
 import android.os.Environment;
 import android.text.TextUtils;
 
+import com.nutomic.syncthingandroid.util.FileUtils;
+
 import java.io.File;
 import java.util.concurrent.TimeUnit;
 
@@ -242,7 +244,7 @@ public class Constants {
     }
 
     static File getLogFile(Context context) {
-        return new File(context.getExternalFilesDir(null), "syncthing.log");
+        return new File(FileUtils.getExternalFilesDir(context, null), "syncthing.log");
     }
 
     /**

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
@@ -482,9 +482,10 @@ public class SyncthingRunnable implements Runnable {
         targetEnv.put("HOME", Environment.getExternalStorageDirectory().getAbsolutePath());
         targetEnv.put("STTRACE", TextUtils.join(" ",
                 mPreferences.getStringSet(Constants.PREF_DEBUG_FACILITIES_ENABLED, new HashSet<>())));
-        File externalFilesDir = mContext.getExternalFilesDir(null);
-        if (externalFilesDir != null)
+        File externalFilesDir = FileUtils.getExternalFilesDir(mContext, null);
+        if (externalFilesDir != null) {
             targetEnv.put("STGUIASSETS", externalFilesDir.getAbsolutePath() + "/gui");
+        }
         targetEnv.put("STMONITORED", "1");
         targetEnv.put("STNOUPGRADE", "1");
         if (mPreferences.getBoolean(Constants.PREF_USE_TOR, false)) {

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
@@ -18,6 +18,7 @@ import com.google.common.io.Files;
 import com.nutomic.syncthingandroid.R;
 import com.nutomic.syncthingandroid.SyncthingApp;
 import com.nutomic.syncthingandroid.service.Constants;
+import com.nutomic.syncthingandroid.util.FileUtils;
 import com.nutomic.syncthingandroid.util.Util;
 
 import java.io.BufferedReader;
@@ -455,7 +456,7 @@ public class SyncthingRunnable implements Runnable {
             int lineCount = lnr.getLineNumber();
             lnr.close();
 
-            File tempFile = new File(mContext.getExternalFilesDir(null), "syncthing.log.tmp");
+            File tempFile = new File(FileUtils.getExternalFilesDir(mContext, null), "syncthing.log.tmp");
 
             BufferedReader reader = new BufferedReader(new FileReader(mLogFile));
             BufferedWriter writer = new BufferedWriter(new FileWriter(tempFile));

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/ConfigXml.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/ConfigXml.java
@@ -1105,7 +1105,7 @@ public class ConfigXml {
         }
 
         // Get app specific directory, e.g. "/storage/emulated/0/Android/data/[PACKAGE_NAME]/Pictures".
-        File storageDir = mContext.getExternalFilesDir(Environment.DIRECTORY_PICTURES);
+        File storageDir = FileUtils.getExternalFilesDir(mContext, Environment.DIRECTORY_PICTURES);
         if (storageDir == null) {
             Log.e(TAG, "addSyncthingCameraFolder: storageDir == null");
             return false;

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/FileUtils.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/FileUtils.java
@@ -164,15 +164,38 @@ public class FileUtils {
     }
 
     public static File getExternalFilesDir(Context context, String type) {
-        // There is a bug on Huawei devices running Android 7, which returns the wrong external path.
-        // See https://github.com/Catfriend1/syncthing-android/issues/541
-        // ... and: https://stackoverflow.com/questions/39895579/fileprovider-error-onhuawei-devices
-        File[] externalFilesDirs = ContextCompat.getExternalFilesDirs(context, type);
-        if (externalFilesDirs.length > 0) {
-            return externalFilesDirs[0];
-        } else {
+        return getExternalFilesDir(context, ExternalStorageDirType.DATA, type);
+    }
+
+    public static File getExternalFilesDir(Context context, ExternalStorageDirType extDirType, String type) {
+        /**
+         * Determine the app's private data folder on external storage if present.
+         * e.g. "/storage/abcd-efgh/Android/data/[PACKAGE_NAME]/files"
+         * e.g. "/storage/abcd-efgh/Android/media/[PACKAGE_NAME]"
+         */
+        ArrayList<File> externalFilesDir = new ArrayList<>();
+        switch(extDirType){
+            case DATA:
+                // There is a bug on Huawei devices running Android 7, which returns the wrong external path.
+                // That's why we use ContextCompat here instead of context.
+                // See https://github.com/Catfriend1/syncthing-android/issues/541
+                // ... and: https://stackoverflow.com/questions/39895579/fileprovider-error-onhuawei-devices
+                externalFilesDir.addAll(Arrays.asList(ContextCompat.getExternalFilesDirs(context, null)));
+                externalFilesDir.remove(context.getExternalFilesDir(null));
+                break;
+            case MEDIA:
+                externalFilesDir.addAll(Arrays.asList(context.getExternalMediaDirs()));
+                if (externalFilesDir.size() > 0) {
+                    externalFilesDir.remove(externalFilesDir.get(0));
+                }
+                break;
+        }
+        externalFilesDir.remove(null);      // getExternalFilesDirs may return null for an ejected SDcard.
+        if (externalFilesDir.size() == 0) {
+            Log.w(TAG, "Could not determine app's private files directory on external storage.");
             return null;
         }
+        return externalFilesDir.get(0);
     }
 
     /**
@@ -188,29 +211,13 @@ public class FileUtils {
     @TargetApi(21)
     public static android.net.Uri getExternalFilesDirUri(Context context, ExternalStorageDirType extDirType) {
         try {
-            /**
-             * Determine the app's private data folder on external storage if present.
-             * e.g. "/storage/abcd-efgh/Android/[PACKAGE_NAME]/files"
-             */
-            ArrayList<File> externalFilesDir = new ArrayList<>();
-            switch(extDirType){
-                case DATA:
-                    externalFilesDir.addAll(Arrays.asList(context.getExternalFilesDirs(null)));
-                    externalFilesDir.remove(context.getExternalFilesDir(null));
-                    break;
-                case MEDIA:
-                    externalFilesDir.addAll(Arrays.asList(context.getExternalMediaDirs()));
-                    if (externalFilesDir.size() > 0) {
-                        externalFilesDir.remove(externalFilesDir.get(0));
-                    }
-                    break;
-            }
-            externalFilesDir.remove(null);      // getExternalFilesDirs may return null for an ejected SDcard.
-            if (externalFilesDir.size() == 0) {
+            File externalFilesDir = getExternalFilesDir(context, extDirType, null);
+            if (externalFilesDir == null) {
                 Log.w(TAG, "Could not determine app's private files directory on external storage.");
                 return null;
             }
-            String absPath = externalFilesDir.get(0).getAbsolutePath();
+            String absPath = externalFilesDir.getAbsolutePath();
+
             // Log.v(TAG, "getExternalFilesDirUri: absPath=" + absPath);
             String[] segments = absPath.split("/");
             if (segments.length < 2) {

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/FileUtils.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/FileUtils.java
@@ -17,6 +17,7 @@ import android.widget.Toast;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
+import androidx.core.content.ContextCompat;
 
 import com.nutomic.syncthingandroid.R;
 
@@ -160,6 +161,18 @@ public class FileUtils {
         // }
         // Log.e(TAG, "getVolumePath failed for volumeId='" + volumeId + "'");
         // return null;
+    }
+
+    public static File getExternalFilesDir(Context context, String type) {
+        // There is a bug on Huawei devices running Android 7, which returns the wrong external path.
+        // See https://github.com/Catfriend1/syncthing-android/issues/541
+        // ... and: https://stackoverflow.com/questions/39895579/fileprovider-error-onhuawei-devices
+        File[] externalFilesDirs = ContextCompat.getExternalFilesDirs(context, type);
+        if (externalFilesDirs.length > 0) {
+            return externalFilesDirs[0];
+        } else {
+            return null;
+        }
     }
 
     /**


### PR DESCRIPTION
Purpose:
- PhotoShootActivity: Move getExternalFilesDir to FileUtils (fixes #759)
- ref #767
