### PR TITLE
Clear prefs when importing backup from Syncthing app (fixes #688)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
@@ -1019,8 +1019,11 @@ public class SyncthingService extends Service {
                 Log.w(TAG, "importConfig: SharedPreferences file missing. This is expected if you migrate from the official app to the forked app.");
                 /**
                  * Don't fail as the file might be expectedly missing when users migrate
-                 * to the forked app.
+                 * to the forked app. Clear cached info like the local deviceID from prefs.
                  */
+                SharedPreferences.Editor editor = mPreferences.edit();
+                editor.clear();
+                editor.commit();
             }
         } catch (IOException | ClassNotFoundException e) {
             Log.e(TAG, "importConfig: Failed to import SharedPreferences #1", e);

--- a/app/src/main/play/release-notes/en-GB/beta.txt
+++ b/app/src/main/play/release-notes/en-GB/beta.txt
@@ -8,6 +8,7 @@ Enhanced
 Fixes
 --
 - Fix opening file intents used in "Recent Changes" dialog (#816)
+- Clear prefs when importing backup from Syncthing app (#821)
 
 
 Others

--- a/app/versions.gradle
+++ b/app/versions.gradle
@@ -2,5 +2,5 @@ ext {
     versionMajor = 1
     versionMinor = 17
     versionPatch = 0
-    versionWrapper = 0
+    versionWrapper = 1
 }


### PR DESCRIPTION
Purpose:
- Clear prefs when importing backup from Syncthing app (fixes #688)

