### PR TITLE
Routing network request to specific network

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
@@ -122,6 +122,7 @@ public class SyncthingRunnable implements Runnable {
         try {
             bindNetwork();
             run(false);
+            clearBindNetwork();
         } catch (ExecutableNotFoundException e) {
             throw new RuntimeException(e.getMessage());
         }
@@ -134,12 +135,22 @@ public class SyncthingRunnable implements Runnable {
      * 2. user only want to connect with mobile network, but not wifi.
      */
     private void bindNetwork() {
+        clearBindNetwork();
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             if (!(mPreferences.getBoolean(Constants.PREF_RUN_ON_WIFI, true)
                     & !mPreferences.getBoolean(Constants.PREF_RUN_ON_MOBILE_DATA, true))) {
                 ConnectivityManager cm = (ConnectivityManager) mContext.getSystemService(Context.CONNECTIVITY_SERVICE);
                 Network network = cm.getActiveNetwork();
                 cm.bindProcessToNetwork(network);
+            }
+        }
+    }
+
+    private void clearBindNetwork() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            ConnectivityManager cm = (ConnectivityManager) mContext.getSystemService(Context.CONNECTIVITY_SERVICE);
+            if (cm.getBoundNetworkForProcess() != null) {
+                cm.bindProcessToNetwork(null);
             }
         }
     }
@@ -423,6 +434,7 @@ public class SyncthingRunnable implements Runnable {
             SystemClock.sleep(50);
         }
         Log.d(TAG, "killSyncthing: Complete.");
+        clearBindNetwork();
     }
 
     /**

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
@@ -137,8 +137,9 @@ public class SyncthingRunnable implements Runnable {
     private void bindNetwork() {
         clearBindNetwork();
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            if (!(mPreferences.getBoolean(Constants.PREF_RUN_ON_WIFI, true) &&
-                    !mPreferences.getBoolean(Constants.PREF_RUN_ON_MOBILE_DATA, true))) {
+            boolean runOnWifi = mPreferences.getBoolean(Constants.PREF_RUN_ON_WIFI, true);
+            boolean runOnMobileData = mPreferences.getBoolean(Constants.PREF_RUN_ON_MOBILE_DATA, true);
+            if ((runOnWifi && !runOnMobileData) || (!runOnWifi && runOnMobileData)) {
                 ConnectivityManager cm = (ConnectivityManager) mContext.getSystemService(Context.CONNECTIVITY_SERVICE);
                 Network network = cm.getActiveNetwork();
                 cm.bindProcessToNetwork(network);

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
@@ -129,10 +129,10 @@ public class SyncthingRunnable implements Runnable {
     }
 
     /**
-     * bind network to avoid the following two situations:
-     * 1. fake wifi, when user want only running in wifi, but connect a no internet wifi,
-     * android will auto routing request to mobile network.
-     * 2. user only want to connect with mobile network, but not wifi.
+     * Avoid the following two situations:
+     * 1. Fake WiFi: User wants only syncing via WiFi, but connects to a WiFi without internet connection,
+     *    Android will auto route the request through the mobile network.
+     * 2. User only wants to sync through mobile network, but not use WiFi.
      */
     private void bindNetwork() {
         clearBindNetwork();

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
@@ -137,8 +137,8 @@ public class SyncthingRunnable implements Runnable {
     private void bindNetwork() {
         clearBindNetwork();
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            if (!(mPreferences.getBoolean(Constants.PREF_RUN_ON_WIFI, true)
-                    & !mPreferences.getBoolean(Constants.PREF_RUN_ON_MOBILE_DATA, true))) {
+            if (!(mPreferences.getBoolean(Constants.PREF_RUN_ON_WIFI, true) &&
+                    !mPreferences.getBoolean(Constants.PREF_RUN_ON_MOBILE_DATA, true))) {
                 ConnectivityManager cm = (ConnectivityManager) mContext.getSystemService(Context.CONNECTIVITY_SERVICE);
                 Network network = cm.getActiveNetwork();
                 cm.bindProcessToNetwork(network);

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
@@ -1,7 +1,5 @@
 package com.nutomic.syncthingandroid.service;
 
-import static com.nutomic.syncthingandroid.service.SyncthingService.EXTRA_STOP_AFTER_CRASHED_NATIVE;
-
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.Intent;
@@ -45,6 +43,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import javax.inject.Inject;
 
 import eu.chainfire.libsuperuser.Shell;
+
+import static com.nutomic.syncthingandroid.service.SyncthingService.EXTRA_STOP_AFTER_CRASHED_NATIVE;
 
 /**
  * Runs the syncthing binary from command line, and prints its output to logcat.


### PR DESCRIPTION
I set wifi only, in the first few days, my home wifi dns broken when I don't know, but it connect.
So, syncthing is running and android system routing all the request to mobile data, and consumed my entire traffic allowance at one night.
The patch is for the situation.