### PR TITLE
UI for untrusted devices, encrypted folder sharing (fixes #724)

### DIFF
--- a/app/src/main/res/layout/item_device_form.xml
+++ b/app/src/main/res/layout/item_device_form.xml
@@ -1,11 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.appcompat.widget.SwitchCompat xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    style="@style/Widget.Syncthing.TextView.Label.Details.DeviceList"
-    android:id="@+id/device_toggle"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:layout_marginLeft="@dimen/material_divider_inset"
-    android:layout_marginStart="@dimen/material_divider_inset"
-    android:textAppearance="@style/TextAppearance.AppCompat.Caption"
-    tools:ignore="RtlHardcoded,RtlSymmetry" />
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content">
+
+    <androidx.appcompat.widget.SwitchCompat
+        xmlns:tools="http://schemas.android.com/tools"
+        style="@style/Widget.Syncthing.TextView.Label.Details.DeviceList"
+        android:id="@+id/device_toggle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="@dimen/material_divider_inset"
+        android:layout_marginStart="@dimen/material_divider_inset"
+        android:textAppearance="@style/TextAppearance.AppCompat.Caption"
+        tools:ignore="RtlHardcoded,RtlSymmetry" />
+
+    <EditText
+        style="@style/Widget.Syncthing.TextView.Label.Details.Field"
+        android:id="@+id/device_encryptionPassword"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="144dp"
+        android:hint="@string/deviceEncryptionPasswordHint"
+        android:inputType="textPassword|textNoSuggestions"
+        android:importantForAutofill="no" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/item_folder_form.xml
+++ b/app/src/main/res/layout/item_folder_form.xml
@@ -1,11 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.appcompat.widget.SwitchCompat xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    style="@style/Widget.Syncthing.TextView.Label.Details.DeviceList"
-    android:id="@+id/folder_toggle"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:layout_marginLeft="@dimen/material_divider_inset"
-    android:layout_marginStart="@dimen/material_divider_inset"
-    android:textAppearance="@style/TextAppearance.AppCompat.Caption"
-    tools:ignore="RtlHardcoded,RtlSymmetry" />
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content">
+
+    <androidx.appcompat.widget.SwitchCompat
+        xmlns:tools="http://schemas.android.com/tools"
+        style="@style/Widget.Syncthing.TextView.Label.Details.DeviceList"
+        android:id="@+id/folder_toggle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="@dimen/material_divider_inset"
+        android:layout_marginStart="@dimen/material_divider_inset"
+        android:textAppearance="@style/TextAppearance.AppCompat.Caption"
+        tools:ignore="RtlHardcoded,RtlSymmetry" />
+
+    <EditText
+        style="@style/Widget.Syncthing.TextView.Label.Details.Field"
+        android:id="@+id/device_encryptionPassword"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="144dp"
+        android:hint="@string/deviceEncryptionPasswordHint"
+        android:inputType="textPassword|textNoSuggestions"
+        android:importantForAutofill="no" />
+
+</LinearLayout>


### PR DESCRIPTION
Purpose:
- Support featureFlag "encryption" (fixes #724)

Known issues, maybe fullfilled by a separate, future PR:
- [ ] Folder edit dialog: missing a nicer way to present the password field

Status:
- [x] Device edit dialog: Add the password entry part when shared folders are selected from the dialog.
- [x] Folder Accept notification needs to open the CreateFolder dialog with "receiveEncrypted" type suggestion. We need to implement "pendingFoldersChanged" for this to work.
- [x] Pending device and pending folder events from SyncthingNative v1.13+ are supported and fields "receiveEncrypted", "remoteEncrypted" are gathered from these events.
- [x] Folder edit dialog: Show "if untrusted, enter password" text field
- [x] folder overview UI: Show "delete unexpected changes" button - revert button for receive encrypted
- [x] Disable MediaScanner routine after files from "receiveEncrypted" folders were received.
- [x] Disallow switching existing folder's type to "Receive Encrypted"
- [x] Add "receiveEncrypted" folder type to UI
- [x] Added "ID" icon to clarify which fields the folder / device ID should be put in.
- [x] Removed the "key" and the "tag" icon from the folder edit dialog, replaced by "A-Z" icon to clarify which is the device name and which will be later the folder encryption password.
- [x] Updated model: "Folder" class now contains the relevant info about devices the folder can be shared with in a new class "SharedWithDevice" (instead of "Device").
- [x] Updated model: "Device" class now knows about the "untrusted" property.
- [x] Updated model: The "options" config section now know about the "featureFlag" property.

Screenshots:
![image](https://user-images.githubusercontent.com/16361913/132982177-2832338c-f163-4eee-b091-7bbd0206d28b.png)
![image](https://user-images.githubusercontent.com/16361913/132982193-ac863f76-caca-48a8-b52c-db1d63be32e5.png)
![image](https://user-images.githubusercontent.com/16361913/132996377-7a304660-041c-414f-8895-a106ec1270e0.png)

