### PR TITLE
Move SyncthingCamera folder from /Android/data to /Android/media

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FirstStartActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FirstStartActivity.java
@@ -398,7 +398,7 @@ public class FirstStartActivity extends AppCompatActivity {
                     @Override
                     public void onClick(View v) {
                         // Get app specific /Android/media directory.
-                        File externalFilesDir = FileUtils.getExternalFilesDir(FirstStartActivity.this, ExternalStorageDirType.MEDIA, null);
+                        File externalFilesDir = FileUtils.getExternalFilesDir(FirstStartActivity.this, ExternalStorageDirType.INT_MEDIA, null);
                         if (externalFilesDir == null) {
                             Log.w(TAG, "Failed to export config. Could not determine app's private files directory on external storage.");
                             Toast.makeText(FirstStartActivity.this,

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
@@ -326,7 +326,7 @@ public class FolderActivity extends SyncthingActivity {
     @SuppressLint("InlinedAPI")
     private void onPathViewClick() {
         // This has to be android.net.Uri as it implements a Parcelable.
-        android.net.Uri externalFilesDirUri = FileUtils.getExternalFilesDirUri(FolderActivity.this, ExternalStorageDirType.MEDIA);
+        android.net.Uri externalFilesDirUri = FileUtils.getExternalFilesDirUri(FolderActivity.this, ExternalStorageDirType.INT_MEDIA);
 
         // Display storage access framework directory picker UI.
         Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
@@ -332,6 +332,7 @@ public class FolderActivity extends SyncthingActivity {
         Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);
         if (externalFilesDirUri != null) {
             intent.putExtra("android.provider.extra.INITIAL_URI", externalFilesDirUri);
+            FileUtils.getExternalFilesDir(FolderActivity.this, ExternalStorageDirType.INT_MEDIA, null).mkdirs();
         } else {
             android.net.Uri internalFilesDirUri = FileUtils.getInternalStorageRootUri();
             if (internalFilesDirUri != null) {

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
@@ -332,7 +332,6 @@ public class FolderActivity extends SyncthingActivity {
         Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);
         if (externalFilesDirUri != null) {
             intent.putExtra("android.provider.extra.INITIAL_URI", externalFilesDirUri);
-            FileUtils.getExternalFilesDir(FolderActivity.this, ExternalStorageDirType.INT_MEDIA, null).mkdirs();
         } else {
             android.net.Uri internalFilesDirUri = FileUtils.getInternalStorageRootUri();
             if (internalFilesDirUri != null) {

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/PhotoShootActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/PhotoShootActivity.java
@@ -27,6 +27,7 @@ import com.nutomic.syncthingandroid.R;
 import com.nutomic.syncthingandroid.SyncthingApp;
 import com.nutomic.syncthingandroid.service.Constants;
 import com.nutomic.syncthingandroid.util.FileUtils;
+import com.nutomic.syncthingandroid.util.FileUtils.ExternalStorageDirType;
 
 import java.io.IOException;
 import java.io.File;
@@ -193,7 +194,7 @@ public class PhotoShootActivity extends AppCompatActivity {
              new SimpleDateFormat("yyyyMMdd_HHmmss",
                           Locale.getDefault()).format(new Date());
         String imageFileName = "IMG_" + timeStamp + "_";
-        File storageDir = FileUtils.getExternalFilesDir(this, Environment.DIRECTORY_PICTURES);
+        File storageDir = FileUtils.getExternalFilesDir(PhotoShootActivity.this, ExternalStorageDirType.MEDIA, Environment.DIRECTORY_PICTURES);
         if (storageDir == null) {
             Log.e(TAG, "createImageFile: storageDir == null");
             return null;

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/PhotoShootActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/PhotoShootActivity.java
@@ -199,6 +199,7 @@ public class PhotoShootActivity extends AppCompatActivity {
             Log.e(TAG, "createImageFile: storageDir == null");
             return null;
         }
+        storageDir.mkdirs();
         File image = File.createTempFile(
                         imageFileName,  /* prefix */
                         ".jpg",         /* suffix */

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/PhotoShootActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/PhotoShootActivity.java
@@ -194,7 +194,7 @@ public class PhotoShootActivity extends AppCompatActivity {
              new SimpleDateFormat("yyyyMMdd_HHmmss",
                           Locale.getDefault()).format(new Date());
         String imageFileName = "IMG_" + timeStamp + "_";
-        File storageDir = FileUtils.getExternalFilesDir(PhotoShootActivity.this, ExternalStorageDirType.MEDIA, Environment.DIRECTORY_PICTURES);
+        File storageDir = FileUtils.getExternalFilesDir(PhotoShootActivity.this, ExternalStorageDirType.INT_MEDIA, Environment.DIRECTORY_PICTURES);
         if (storageDir == null) {
             Log.e(TAG, "createImageFile: storageDir == null");
             return null;

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/ConfigXml.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/ConfigXml.java
@@ -17,6 +17,7 @@ import com.nutomic.syncthingandroid.R;
 import com.nutomic.syncthingandroid.service.AppPrefs;
 import com.nutomic.syncthingandroid.service.Constants;
 import com.nutomic.syncthingandroid.service.SyncthingRunnable;
+import com.nutomic.syncthingandroid.util.FileUtils.ExternalStorageDirType;
 
 import java.io.ByteArrayOutputStream;
 import java.io.InputStreamReader;
@@ -1104,8 +1105,8 @@ public class ConfigXml {
             return false;
         }
 
-        // Get app specific directory, e.g. "/storage/emulated/0/Android/data/[PACKAGE_NAME]/Pictures".
-        File storageDir = FileUtils.getExternalFilesDir(mContext, Environment.DIRECTORY_PICTURES);
+        // Get app specific directory, e.g. "/storage/emulated/0/Android/media/[PACKAGE_NAME]/Pictures".
+        File storageDir = FileUtils.getExternalFilesDir(mContext, ExternalStorageDirType.MEDIA, Environment.DIRECTORY_PICTURES);
         if (storageDir == null) {
             Log.e(TAG, "addSyncthingCameraFolder: storageDir == null");
             return false;
@@ -1127,7 +1128,7 @@ public class ConfigXml {
         folder.versioning.fsType = "basic";
 
         // Add folder to config.
-        LogV("addSyncthingCameraFolder: Adding folder to config ...");
+        LogV("addSyncthingCameraFolder: Adding folder to config [" + folder.path + "]");
         addFolder(folder);
         return true;
     }

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/ConfigXml.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/ConfigXml.java
@@ -1106,7 +1106,7 @@ public class ConfigXml {
         }
 
         // Get app specific directory, e.g. "/storage/emulated/0/Android/media/[PACKAGE_NAME]/Pictures".
-        File storageDir = FileUtils.getExternalFilesDir(mContext, ExternalStorageDirType.MEDIA, Environment.DIRECTORY_PICTURES);
+        File storageDir = FileUtils.getExternalFilesDir(mContext, ExternalStorageDirType.INT_MEDIA, Environment.DIRECTORY_PICTURES);
         if (storageDir == null) {
             Log.e(TAG, "addSyncthingCameraFolder: storageDir == null");
             return false;

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/FileUtils.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/FileUtils.java
@@ -51,7 +51,8 @@ public class FileUtils {
 
     public enum ExternalStorageDirType {
         DATA,
-        MEDIA
+        EXT_MEDIA,
+        INT_MEDIA
     }
 
     @Nullable
@@ -183,21 +184,25 @@ public class FileUtils {
                 externalFilesDir.addAll(Arrays.asList(ContextCompat.getExternalFilesDirs(context, null)));
                 externalFilesDir.remove(context.getExternalFilesDir(null));
                 break;
-            case MEDIA:
+            case INT_MEDIA:
+                externalFilesDir.add(Environment.getExternalStorageDirectory());
+                break;
+            case EXT_MEDIA:
                 externalFilesDir.addAll(Arrays.asList(context.getExternalMediaDirs()));
-                if (externalFilesDir.size() > 0) {
+                if (!externalFilesDir.isEmpty()) {
                     externalFilesDir.remove(externalFilesDir.get(0));
                 }
                 break;
         }
         externalFilesDir.remove(null);      // getExternalFilesDirs may return null for an ejected SDcard.
-        if (externalFilesDir.size() == 0) {
+        if (externalFilesDir.isEmpty()) {
             Log.w(TAG, "Could not determine app's private files directory on external storage.");
             return null;
         }
         if (type != null) {
             switch(extDirType) {
-                case MEDIA:
+                case EXT_MEDIA:
+                case INT_MEDIA:
                     if (type.equals(Environment.DIRECTORY_PICTURES)) {
                         return new File(externalFilesDir.get(0), Environment.DIRECTORY_PICTURES);
                     }
@@ -241,7 +246,8 @@ public class FileUtils {
                         "content://com.android.externalstorage.documents/document/" +
                         volumeId + "%3AAndroid%2Fdata%2F" +
                         context.getPackageName() + "%2Ffiles");
-                case MEDIA:
+                case EXT_MEDIA:
+                case INT_MEDIA:
                     // Build the content Uri for our private ".../media/[PKG_NAME]" folder.
                     return android.net.Uri.parse(
                         "content://com.android.externalstorage.documents/document/" +

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/FileUtils.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/FileUtils.java
@@ -255,8 +255,8 @@ public class FileUtils {
                 case INT_MEDIA:
                     // Build the content Uri for our private ".../media/[PKG_NAME]" folder.
                     return android.net.Uri.parse(
-                        "content://com.android.externalstorage.documents/tree/primary" +
-                        "%3AAndroid%2Fmedia%2F" +
+                        "content://com.android.externalstorage.documents/document/" +
+                        "primary" + "%3AAndroid%2Fmedia%2F" +
                         context.getPackageName());
             }
         } catch (Exception e) {

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/FileUtils.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/FileUtils.java
@@ -185,7 +185,7 @@ public class FileUtils {
                 externalFilesDir.remove(context.getExternalFilesDir(null));
                 break;
             case INT_MEDIA:
-                externalFilesDir.add(Environment.getExternalStorageDirectory());
+                externalFilesDir.add(new File(Environment.getExternalStorageDirectory() + "/Android/media/" + context.getPackageName()));
                 break;
             case EXT_MEDIA:
                 externalFilesDir.addAll(Arrays.asList(context.getExternalMediaDirs()));

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/FileUtils.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/FileUtils.java
@@ -195,6 +195,14 @@ public class FileUtils {
             Log.w(TAG, "Could not determine app's private files directory on external storage.");
             return null;
         }
+        if (type != null) {
+            switch(extDirType) {
+                case MEDIA:
+                    if (type.equals(Environment.DIRECTORY_PICTURES)) {
+                        return new File(externalFilesDir.get(0), Environment.DIRECTORY_PICTURES);
+                    }
+            }
+        }
         return externalFilesDir.get(0);
     }
 

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/FileUtils.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/FileUtils.java
@@ -255,8 +255,8 @@ public class FileUtils {
                 case INT_MEDIA:
                     // Build the content Uri for our private ".../media/[PKG_NAME]" folder.
                     return android.net.Uri.parse(
-                        "content://com.android.externalstorage.documents/tree/" +
-                        volumeId + "%3AAndroid%2Fmedia%2F" +
+                        "content://com.android.externalstorage.documents/tree/primary" +
+                        "%3AAndroid%2Fmedia%2F" +
                         context.getPackageName());
             }
         } catch (Exception e) {

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/FileUtils.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/FileUtils.java
@@ -247,10 +247,15 @@ public class FileUtils {
                         volumeId + "%3AAndroid%2Fdata%2F" +
                         context.getPackageName() + "%2Ffiles");
                 case EXT_MEDIA:
-                case INT_MEDIA:
                     // Build the content Uri for our private ".../media/[PKG_NAME]" folder.
                     return android.net.Uri.parse(
                         "content://com.android.externalstorage.documents/document/" +
+                        volumeId + "%3AAndroid%2Fmedia%2F" +
+                        context.getPackageName());
+                case INT_MEDIA:
+                    // Build the content Uri for our private ".../media/[PKG_NAME]" folder.
+                    return android.net.Uri.parse(
+                        "content://com.android.externalstorage.documents/tree/" +
                         volumeId + "%3AAndroid%2Fmedia%2F" +
                         context.getPackageName());
             }

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths xmlns:android="http://schemas.android.com/apk/res/android">
     <external-files-path name="my_images" />
+    <external-media-path name="my_images" />
 </paths>


### PR DESCRIPTION
Purpose:
- Move SyncthingCamera folder from /Android/data to /Android/media

Reason:
- On Android 11, gallery apps like "Simple Gallery" can no longer access / show / share / delete pictures from Syncthing's own camera folder.

ref #767
