### PR TITLE
Fix Syncthing not running after boot when on schedule

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/service/RunConditionMonitor.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/RunConditionMonitor.java
@@ -182,7 +182,7 @@ public class RunConditionMonitor {
          */
         if (lastSyncTimeSinceBootMillisecs > elapsedRealtime) {
             SharedPreferences.Editor editor = mPreferences.edit();
-            editor.putLong(Constants.PREF_LAST_RUN_TIME, -Constants.WAIT_FOR_NEXT_SYNC_DELAY_SECS);
+            editor.putLong(Constants.PREF_LAST_RUN_TIME, -Constants.WAIT_FOR_NEXT_SYNC_DELAY_SECS * 1000);
             editor.apply();
             lastSyncTimeSinceBootMillisecs = 0;
         }


### PR DESCRIPTION
I noticed that, when running on schedule, after a reboot syncthing would claim it was just running a minute ago.

Looks like I didn't test well enough in #766, and overlooked that `PREF_LAST_RUN_TIME` is in milliseconds, but `WAIT_FOR_NEXT_SYNC_DELAY_SECS` is in seconds.

Maybe `PREF_LAST_RUN_TIME` should have been named something like `PREF_LAST_RUN_TIME_MILLISECS`... but anyway, it's easy to fix.