### PR TITLE
Merge upstream SyncthingNative PR 7794 to work around slow scanning on Android 11 (fixes #826)

### DIFF
--- a/SyncthingNative_update_and_build.cmd
+++ b/SyncthingNative_update_and_build.cmd
@@ -53,6 +53,11 @@ git checkout %DESIRED_SUBMODULE_VERSION% 2>&1 | find /i "HEAD is now at"
 SET RESULT=%ERRORLEVEL%
 IF NOT "%RESULT%" == "0" echo [ERROR] git checkout FAILED. & goto :eos
 REM
+REM Apply upstream PR #7794 lib/fs: Set expiry after DirNames in case-fs
+git cherry-pick --quiet 08e3cd1cce02a65b0bab502b1c953e6ce7b5aef8
+SET RESULT=%ERRORLEVEL%
+IF NOT "%RESULT%" == "0" echo [ERROR] git cherry-pick FAILED. & goto :eos
+REM
 :afterCheckoutSrc
 cd /d "%SCRIPT_PATH%"
 REM

--- a/app/src/main/play/release-notes/en-GB/beta.txt
+++ b/app/src/main/play/release-notes/en-GB/beta.txt
@@ -1,4 +1,4 @@
-* Syncthing v1.17.0
+* Syncthing v1.17.0 + upstream PR #7794
 
 Enhanced
 --


### PR DESCRIPTION
Purpose:
- Merge upstream SyncthingNative PR 7794 to work around slow scanning on Android 11

git cherry-pick 08e3cd1cce02a65b0bab502b1c953e6ce7b5aef8
ref https://github.com/syncthing/syncthing/commit/08e3cd1cce02a65b0bab502b1c953e6ce7b5aef8
ref https://github.com/syncthing/syncthing/pull/7794