### PR TITLE
buildScript: F-Droid use NDK served by fdroiddata def (fixes #1034)

### DIFF
--- a/App_build_and_release.cmd
+++ b/App_build_and_release.cmd
@@ -8,6 +8,7 @@ REM Script Consts.
 SET CLEANUP_BEFORE_BUILD=1
 REM
 REM Runtime Variables.
+IF EXIST "%LocalAppData%\Android\Sdk" SET "ANDROID_SDK_ROOT=%LocalAppData%\Android\Sdk"
 IF NOT DEFINED ANDROID_SDK_ROOT SET "ANDROID_SDK_ROOT=%SCRIPT_PATH%..\syncthing-android-prereq"
 SET SKIP_RELEASE_BUILD=0
 IF NOT DEFINED ANDROID_PUBLISHER_CREDENTIALS echo [WARN] ANDROID_PUBLISHER_CREDENTIALS env var not set. We will skip the signed release build. & SET SKIP_RELEASE_BUILD=1
@@ -29,7 +30,7 @@ echo [INFO] Checking prerequisites ...
 REM
 where java 2>&1 >NUL: || (echo [ERROR] Java is missing. Check env. & goto :eof)
 REM
-IF NOT EXIST %ANDROID_SDK_ROOT%\tools\bin\sdkmanager.bat (echo [WARN] Android SDK manager is missing. Trying to run 'python install_minimum_android_sdk_prerequisites.py' ... & call python install_minimum_android_sdk_prerequisites.py)
+IF NOT EXIST "%ANDROID_SDK_ROOT%\.knownPackages" (echo [WARN] Android SDK missing. Trying to run 'python install_minimum_android_sdk_prerequisites.py' ... & call python install_minimum_android_sdk_prerequisites.py)
 REM
 echo [INFO] Checking if SyncthingNative was built before starting this script ...
 SET LIBCOUNT=

--- a/SyncthingNative_update_and_build.cmd
+++ b/SyncthingNative_update_and_build.cmd
@@ -13,6 +13,7 @@ SET DESIRED_SUBMODULE_VERSION=v1.26.1
 SET GRADLEW_PARAMS=-q
 REM
 REM Runtime Variables.
+IF EXIST "%LocalAppData%\Android\Sdk" SET "ANDROID_SDK_ROOT=%LocalAppData%\Android\Sdk"
 IF NOT DEFINED ANDROID_SDK_ROOT SET "ANDROID_SDK_ROOT=%SCRIPT_PATH%..\syncthing-android-prereq"
 IF NOT DEFINED JAVA_HOME SET JAVA_HOME=%ProgramFiles%\Android\Android Studio\jbr
 REM

--- a/SyncthingNative_update_and_build.cmd
+++ b/SyncthingNative_update_and_build.cmd
@@ -27,7 +27,7 @@ REM
 where /q java
 IF NOT "%ERRORLEVEL%" == "0" SET PATH=%PATH%;%JAVA_HOME%\bin
 where /q java
-IF NOT "%ERRORLEVEL%" == "0" echo [ERROR] java.exe not found on PATH env var. Download 'https://www.oracle.com/java/technologies/downloads/#java11-windows' and run the installer & pause & goto :checkPrerequisites
+IF NOT "%ERRORLEVEL%" == "0" echo [ERROR] java.exe not found on PATH env var. Download 'https://www.oracle.com/java/technologies/downloads/#java17' and run the installer & pause & goto :checkPrerequisites
 REM
 where /q python
 IF NOT "%ERRORLEVEL%" == "0" echo [ERROR] python.exe not found on PATH env var. Download 'https://www.python.org/ftp/python/3.9.6/python-3.9.6-amd64.exe' and run 'python-3.9.6-amd64.exe /quiet InstallAllUsers=1 PrependPath=1 Include_test=0' & pause & goto :checkPrerequisites

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext {
         // Cannot be called "ndkVersion" as that leads to naming collision
-        ndkVersionShared = '25.1.8937393'
+        ndkVersionShared = '26.1.10909125'
     }
     repositories {
         google()

--- a/install_minimum_android_sdk_prerequisites.py
+++ b/install_minimum_android_sdk_prerequisites.py
@@ -161,7 +161,7 @@ print('sdk_manager_bin=\'' + sdk_manager_bin + '\'')
 if sys.platform == 'win32':
     subprocess.check_call([sdk_manager_bin, '--update'])
     powershell_bin = which('powershell')
-    subprocess.check_call([powershell_bin, 'for($i=0;$i -lt 32;$i++) { $response += \"y`n\"}; $response | sdkmanager --licenses'], stdout=subprocess.DEVNULL)
+    subprocess.check_call([powershell_bin, 'for($i=0;$i -lt ' + ANDROID_SDK_VERSION + ';$i++) { $response += \"y`n\"}; $response | sdkmanager --licenses'], stdout=subprocess.DEVNULL)
     subprocess.check_call([sdk_manager_bin, 'platforms;android-' + ANDROID_SDK_VERSION])
     subprocess.check_call([sdk_manager_bin, 'build-tools;' + ANDROID_SDK_VERSION + '.0.0'])
 

--- a/setenv.cmd
+++ b/setenv.cmd
@@ -1,0 +1,11 @@
+@echo off
+REM
+REM Runtime Variables.
+IF NOT DEFINED JAVA_HOME SET JAVA_HOME=%ProgramFiles%\Android\Android Studio\jbr
+REM
+where /q java
+IF NOT "%ERRORLEVEL%" == "0" SET PATH=%PATH%;%JAVA_HOME%\bin
+where /q java
+IF NOT "%ERRORLEVEL%" == "0" echo [ERROR] java.exe not found on PATH env var. Download 'https://www.oracle.com/java/technologies/downloads/#java17' and run the installer & pause & goto :checkPrerequisites
+REM
+goto :eof

--- a/setenv.cmd
+++ b/setenv.cmd
@@ -2,6 +2,7 @@
 REM
 REM Runtime Variables.
 IF NOT DEFINED JAVA_HOME SET JAVA_HOME=%ProgramFiles%\Android\Android Studio\jbr
+IF EXIST "%LocalAppData%\Android\Sdk" SET "ANDROID_SDK_ROOT=%LocalAppData%\Android\Sdk"
 REM
 where /q java
 IF NOT "%ERRORLEVEL%" == "0" SET PATH=%PATH%;%JAVA_HOME%\bin

--- a/syncthing/build-syncthing.py
+++ b/syncthing/build-syncthing.py
@@ -230,7 +230,7 @@ def get_ndk_ready():
         print('ANDROID_NDK_HOME or NDK_VERSION and ANDROID_HOME environment variable must be defined')
         install_ndk()
         return
-    os.environ["ANDROID_NDK_HOME"] = return os.path.join(os.environ['ANDROID_HOME'], 'ndk', os.environ['NDK_VERSION'])
+    os.environ["ANDROID_NDK_HOME"] = os.path.join(os.environ['ANDROID_HOME'], 'ndk', os.environ['NDK_VERSION'])
     return
 
 

--- a/syncthing/build-syncthing.py
+++ b/syncthing/build-syncthing.py
@@ -226,11 +226,11 @@ def write_file(fullfn, text):
 def get_ndk_ready():
     if os.environ.get('ANDROID_NDK_HOME', ''):
         return
-    if not os.environ.get('NDK_VERSION', '') or not os.environ.get('ANDROID_HOME', ''):
-        print('ANDROID_NDK_HOME or NDK_VERSION and ANDROID_HOME environment variable must be defined')
+    if not (os.environ.get('NDK_VERSION', '') and os.environ.get('ANDROID_SDK_ROOT', '')):
+        print('ANDROID_NDK_HOME env var is not defined. Then, NDK_VERSION and ANDROID_SDK_ROOT env vars must be defined.')
         install_ndk()
         return
-    os.environ["ANDROID_NDK_HOME"] = os.path.join(os.environ['ANDROID_HOME'], 'ndk', os.environ['NDK_VERSION'])
+    os.environ["ANDROID_NDK_HOME"] = os.path.join(os.environ['ANDROID_SDK_ROOT'], 'ndk', os.environ['NDK_VERSION'])
     return
 
 

--- a/syncthing/build-syncthing.py
+++ b/syncthing/build-syncthing.py
@@ -223,6 +223,17 @@ def write_file(fullfn, text):
         hFile.write(text + '\n')
 
 
+def get_ndk_ready():
+    if os.environ.get('ANDROID_NDK_HOME', ''):
+        return
+    if not os.environ.get('NDK_VERSION', '') or not os.environ.get('ANDROID_HOME', ''):
+        print('ANDROID_NDK_HOME or NDK_VERSION and ANDROID_HOME environment variable must be defined')
+        install_ndk()
+        return
+    os.environ["ANDROID_NDK_HOME"] = return os.path.join(os.environ['ANDROID_HOME'], 'ndk', os.environ['NDK_VERSION'])
+    return
+
+
 def install_ndk():
     import os
     import zipfile
@@ -327,13 +338,10 @@ if not go_bin:
         fail('Error: go is not available on the PATH.')
 print('go_bin=\'' + go_bin + '\'')
 
-# Check if ANDROID_NDK_HOME variable is set.
+# Check if "ANDROID_NDK_HOME" env var is set. If not, try to discover and set it.
+get_ndk_ready()
 if not os.environ.get('ANDROID_NDK_HOME', ''):
-    print('Warning: ANDROID_NDK_HOME environment variable not defined.')
-    install_ndk();
-    # Retry: Check if ANDROID_NDK_HOME variable is set.
-    if not os.environ.get('ANDROID_NDK_HOME', ''):
-        fail('Error: ANDROID_NDK_HOME environment variable not defined')
+    fail('Error: ANDROID_NDK_HOME environment variable not defined')
 print('ANDROID_NDK_HOME=\'' + os.environ.get('ANDROID_NDK_HOME', '') + '\'')
 
 # Make sure all tags are available for git describe

--- a/syncthing/build.gradle
+++ b/syncthing/build.gradle
@@ -3,6 +3,7 @@ plugins {
 }
 
 task buildNative(type: PythonTask) {
+    environment "NDK_VERSION", "$ndkVersionShared"
     inputs.dir("$projectDir/src/")
     outputs.dir("$projectDir/../app/src/main/jniLibs/")
     command = "-u ./build-syncthing.py"


### PR DESCRIPTION
Prerequiste: 
* Download NDK r26b by Android Studio (select version 26.1.10909125)
![image](https://github.com/Catfriend1/syncthing-android/assets/16361913/1955c3ea-5f91-4790-bfed-c0946a0f90f5)

Verification on Windows builder:
Exec "setenv & gradlew cleanNative buildNative" (SUCCESS)
Exec "SyncthingNative_update_and_build.cmd" (SUCCESS)

![image](https://github.com/Catfriend1/syncthing-android/assets/16361913/a4c838be-d066-425f-8d13-d04a10182824)

![image](https://github.com/Catfriend1/syncthing-android/assets/16361913/0e556fc2-4343-40e3-bf26-96b9ef19f55e)
