### PR TITLE
i18n: Indirect string-array declarations through arrays.xml

### DIFF
--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -99,11 +99,9 @@
     <!-- Setting title -->
     <string name="compression">Компресиране</string>
     <!-- Strings representing compression options -->
-    <string-array name="compress_entries">
-        <item>Изключено</item>
-        <item>Само мета информацията</item>
-        <item>Всички данни</item>
-    </string-array>
+    <string name="compress_never">Изключено</string>
+    <string name="compress_metadata">Само мета информацията</string>
+    <string name="compress_always">Всички данни</string>
     <!-- Setting title -->
     <string name="introducer">Може да предлага други устройства</string>
     <!-- ActionBar item -->
@@ -208,21 +206,17 @@
     <!-- Shown when a device ID is copied to the clipboard -->
     <string name="device_id_copied_to_clipboard">Идентификаторът на устройството е копиран в клипборда</string>
     <!-- Strings representing units for file sizes, from smallest to largest -->
-    <string-array name="file_size_units">
-        <item>B</item>
-        <item>KiB</item>
-        <item>MiB</item>
-        <item>GiB</item>
-        <item>TiB</item>
-    </string-array>
+    <string name="file_size_unit_B">B</string>
+    <string name="file_size_unit_KiB">KiB</string>
+    <string name="file_size_unit_MiB">MiB</string>
+    <string name="file_size_unit_GiB">GiB</string>
+    <string name="file_size_unit_TiB">TiB</string>
     <!-- Strings representing units for transfer rates, from smallest to largest -->
-    <string-array name="transfer_rate_units">
-        <item>B/s</item>
-        <item>KiB/s</item>
-        <item>MiB/s</item>
-        <item>GiB/s</item>
-        <item>TiB/s</item>
-    </string-array>
+    <string name="transfer_rate_unit_B_s">B/s</string>
+    <string name="transfer_rate_unit_KiB_s">KiB/s</string>
+    <string name="transfer_rate_unit_MiB_s">MiB/s</string>
+    <string name="transfer_rate_unit_GiB_s">GiB/s</string>
+    <string name="transfer_rate_unit_TiB_s">TiB/s</string>
     <string name="state_scanning">Сканиране</string>
     <string name="state_syncing">Синхронизиране (%1$d%%)</string>
     <string name="state_error">Грешка</string>

--- a/app/src/main/res/values-ca-rES/strings.xml
+++ b/app/src/main/res/values-ca-rES/strings.xml
@@ -177,11 +177,9 @@
     <!-- Setting title -->
     <string name="compression">Compressió</string>
     <!-- Strings representing compression options -->
-    <string-array name="compress_entries">
-        <item>Mai</item>
-        <item>Metadades</item>
-        <item>Sempre</item>
-    </string-array>
+    <string name="compress_never">Mai</string>
+    <string name="compress_metadata">Metadades</string>
+    <string name="compress_always">Sempre</string>
     <!-- Setting title -->
     <string name="introducer">Introductor</string>
     <!-- Setting title -->
@@ -258,11 +256,9 @@
     <string name="sync_only_wifi_ssids_location_permission_rejected_dialog_title">Calen permisos</string>
     <string name="sync_only_wifi_ssids_location_permission_rejected_dialog_content">A partir de l\'Android 8.1, cal tenir accés a la ubicació per poder llegir el nom de la WiFi. Només ho podreu fer si concediu aquest permís.</string>
     <string name="power_source_title">Executa quan el dispositiu estigui encès</string>
-    <string-array name="power_source_entries">
-        <item>Connectat a la corrent i amb bateria</item>
-        <item>Connectat a la corrent</item>
-        <item>Amb bateria</item>
-    </string-array>
+    <string name="power_source_ac_and_battery_power">Connectat a la corrent i amb bateria</string>
+    <string name="power_source_ac_power">Connectat a la corrent</string>
+    <string name="power_source_battery_power">Amb bateria</string>
     <string name="respect_battery_saving_title">Respecta la configuració d\'estalvi de bateria de l\'Android</string>
     <string name="respect_battery_saving_summary">Desactiva el Syncthing durant el mode d\'estalvi de bateria.</string>
     <string name="respect_master_sync_title">Respecta l\'ajustament de l\'Android d\'\'Auto-sincronitzar dades\'</string>
@@ -277,27 +273,20 @@
     <string name="preference_language_title">Idioma</string>
     <string name="preference_language_summary">Canvieu l\'idioma de l\'aplicació</string>
     <string name="pref_language_default">Idioma per defecte</string>
-    <string-array name="folder_types">
-        <item>Envia i rep</item>
-        <item>Només envia</item>
-        <item>Només rep</item>
-        <item>Receive Encrypted</item>
-    </string-array>
-    <string-array name="pull_order_types">
-        <item>Aleatori</item>
-        <item>Alfabètic</item>
-        <item>Primer el més petit</item>
-        <item>Primer el més gran</item>
-        <item>Primer el més antic</item>
-        <item>Primer el més nou</item>
-    </string-array>
-    <string-array name="versioning_types">
-        <item>Cap</item>
-        <item>Paperera</item>
-        <item>Simple</item>
-        <item>Escalonat</item>
-        <item>Extern</item>
-    </string-array>
+    <string name="folder_type_send_receive">Envia i rep</string>
+    <string name="folder_type_send_only">Només envia</string>
+    <string name="folder_type_receive_only">Només rep</string>
+    <string name="pull_order_random">Aleatori</string>
+    <string name="pull_order_alphabetic">Alfabètic</string>
+    <string name="pull_order_smallest_first">Primer el més petit</string>
+    <string name="pull_order_largest_first">Primer el més gran</string>
+    <string name="pull_order_oldest_first">Primer el més antic</string>
+    <string name="pull_order_newest_first">Primer el més nou</string>
+    <string name="versioning_type_none">Cap</string>
+    <string name="versioning_type_trashcan">Paperera</string>
+    <string name="versioning_type_simple">Simple</string>
+    <string name="versioning_type_staggered">Escalonat</string>
+    <string name="versioning_type_external">Extern</string>
     <string name="device_name">Nom del dispositiu</string>
     <string name="listen_address">Adreces d\'escolta del protocol de sincronització</string>
     <string name="max_recv_kbps">Límit de transferència entrant (KiB/s)</string>
@@ -481,21 +470,17 @@
     <!-- Shown when a device ID is copied to the clipboard -->
     <string name="device_id_copied_to_clipboard">S\'ha copiat la ID del dispositiu al porta-retalls</string>
     <!-- Strings representing units for file sizes, from smallest to largest -->
-    <string-array name="file_size_units">
-        <item>B</item>
-        <item>KiB</item>
-        <item>MiB</item>
-        <item>GiB</item>
-        <item>TiB</item>
-    </string-array>
+    <string name="file_size_unit_B">B</string>
+    <string name="file_size_unit_KiB">KiB</string>
+    <string name="file_size_unit_MiB">MiB</string>
+    <string name="file_size_unit_GiB">GiB</string>
+    <string name="file_size_unit_TiB">TiB</string>
     <!-- Strings representing units for transfer rates, from smallest to largest -->
-    <string-array name="transfer_rate_units">
-        <item>B/s</item>
-        <item>KiB/s</item>
-        <item>MiB/s</item>
-        <item>GiB/s</item>
-        <item>TiB/s</item>
-    </string-array>
+    <string name="transfer_rate_unit_B_s">B/s</string>
+    <string name="transfer_rate_unit_KiB_s">KiB/s</string>
+    <string name="transfer_rate_unit_MiB_s">MiB/s</string>
+    <string name="transfer_rate_unit_GiB_s">GiB/s</string>
+    <string name="transfer_rate_unit_TiB_s">TiB/s</string>
     <string name="state_scanning">Escanejant</string>
     <string name="state_syncing_general">Sincronitzant</string>
     <string name="state_syncing">Sincronitzant (%1$d%%)</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -109,11 +109,9 @@
     <!-- Setting title -->
     <string name="compression">Komprese</string>
     <!-- Strings representing compression options -->
-    <string-array name="compress_entries">
-        <item>Vypnuta</item>
-        <item>Metadata</item>
-        <item>Všechno</item>
-    </string-array>
+    <string name="compress_never">Vypnuta</string>
+    <string name="compress_metadata">Metadata</string>
+    <string name="compress_always">Všechno</string>
     <!-- Setting title -->
     <string name="introducer">Zavaděč</string>
     <!-- ActionBar item -->
@@ -150,13 +148,11 @@
     <string name="preference_language_title">Jazyk</string>
     <string name="preference_language_summary">Změnit jazyk aplikace</string>
     <string name="pref_language_default">Výchozí jazyk</string>
-    <string-array name="versioning_types">
-        <item>Žádné</item>
-        <item>Odpadkový koš</item>
-        <item>Jednoduché</item>
-        <item>Postupné</item>
-        <item>Externí</item>
-    </string-array>
+    <string name="versioning_type_none">Žádné</string>
+    <string name="versioning_type_trashcan">Odpadkový koš</string>
+    <string name="versioning_type_simple">Jednoduché</string>
+    <string name="versioning_type_staggered">Postupné</string>
+    <string name="versioning_type_external">Externí</string>
     <string name="device_name">Jméno přístroje</string>
     <string name="listen_address">Adresy naslouchání protokolu synchronizace</string>
     <string name="max_recv_kbps">Omezení příchozí rychlosti (KiB/s)</string>
@@ -279,21 +275,17 @@
     <!-- Shown when a device ID is copied to the clipboard -->
     <string name="device_id_copied_to_clipboard">ID přístroje bylo zkopírováno schránky</string>
     <!-- Strings representing units for file sizes, from smallest to largest -->
-    <string-array name="file_size_units">
-        <item>B</item>
-        <item>KiB</item>
-        <item>MiB</item>
-        <item>GiB</item>
-        <item>TiB</item>
-    </string-array>
+    <string name="file_size_unit_B">B</string>
+    <string name="file_size_unit_KiB">KiB</string>
+    <string name="file_size_unit_MiB">MiB</string>
+    <string name="file_size_unit_GiB">GiB</string>
+    <string name="file_size_unit_TiB">TiB</string>
     <!-- Strings representing units for transfer rates, from smallest to largest -->
-    <string-array name="transfer_rate_units">
-        <item>B/s</item>
-        <item>KiB/s</item>
-        <item>MiB/s</item>
-        <item>GiB/s</item>
-        <item>TiB/s</item>
-    </string-array>
+    <string name="transfer_rate_unit_B_s">B/s</string>
+    <string name="transfer_rate_unit_KiB_s">KiB/s</string>
+    <string name="transfer_rate_unit_MiB_s">MiB/s</string>
+    <string name="transfer_rate_unit_GiB_s">GiB/s</string>
+    <string name="transfer_rate_unit_TiB_s">TiB/s</string>
     <string name="state_up_to_date">Aktuální</string>
     <string name="state_scanning">Skenování</string>
     <string name="state_syncing">Synchronizuje se (%1$d%%)</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -168,11 +168,9 @@
     <!-- Setting title -->
     <string name="compression">Kompression</string>
     <!-- Strings representing compression options -->
-    <string-array name="compress_entries">
-        <item>Aldrig</item>
-        <item>Metadata</item>
-        <item>Altid</item>
-    </string-array>
+    <string name="compress_never">Aldrig</string>
+    <string name="compress_metadata">Metadata</string>
+    <string name="compress_always">Altid</string>
     <!-- Setting title -->
     <string name="introducer">Introducer</string>
     <!-- Setting title -->
@@ -248,11 +246,9 @@
     <string name="sync_only_wifi_ssids_location_permission_rejected_dialog_title">Tilladelse påkrævet</string>
     <string name="sync_only_wifi_ssids_location_permission_rejected_dialog_content">Fra starten af Android 8.1, vil lokationstilladelse være krævet for at kunne læse Wi-Fi-navnet. Du kan kun bruge denne egenskab hvis du tillader denne tilladelse.</string>
     <string name="power_source_title">Kør når enheden er tilsluttet til</string>
-    <string-array name="power_source_entries">
-        <item>AC og batteri strøm</item>
-        <item>AC strøm.</item>
-        <item>Batteri strøm</item>
-    </string-array>
+    <string name="power_source_ac_and_battery_power">AC og batteri strøm</string>
+    <string name="power_source_ac_power">AC strøm.</string>
+    <string name="power_source_battery_power">Batteri strøm</string>
     <string name="respect_battery_saving_title">Respekter Android battery saving indstillinger</string>
     <string name="respect_battery_saving_summary">Afbryd Syncthing hvis batteribesparelse er aktivt.</string>
     <string name="respect_master_sync_title">Respekter Android \'Auto-sync data\' indstilling</string>
@@ -266,27 +262,20 @@
     <string name="preference_language_title">Sprog</string>
     <string name="preference_language_summary">Ændr app sproget</string>
     <string name="pref_language_default">Default Sprog</string>
-    <string-array name="folder_types">
-        <item>Send &amp; Modtag </item>
-        <item>Send Kun</item>
-        <item>Modtag Kun</item>
-        <item>Receive Encrypted</item>
-    </string-array>
-    <string-array name="pull_order_types">
-        <item>Tilfældig</item>
-        <item>Alfabetisk</item>
-        <item>Mindste Først</item>
-        <item>Størst Først</item>
-        <item>Ældste Først</item>
-        <item>Nyeste Først</item>
-    </string-array>
-    <string-array name="versioning_types">
-        <item>Ingen</item>
-        <item>Skraldespand</item>
-        <item>Simpel</item>
-        <item>Forskudt</item>
-        <item>Ekstern</item>
-    </string-array>
+    <string name="folder_type_send_receive">Send &amp; Modtag </string>
+    <string name="folder_type_send_only">Send Kun</string>
+    <string name="folder_type_receive_only">Modtag Kun</string>
+    <string name="pull_order_random">Tilfældig</string>
+    <string name="pull_order_alphabetic">Alfabetisk</string>
+    <string name="pull_order_smallest_first">Mindste Først</string>
+    <string name="pull_order_largest_first">Størst Først</string>
+    <string name="pull_order_oldest_first">Ældste Først</string>
+    <string name="pull_order_newest_first">Nyeste Først</string>
+    <string name="versioning_type_none">Ingen</string>
+    <string name="versioning_type_trashcan">Skraldespand</string>
+    <string name="versioning_type_simple">Simpel</string>
+    <string name="versioning_type_staggered">Forskudt</string>
+    <string name="versioning_type_external">Ekstern</string>
     <string name="device_name">Enhedens navn</string>
     <string name="listen_address">Sync Protocol Listen Addresser</string>
     <string name="max_recv_kbps">Indgående Rate Limit (KiB/s)</string>
@@ -463,21 +452,17 @@
     <!-- Shown when a device ID is copied to the clipboard -->
     <string name="device_id_copied_to_clipboard">Enheds-ID kopieret til clipboard</string>
     <!-- Strings representing units for file sizes, from smallest to largest -->
-    <string-array name="file_size_units">
-        <item>B</item>
-        <item>KiB</item>
-        <item>MiB</item>
-        <item>GiB</item>
-        <item>TiB</item>
-    </string-array>
+    <string name="file_size_unit_B">B</string>
+    <string name="file_size_unit_KiB">KiB</string>
+    <string name="file_size_unit_MiB">MiB</string>
+    <string name="file_size_unit_GiB">GiB</string>
+    <string name="file_size_unit_TiB">TiB</string>
     <!-- Strings representing units for transfer rates, from smallest to largest -->
-    <string-array name="transfer_rate_units">
-        <item>B/s</item>
-        <item>KiB/s</item>
-        <item>MiB/s</item>
-        <item>GiB/s</item>
-        <item>TiB/s</item>
-    </string-array>
+    <string name="transfer_rate_unit_B_s">B/s</string>
+    <string name="transfer_rate_unit_KiB_s">KiB/s</string>
+    <string name="transfer_rate_unit_MiB_s">MiB/s</string>
+    <string name="transfer_rate_unit_GiB_s">GiB/s</string>
+    <string name="transfer_rate_unit_TiB_s">TiB/s</string>
     <string name="state_scanning">Scanner</string>
     <string name="state_syncing">Synkroniserer (%1$d%%)</string>
     <string name="state_error">Fejl</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -232,11 +232,9 @@
     <!-- Setting title -->
     <string name="compression">Datenkomprimierung</string>
     <!-- Strings representing compression options -->
-    <string-array name="compress_entries">
-        <item>Nie</item>
-        <item>Metadaten</item>
-        <item>Immer</item>
-    </string-array>
+    <string name="compress_never">Nie</string>
+    <string name="compress_metadata">Metadaten</string>
+    <string name="compress_always">Immer</string>
     <!-- Setting title -->
     <string name="introducer">Verteilergerät</string>
     <!-- Setting title -->
@@ -351,11 +349,9 @@
     <string name="sync_only_wifi_ssids_location_permission_rejected_dialog_title">Berechtigung benötigt</string>
     <string name="sync_only_wifi_ssids_location_permission_rejected_dialog_content">Mit Android 8.1 beginnend wird der Standortzugriff dazu benötigt, den WLAN-Namen zu ermitteln. Daher kann diese Funktion nur genutzt werden, wenn diese Berechtigung erteilt wird.</string>
     <string name="power_source_title">Starte, wenn Gerät betrieben per</string>
-    <string-array name="power_source_entries">
-        <item>Ladegerät und Akku</item>
-        <item>Ladegerät</item>
-        <item>Akku</item>
-    </string-array>
+    <string name="power_source_ac_and_battery_power">Ladegerät und Akku</string>
+    <string name="power_source_ac_power">Ladegerät</string>
+    <string name="power_source_battery_power">Akku</string>
     <string name="respect_battery_saving_title">Berücksichtige Android Energiesparmodus</string>
     <string name="respect_battery_saving_summary">Stoppe Syncthing während der Energiesparmodus aktiv ist.</string>
     <string name="respect_master_sync_title">Berücksichtige \"Autom. Datensynchronisierung\"</string>
@@ -378,27 +374,20 @@
     <string name="preference_language_title">Sprache</string>
     <string name="preference_language_summary">Anwendungssprache ändern</string>
     <string name="pref_language_default">Standardsprache</string>
-    <string-array name="folder_types">
-        <item>Senden &amp; Empfangen</item>
-        <item>Nur Senden</item>
-        <item>Nur Empfangen</item>
-        <item>Empfange verschlüsselt</item>
-    </string-array>
-    <string-array name="pull_order_types">
-        <item>Zufall</item>
-        <item>Alphabetisch</item>
-        <item>Kleinstes zuerst</item>
-        <item>Größtes zuerst</item>
-        <item>Älteste zuerst</item>
-        <item>Neueste zuerst</item>
-    </string-array>
-    <string-array name="versioning_types">
-        <item>Keine</item>
-        <item>Papierkorb</item>
-        <item>Einfach</item>
-        <item>Gestaffelt</item>
-        <item>Extern</item>
-    </string-array>
+    <string name="folder_type_send_receive">Senden &amp; Empfangen</string>
+    <string name="folder_type_send_only">Nur Senden</string>
+    <string name="folder_type_receive_only">Nur Empfangen</string>
+    <string name="pull_order_random">Zufall</string>
+    <string name="pull_order_alphabetic">Alphabetisch</string>
+    <string name="pull_order_smallest_first">Kleinstes zuerst</string>
+    <string name="pull_order_largest_first">Größtes zuerst</string>
+    <string name="pull_order_oldest_first">Älteste zuerst</string>
+    <string name="pull_order_newest_first">Neueste zuerst</string>
+    <string name="versioning_type_none">Keine</string>
+    <string name="versioning_type_trashcan">Papierkorb</string>
+    <string name="versioning_type_simple">Einfach</string>
+    <string name="versioning_type_staggered">Gestaffelt</string>
+    <string name="versioning_type_external">Extern</string>
     <string name="device_name">Gerätename</string>
     <string name="listen_address">Adresse(n) für das Synchronisierungsprotokoll</string>
     <string name="max_recv_kbps">Eingehende Datenrate Limite (KiB/s)</string>
@@ -650,21 +639,17 @@
     <!-- Shown when a device ID is copied to the clipboard -->
     <string name="device_id_copied_to_clipboard">Geräte-ID in die Zwischenablage kopiert</string>
     <!-- Strings representing units for file sizes, from smallest to largest -->
-    <string-array name="file_size_units">
-        <item>B</item>
-        <item>KB</item>
-        <item>MB</item>
-        <item>GB</item>
-        <item>TB</item>
-    </string-array>
+    <string name="file_size_unit_B">B</string>
+    <string name="file_size_unit_KiB">KB</string>
+    <string name="file_size_unit_MiB">MB</string>
+    <string name="file_size_unit_GiB">GB</string>
+    <string name="file_size_unit_TiB">TB</string>
     <!-- Strings representing units for transfer rates, from smallest to largest -->
-    <string-array name="transfer_rate_units">
-        <item>B/s</item>
-        <item>KB/s</item>
-        <item>MB/s</item>
-        <item>GB/s</item>
-        <item>TB/s</item>
-    </string-array>
+    <string name="transfer_rate_unit_B_s">B/s</string>
+    <string name="transfer_rate_unit_KiB_s">KB/s</string>
+    <string name="transfer_rate_unit_MiB_s">MB/s</string>
+    <string name="transfer_rate_unit_GiB_s">GB/s</string>
+    <string name="transfer_rate_unit_TiB_s">TB/s</string>
     <!-- Possible folder states -->
     <string name="state_failed_items">Fehlgeschlagene Elemente (%1$d)</string>
     <string name="state_up_to_date">Aktuell</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -106,11 +106,9 @@
     <!-- Setting title -->
     <string name="compression">Συμπίεση</string>
     <!-- Strings representing compression options -->
-    <string-array name="compress_entries">
-        <item>Ποτέ</item>
-        <item>Μεταδεδομένα</item>
-        <item>Πάντα</item>
-    </string-array>
+    <string name="compress_never">Ποτέ</string>
+    <string name="compress_metadata">Μεταδεδομένα</string>
+    <string name="compress_always">Πάντα</string>
     <!-- Setting title -->
     <string name="introducer">Βασικός κόμβος</string>
     <!-- ActionBar item -->
@@ -147,13 +145,11 @@
     <string name="preference_language_title">Γλώσσα</string>
     <string name="preference_language_summary">Αλλαγή γλώσσας της εφαρμογής</string>
     <string name="pref_language_default">Προεπιλεγμένη γλώσσα</string>
-    <string-array name="versioning_types">
-        <item>Καμία</item>
-        <item>Κάδος ανακύκλωσης</item>
-        <item>Απλή</item>
-        <item>Κλιμακούμενη</item>
-        <item>Εξωτερική</item>
-    </string-array>
+    <string name="versioning_type_none">Καμία</string>
+    <string name="versioning_type_trashcan">Κάδος ανακύκλωσης</string>
+    <string name="versioning_type_simple">Απλή</string>
+    <string name="versioning_type_staggered">Κλιμακούμενη</string>
+    <string name="versioning_type_external">Εξωτερική</string>
     <string name="device_name">Όνομα συσκευής</string>
     <string name="listen_address">Διευθύνσεις ακρόασης πρωτοκόλλου συγχρονισμού</string>
     <string name="max_recv_kbps">Περιορισμός ταχύτητας λήψης (KiB/s)</string>
@@ -270,21 +266,17 @@
     <!-- Shown when a device ID is copied to the clipboard -->
     <string name="device_id_copied_to_clipboard">Το ID της συσκευής έχει αντιγραφεί στο πρόχειρο</string>
     <!-- Strings representing units for file sizes, from smallest to largest -->
-    <string-array name="file_size_units">
-        <item>B</item>
-        <item>KiB</item>
-        <item>MiB</item>
-        <item>GiB</item>
-        <item>TiB</item>
-    </string-array>
+    <string name="file_size_unit_B">B</string>
+    <string name="file_size_unit_KiB">KiB</string>
+    <string name="file_size_unit_MiB">MiB</string>
+    <string name="file_size_unit_GiB">GiB</string>
+    <string name="file_size_unit_TiB">TiB</string>
     <!-- Strings representing units for transfer rates, from smallest to largest -->
-    <string-array name="transfer_rate_units">
-        <item>B/s</item>
-        <item>KiB/s</item>
-        <item>MiB/s</item>
-        <item>GiB/s</item>
-        <item>TiB/s</item>
-    </string-array>
+    <string name="transfer_rate_unit_B_s">B/s</string>
+    <string name="transfer_rate_unit_KiB_s">KiB/s</string>
+    <string name="transfer_rate_unit_MiB_s">MiB/s</string>
+    <string name="transfer_rate_unit_GiB_s">GiB/s</string>
+    <string name="transfer_rate_unit_TiB_s">TiB/s</string>
     <string name="state_scanning">Σάρωση</string>
     <string name="state_syncing">Συγχρονισμός (%1$d%%)</string>
     <string name="state_error">Σφάλμα</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -92,11 +92,9 @@
     <!-- Setting title -->
     <string name="compression">Compresión</string>
     <!-- Strings representing compression options -->
-    <string-array name="compress_entries">
-        <item>Nunca</item>
-        <item>Metadatos</item>
-        <item>Siempre</item>
-    </string-array>
+    <string name="compress_never">Nunca</string>
+    <string name="compress_metadata">Metadatos</string>
+    <string name="compress_always">Siempre</string>
     <!-- Setting title -->
     <string name="introducer">Introductor</string>
     <!-- ActionBar item -->
@@ -193,21 +191,17 @@
     <!-- Shown when a device ID is copied to the clipboard -->
     <string name="device_id_copied_to_clipboard">ID del dispositivo copiada al portapapeles</string>
     <!-- Strings representing units for file sizes, from smallest to largest -->
-    <string-array name="file_size_units">
-        <item>B</item>
-        <item>KiB</item>
-        <item>MiB</item>
-        <item>GiB</item>
-        <item>TiB</item>
-    </string-array>
+    <string name="file_size_unit_B">B</string>
+    <string name="file_size_unit_KiB">KiB</string>
+    <string name="file_size_unit_MiB">MiB</string>
+    <string name="file_size_unit_GiB">GiB</string>
+    <string name="file_size_unit_TiB">TiB</string>
     <!-- Strings representing units for transfer rates, from smallest to largest -->
-    <string-array name="transfer_rate_units">
-        <item>B/s</item>
-        <item>KiB/s</item>
-        <item>MiB/s</item>
-        <item>GiB/s</item>
-        <item>TiB/s</item>
-    </string-array>
+    <string name="transfer_rate_unit_B_s">B/s</string>
+    <string name="transfer_rate_unit_KiB_s">KiB/s</string>
+    <string name="transfer_rate_unit_MiB_s">MiB/s</string>
+    <string name="transfer_rate_unit_GiB_s">GiB/s</string>
+    <string name="transfer_rate_unit_TiB_s">TiB/s</string>
     <string name="state_scanning">Escaneando</string>
     <string name="state_syncing">Sincronizando (%1$d%%)</string>
     <string name="state_error">Error</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -235,11 +235,9 @@
     <!-- Setting title -->
     <string name="compression">Compresión</string>
     <!-- Strings representing compression options -->
-    <string-array name="compress_entries">
-        <item>Nunca</item>
-        <item>Metadatos</item>
-        <item>Siempre</item>
-    </string-array>
+    <string name="compress_never">Nunca</string>
+    <string name="compress_metadata">Metadatos</string>
+    <string name="compress_always">Siempre</string>
     <!-- Setting title -->
     <string name="introducer">Introductor</string>
     <!-- Setting title -->
@@ -354,11 +352,9 @@
     <string name="sync_only_wifi_ssids_location_permission_rejected_dialog_title">Permiso requerido</string>
     <string name="sync_only_wifi_ssids_location_permission_rejected_dialog_content">A partir de Android 8.1, el acceso a la ubicación es necesario para poder leer el nombre del Wifi. Solo puedes utilizar esta función si concedes este permiso.</string>
     <string name="power_source_title">Ejecutar cuando el dispositivo está siendo alimentado mediante</string>
-    <string-array name="power_source_entries">
-        <item>Corriente Alterna y Batería</item>
-        <item>Corriente Alterna</item>
-        <item>Batería</item>
-    </string-array>
+    <string name="power_source_ac_and_battery_power">Corriente Alterna y Batería</string>
+    <string name="power_source_ac_power">Corriente Alterna</string>
+    <string name="power_source_battery_power">Batería</string>
     <string name="respect_battery_saving_title">Respeta la configuración de ahorro de batería de Android</string>
     <string name="respect_battery_saving_summary">Desactivar Syncthing si el ahorro de batería está activo.</string>
     <string name="respect_master_sync_title">Respetar el ajuste de Android \"Sincronizar datos automáticamente\"</string>
@@ -381,27 +377,20 @@
     <string name="preference_language_title">Idioma</string>
     <string name="preference_language_summary">Cambiar el idioma de la aplicación</string>
     <string name="pref_language_default">Idioma predeterminado</string>
-    <string-array name="folder_types">
-        <item>Enviar &amp; Recibir</item>
-        <item>Solo Enviar</item>
-        <item>Solo Recibir</item>
-        <item>Recibir Encriptado</item>
-    </string-array>
-    <string-array name="pull_order_types">
-        <item>Aleatorio</item>
-        <item>Alfabético</item>
-        <item>Más Pequeños Primero</item>
-        <item>Más Grandes Primero</item>
-        <item>Más Antiguos Primero</item>
-        <item>Más Nuevos Primero</item>
-    </string-array>
-    <string-array name="versioning_types">
-        <item>Ninguna</item>
-        <item>Papelera</item>
-        <item>Simple</item>
-        <item>Escalonado</item>
-        <item>Externo</item>
-    </string-array>
+    <string name="folder_type_send_receive">Enviar &amp; Recibir</string>
+    <string name="folder_type_send_only">Solo Enviar</string>
+    <string name="folder_type_receive_only">Solo Recibir</string>
+    <string name="pull_order_random">Aleatorio</string>
+    <string name="pull_order_alphabetic">Alfabético</string>
+    <string name="pull_order_smallest_first">Más Pequeños Primero</string>
+    <string name="pull_order_largest_first">Más Grandes Primero</string>
+    <string name="pull_order_oldest_first">Más Antiguos Primero</string>
+    <string name="pull_order_newest_first">Más Nuevos Primero</string>
+    <string name="versioning_type_none">Ninguna</string>
+    <string name="versioning_type_trashcan">Papelera</string>
+    <string name="versioning_type_simple">Simple</string>
+    <string name="versioning_type_staggered">Escalonado</string>
+    <string name="versioning_type_external">Externo</string>
     <string name="device_name">Nombre del dispositivo</string>
     <string name="listen_address">Direcciones de escucha del protocolo de sincronización</string>
     <string name="max_recv_kbps">Límite de tráfico de entrada (KiB/s)</string>
@@ -659,21 +648,17 @@
     <!-- Shown when a device ID is copied to the clipboard -->
     <string name="device_id_copied_to_clipboard">ID de dispositivo copiado al portapapeles</string>
     <!-- Strings representing units for file sizes, from smallest to largest -->
-    <string-array name="file_size_units">
-        <item>B</item>
-        <item>KiB</item>
-        <item>MiB</item>
-        <item>GiB</item>
-        <item>TiB</item>
-    </string-array>
+    <string name="file_size_unit_B">B</string>
+    <string name="file_size_unit_KiB">KiB</string>
+    <string name="file_size_unit_MiB">MiB</string>
+    <string name="file_size_unit_GiB">GiB</string>
+    <string name="file_size_unit_TiB">TiB</string>
     <!-- Strings representing units for transfer rates, from smallest to largest -->
-    <string-array name="transfer_rate_units">
-        <item>B/s</item>
-        <item>KiB/s</item>
-        <item>MiB/s</item>
-        <item>GiB/s</item>
-        <item>TiB/s</item>
-    </string-array>
+    <string name="transfer_rate_unit_B_s">B/s</string>
+    <string name="transfer_rate_unit_KiB_s">KiB/s</string>
+    <string name="transfer_rate_unit_MiB_s">MiB/s</string>
+    <string name="transfer_rate_unit_GiB_s">GiB/s</string>
+    <string name="transfer_rate_unit_TiB_s">TiB/s</string>
     <!-- Possible folder states -->
     <string name="state_failed_items">Elementos Fallidos (%1$d)</string>
     <string name="state_up_to_date">Actualizado</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -212,11 +212,9 @@
     <!-- Setting title -->
     <string name="compression">Pakkaus</string>
     <!-- Strings representing compression options -->
-    <string-array name="compress_entries">
-        <item>Ei koskaan</item>
-        <item>Metatiedot</item>
-        <item>Aina</item>
-    </string-array>
+    <string name="compress_never">Ei koskaan</string>
+    <string name="compress_metadata">Metatiedot</string>
+    <string name="compress_always">Aina</string>
     <!-- Setting title -->
     <string name="introducer">Esittelijä</string>
     <!-- ActionBar item -->
@@ -409,21 +407,17 @@
     <!-- Shown when a device ID is copied to the clipboard -->
     <string name="device_id_copied_to_clipboard">Laitetunnus kopioitu leikepöydälle</string>
     <!-- Strings representing units for file sizes, from smallest to largest -->
-    <string-array name="file_size_units">
-        <item>B</item>
-        <item>KiB</item>
-        <item>MiB</item>
-        <item>GiB</item>
-        <item>TiB</item>
-    </string-array>
+    <string name="file_size_unit_B">B</string>
+    <string name="file_size_unit_KiB">KiB</string>
+    <string name="file_size_unit_MiB">MiB</string>
+    <string name="file_size_unit_GiB">GiB</string>
+    <string name="file_size_unit_TiB">TiB</string>
     <!-- Strings representing units for transfer rates, from smallest to largest -->
-    <string-array name="transfer_rate_units">
-        <item>B/s</item>
-        <item>KiB/s</item>
-        <item>MiB/s</item>
-        <item>GiB/s</item>
-        <item>TiB/s</item>
-    </string-array>
+    <string name="transfer_rate_unit_B_s">B/s</string>
+    <string name="transfer_rate_unit_KiB_s">KiB/s</string>
+    <string name="transfer_rate_unit_MiB_s">MiB/s</string>
+    <string name="transfer_rate_unit_GiB_s">GiB/s</string>
+    <string name="transfer_rate_unit_TiB_s">TiB/s</string>
     <string name="state_scanning">Skannataan</string>
     <string name="state_syncing">Synkronoidaan (%1$d%%)</string>
     <string name="state_error">Virhe</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -137,11 +137,9 @@
     <!-- Setting title -->
     <string name="compression">Compression</string>
     <!-- Strings representing compression options -->
-    <string-array name="compress_entries">
-        <item>Jamais</item>
-        <item>Metadonnées</item>
-        <item>Toujours</item>
-    </string-array>
+    <string name="compress_never">Jamais</string>
+    <string name="compress_metadata">Metadonnées</string>
+    <string name="compress_always">Toujours</string>
     <!-- Setting title -->
     <string name="introducer">Initiateur</string>
     <!-- Setting title -->
@@ -183,13 +181,11 @@
     <string name="preference_language_title">Langue</string>
     <string name="preference_language_summary">Changer la langue de l\'application</string>
     <string name="pref_language_default">Langue par défaut</string>
-    <string-array name="versioning_types">
-        <item>Aucun</item>
-        <item>Corbeille</item>
-        <item>Simple</item>
-        <item>Décalé</item>
-        <item>Externe</item>
-    </string-array>
+    <string name="versioning_type_none">Aucun</string>
+    <string name="versioning_type_trashcan">Corbeille</string>
+    <string name="versioning_type_simple">Simple</string>
+    <string name="versioning_type_staggered">Décalé</string>
+    <string name="versioning_type_external">Externe</string>
     <string name="device_name">Nom de l\'appareil</string>
     <string name="listen_address">Adresse d\'écoute pour la synchro</string>
     <string name="max_recv_kbps">Limite du débit de réception (Ko/s)</string>
@@ -336,21 +332,17 @@
     <!-- Shown when a device ID is copied to the clipboard -->
     <string name="device_id_copied_to_clipboard">L\'ID d\'appareil est copié dans le bloc-notes</string>
     <!-- Strings representing units for file sizes, from smallest to largest -->
-    <string-array name="file_size_units">
-        <item>o</item>
-        <item>Ko</item>
-        <item>Mo</item>
-        <item>Go</item>
-        <item>To</item>
-    </string-array>
+    <string name="file_size_unit_B">o</string>
+    <string name="file_size_unit_KiB">Ko</string>
+    <string name="file_size_unit_MiB">Mo</string>
+    <string name="file_size_unit_GiB">Go</string>
+    <string name="file_size_unit_TiB">To</string>
     <!-- Strings representing units for transfer rates, from smallest to largest -->
-    <string-array name="transfer_rate_units">
-        <item>Octets/s</item>
-        <item>Ko/s</item>
-        <item>Mo/s</item>
-        <item>Go/s</item>
-        <item>To/s</item>
-    </string-array>
+    <string name="transfer_rate_unit_B_s">Octets/s</string>
+    <string name="transfer_rate_unit_KiB_s">Ko/s</string>
+    <string name="transfer_rate_unit_MiB_s">Mo/s</string>
+    <string name="transfer_rate_unit_GiB_s">Go/s</string>
+    <string name="transfer_rate_unit_TiB_s">To/s</string>
     <string name="state_up_to_date">à jour</string>
     <string name="state_scanning">Analyse en cours</string>
     <string name="state_syncing">Synchronisation (%1$d%%)</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -234,11 +234,9 @@ Az összesített statisztika nyilvánosan elérhető a https://data.syncthing.ne
     <!-- Setting title -->
     <string name="compression">Tömörítés</string>
     <!-- Strings representing compression options -->
-    <string-array name="compress_entries">
-        <item>Semmit</item>
-        <item>Csak metaadatot</item>
-        <item>Mindet</item>
-    </string-array>
+    <string name="compress_never">Semmit</string>
+    <string name="compress_metadata">Csak metaadatot</string>
+    <string name="compress_always">Mindet</string>
     <!-- Setting title -->
     <string name="introducer">Bevezető</string>
     <!-- Setting title -->
@@ -353,11 +351,9 @@ Az összesített statisztika nyilvánosan elérhető a https://data.syncthing.ne
     <string name="sync_only_wifi_ssids_location_permission_rejected_dialog_title">Hozzáférés szükséges</string>
     <string name="sync_only_wifi_ssids_location_permission_rejected_dialog_content">Az Android 8.1-el kezdve helyzeti hozzáférés szükséges a WiFi hálózat nevének olvasásához. Ezt a funkciót csak akkor használhatod, ha megadod ezt a hozzáférést.</string>
     <string name="power_source_title">Futtatás, ha a készülék áramellátása</string>
-    <string-array name="power_source_entries">
-        <item>AC és akkumulátoros tápellátás.</item>
-        <item>Hálózati tápellátás.</item>
-        <item>Akkumulátoros üzem.</item>
-    </string-array>
+    <string name="power_source_ac_and_battery_power">AC és akkumulátoros tápellátás.</string>
+    <string name="power_source_ac_power">Hálózati tápellátás.</string>
+    <string name="power_source_battery_power">Akkumulátoros üzem.</string>
     <string name="respect_battery_saving_title">Az Android akkumulátor-optimalizáció beállításainak tiszteletben tartása</string>
     <string name="respect_battery_saving_summary">A Syncthing letiltása, ha az akkumulátorkímélő funkció aktív.</string>
     <string name="respect_master_sync_title">Az Android \'Automatikus adatszinkronizálás\' beállításának tiszteletben tartása</string>
@@ -380,27 +376,20 @@ Az összesített statisztika nyilvánosan elérhető a https://data.syncthing.ne
     <string name="preference_language_title">Nyelv</string>
     <string name="preference_language_summary">Alkalmazás nyelvének megváltoztatása</string>
     <string name="pref_language_default">Alapértelmezett nyelv</string>
-    <string-array name="folder_types">
-        <item>Küldés és fogadás</item>
-        <item>Csak küldés</item>
-        <item>Csak fogadás</item>
-        <item>Titkosított vétel</item>
-    </string-array>
-    <string-array name="pull_order_types">
-        <item>Véletlenszerű</item>
-        <item>Betűrendes</item>
-        <item>Legkisebb elsőnek</item>
-        <item>A legnagyobb elsőként</item>
-        <item>Legrégebbi elsőnek</item>
-        <item>Legújabb elsőnek</item>
-    </string-array>
-    <string-array name="versioning_types">
-        <item>Kikapcsolva</item>
-        <item>Lomtár</item>
-        <item>Egyszerű</item>
-        <item>Lépcsőzetes</item>
-        <item>Külső</item>
-    </string-array>
+    <string name="folder_type_send_receive">Küldés és fogadás</string>
+    <string name="folder_type_send_only">Csak küldés</string>
+    <string name="folder_type_receive_only">Csak fogadás</string>
+    <string name="pull_order_random">Véletlenszerű</string>
+    <string name="pull_order_alphabetic">Betűrendes</string>
+    <string name="pull_order_smallest_first">Legkisebb elsőnek</string>
+    <string name="pull_order_largest_first">A legnagyobb elsőként</string>
+    <string name="pull_order_oldest_first">Legrégebbi elsőnek</string>
+    <string name="pull_order_newest_first">Legújabb elsőnek</string>
+    <string name="versioning_type_none">Kikapcsolva</string>
+    <string name="versioning_type_trashcan">Lomtár</string>
+    <string name="versioning_type_simple">Egyszerű</string>
+    <string name="versioning_type_staggered">Lépcsőzetes</string>
+    <string name="versioning_type_external">Külső</string>
     <string name="device_name">Eszköz neve</string>
     <string name="listen_address">IP cím a szinkronizáláshoz</string>
     <string name="max_recv_kbps">Max letöltési sebesség (KiB/s)</string>
@@ -652,21 +641,17 @@ VIGYÁZAT! Más alkalmazások kiolvashatják a backupból a titkos kulcsot, és 
     <!-- Shown when a device ID is copied to the clipboard -->
     <string name="device_id_copied_to_clipboard">Az eszközazonosító a vágólapra másolva</string>
     <!-- Strings representing units for file sizes, from smallest to largest -->
-    <string-array name="file_size_units">
-        <item>B</item>
-        <item>KiB</item>
-        <item>MiB</item>
-        <item>GiB</item>
-        <item>TiB</item>
-    </string-array>
+    <string name="file_size_unit_B">B</string>
+    <string name="file_size_unit_KiB">KiB</string>
+    <string name="file_size_unit_MiB">MiB</string>
+    <string name="file_size_unit_GiB">GiB</string>
+    <string name="file_size_unit_TiB">TiB</string>
     <!-- Strings representing units for transfer rates, from smallest to largest -->
-    <string-array name="transfer_rate_units">
-        <item>B/s</item>
-        <item>KiB/s</item>
-        <item>MiB/s</item>
-        <item>GiB/s</item>
-        <item>TiB/s</item>
-    </string-array>
+    <string name="transfer_rate_unit_B_s">B/s</string>
+    <string name="transfer_rate_unit_KiB_s">KiB/s</string>
+    <string name="transfer_rate_unit_MiB_s">MiB/s</string>
+    <string name="transfer_rate_unit_GiB_s">GiB/s</string>
+    <string name="transfer_rate_unit_TiB_s">TiB/s</string>
     <!-- Possible folder states -->
     <string name="state_failed_items">Meghiúsult tételek (%1$d)</string>
     <string name="state_up_to_date">Naprakész</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -101,11 +101,9 @@
     <!-- Setting title -->
     <string name="compression">Kompresi</string>
     <!-- Strings representing compression options -->
-    <string-array name="compress_entries">
-        <item>Jangan</item>
-        <item>Metadata</item>
-        <item>Selalu</item>
-    </string-array>
+    <string name="compress_never">Jangan</string>
+    <string name="compress_metadata">Metadata</string>
+    <string name="compress_always">Selalu</string>
     <!-- Setting title -->
     <string name="introducer">Pengenalan</string>
     <!-- ActionBar item -->

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -234,11 +234,9 @@ Si prega di segnalare eventuali problemi su Github.</string>
     <!-- Setting title -->
     <string name="compression">Compressione</string>
     <!-- Strings representing compression options -->
-    <string-array name="compress_entries">
-        <item>Mai</item>
-        <item>Metadati</item>
-        <item>Sempre</item>
-    </string-array>
+    <string name="compress_never">Mai</string>
+    <string name="compress_metadata">Metadati</string>
+    <string name="compress_always">Sempre</string>
     <!-- Setting title -->
     <string name="introducer">Introduttore</string>
     <!-- Setting title -->
@@ -353,11 +351,9 @@ Si prega di segnalare eventuali problemi su Github.</string>
     <string name="sync_only_wifi_ssids_location_permission_rejected_dialog_title">Autorizzazione richiesta</string>
     <string name="sync_only_wifi_ssids_location_permission_rejected_dialog_content">A partire da Android 8.1, è necessario l\'accesso alla posizione per poter leggere il nome del WiFi. È possibile utilizzare questa funzionalità solo se si concede questa autorizzazione.</string>
     <string name="power_source_title">Esegui quando il dispositivo è alimentato da:</string>
-    <string-array name="power_source_entries">
-        <item>Corrente e batteria.</item>
-        <item>Corrente.</item>
-        <item>Batteria.</item>
-    </string-array>
+    <string name="power_source_ac_and_battery_power">Corrente e batteria.</string>
+    <string name="power_source_ac_power">Corrente.</string>
+    <string name="power_source_battery_power">Batteria.</string>
     <string name="respect_battery_saving_title">Rispetta l\'impostazione di risparmio batteria di Android</string>
     <string name="respect_battery_saving_summary">Disabilita Syncthing se il risparmio energia è attivo.</string>
     <string name="respect_master_sync_title">Rispetta l\'impostazione di Android \'Sincronizza i dati automaticamente\'</string>
@@ -380,27 +376,20 @@ Si prega di segnalare eventuali problemi su Github.</string>
     <string name="preference_language_title">Lingua</string>
     <string name="preference_language_summary">Cambia la lingua dell\'app</string>
     <string name="pref_language_default">Lingua di default</string>
-    <string-array name="folder_types">
-        <item>Invia &amp; Ricevi</item>
-        <item>Invia solo</item>
-        <item>Ricevi solo</item>
-        <item>Receive Encrypted</item>
-    </string-array>
-    <string-array name="pull_order_types">
-        <item>Casuale</item>
-        <item>Alfabetico</item>
-        <item>Prima il più piccolo</item>
-        <item>Prima il più grande</item>
-        <item>Prima il meno recente</item>
-        <item>Prima il più recente</item>
-    </string-array>
-    <string-array name="versioning_types">
-        <item>Nessuno</item>
-        <item>Cestino</item>
-        <item>Semplice</item>
-        <item>Cadenzato</item>
-        <item>Esterno</item>
-    </string-array>
+    <string name="folder_type_send_receive">Invia &amp; Ricevi</string>
+    <string name="folder_type_send_only">Invia solo</string>
+    <string name="folder_type_receive_only">Ricevi solo</string>
+    <string name="pull_order_random">Casuale</string>
+    <string name="pull_order_alphabetic">Alfabetico</string>
+    <string name="pull_order_smallest_first">Prima il più piccolo</string>
+    <string name="pull_order_largest_first">Prima il più grande</string>
+    <string name="pull_order_oldest_first">Prima il meno recente</string>
+    <string name="pull_order_newest_first">Prima il più recente</string>
+    <string name="versioning_type_none">Nessuno</string>
+    <string name="versioning_type_trashcan">Cestino</string>
+    <string name="versioning_type_simple">Semplice</string>
+    <string name="versioning_type_staggered">Cadenzato</string>
+    <string name="versioning_type_external">Esterno</string>
     <string name="device_name">Nome Dispositivo</string>
     <string name="listen_address">Indirizzi Protocollo Sincronizzazione</string>
     <string name="max_recv_kbps">Limite Velocità in Ingresso (KiB/s)</string>
@@ -657,21 +646,17 @@ Si prega di segnalare eventuali problemi su Github.</string>
     <!-- Shown when a device ID is copied to the clipboard -->
     <string name="device_id_copied_to_clipboard">ID Dispositivo copiato negli appunti</string>
     <!-- Strings representing units for file sizes, from smallest to largest -->
-    <string-array name="file_size_units">
-        <item>B</item>
-        <item>KiB</item>
-        <item>MiB</item>
-        <item>GiB</item>
-        <item>TiB</item>
-    </string-array>
+    <string name="file_size_unit_B">B</string>
+    <string name="file_size_unit_KiB">KiB</string>
+    <string name="file_size_unit_MiB">MiB</string>
+    <string name="file_size_unit_GiB">GiB</string>
+    <string name="file_size_unit_TiB">TiB</string>
     <!-- Strings representing units for transfer rates, from smallest to largest -->
-    <string-array name="transfer_rate_units">
-        <item>B/s</item>
-        <item>KiB/s</item>
-        <item>MiB/s</item>
-        <item>GiB/s</item>
-        <item>TiB/s</item>
-    </string-array>
+    <string name="transfer_rate_unit_B_s">B/s</string>
+    <string name="transfer_rate_unit_KiB_s">KiB/s</string>
+    <string name="transfer_rate_unit_MiB_s">MiB/s</string>
+    <string name="transfer_rate_unit_GiB_s">GiB/s</string>
+    <string name="transfer_rate_unit_TiB_s">TiB/s</string>
     <!-- Possible folder states -->
     <string name="state_failed_items">Elementi Falliti (%1$d)</string>
     <string name="state_up_to_date">Sincronizzato</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -198,11 +198,9 @@
     <!-- Setting title -->
     <string name="compression">圧縮</string>
     <!-- Strings representing compression options -->
-    <string-array name="compress_entries">
-        <item>オフ</item>
-        <item>メタデータのみ</item>
-        <item>全てのデータ</item>
-    </string-array>
+    <string name="compress_never">オフ</string>
+    <string name="compress_metadata">メタデータのみ</string>
+    <string name="compress_always">全てのデータ</string>
     <!-- Setting title -->
     <string name="introducer">紹介者デバイス</string>
     <!-- Setting title -->
@@ -289,11 +287,9 @@
     <string name="sync_only_wifi_ssids_need_to_grant_location_permission">この機能を使用するには、位置情報取得許可を与える必要があります。</string>
     <string name="sync_only_wifi_ssids_location_permission_rejected_dialog_title">許可が必要</string>
     <string name="power_source_title">デバイスの電源が次のものである場合に実行</string>
-    <string-array name="power_source_entries">
-        <item>ACとバッテリー電源。</item>
-        <item>AC電源</item>
-        <item>バッテリー電源</item>
-    </string-array>
+    <string name="power_source_ac_and_battery_power">ACとバッテリー電源。</string>
+    <string name="power_source_ac_power">AC電源</string>
+    <string name="power_source_battery_power">バッテリー電源</string>
     <string name="respect_battery_saving_title">Android の節電設定に従う</string>
     <string name="respect_battery_saving_summary">バッテリー節約が有効な場合は、Syncthingを無効にします。</string>
     <string name="respect_master_sync_title">Androidの「自動同期データ」の設定を優先します。</string>
@@ -307,27 +303,20 @@
     <string name="preference_language_title">言語</string>
     <string name="preference_language_summary">アプリの言語を変更します</string>
     <string name="pref_language_default">デフォルトの言語</string>
-    <string-array name="folder_types">
-        <item>送信と受信</item>
-        <item>送信のみ</item>
-        <item>受信のみ</item>
-        <item>Receive Encrypted</item>
-    </string-array>
-    <string-array name="pull_order_types">
-        <item>ランダム</item>
-        <item>アルファベット順</item>
-        <item>小さい順</item>
-        <item>大きい順</item>
-        <item>古い順</item>
-        <item>新しい順</item>
-    </string-array>
-    <string-array name="versioning_types">
-        <item>なし</item>
-        <item>ゴミ箱</item>
-        <item>シンプル</item>
-        <item>ジグザグ</item>
-        <item>外部</item>
-    </string-array>
+    <string name="folder_type_send_receive">送信と受信</string>
+    <string name="folder_type_send_only">送信のみ</string>
+    <string name="folder_type_receive_only">受信のみ</string>
+    <string name="pull_order_random">ランダム</string>
+    <string name="pull_order_alphabetic">アルファベット順</string>
+    <string name="pull_order_smallest_first">小さい順</string>
+    <string name="pull_order_largest_first">大きい順</string>
+    <string name="pull_order_oldest_first">古い順</string>
+    <string name="pull_order_newest_first">新しい順</string>
+    <string name="versioning_type_none">なし</string>
+    <string name="versioning_type_trashcan">ゴミ箱</string>
+    <string name="versioning_type_simple">シンプル</string>
+    <string name="versioning_type_staggered">ジグザグ</string>
+    <string name="versioning_type_external">外部</string>
     <string name="device_name">デバイス名</string>
     <string name="listen_address">同期プロトコルの待ち受けアドレス</string>
     <string name="max_recv_kbps">下り帯域制限 (KiB/秒)</string>
@@ -487,21 +476,17 @@
     <!-- Shown when a device ID is copied to the clipboard -->
     <string name="device_id_copied_to_clipboard">デバイス ID をクリップボードにコピーしました</string>
     <!-- Strings representing units for file sizes, from smallest to largest -->
-    <string-array name="file_size_units">
-        <item>B</item>
-        <item>KiB</item>
-        <item>MiB</item>
-        <item>GiB</item>
-        <item>TiB</item>
-    </string-array>
+    <string name="file_size_unit_B">B</string>
+    <string name="file_size_unit_KiB">KiB</string>
+    <string name="file_size_unit_MiB">MiB</string>
+    <string name="file_size_unit_GiB">GiB</string>
+    <string name="file_size_unit_TiB">TiB</string>
     <!-- Strings representing units for transfer rates, from smallest to largest -->
-    <string-array name="transfer_rate_units">
-        <item>B/s</item>
-        <item>KiB/s</item>
-        <item>MiB/s</item>
-        <item>GiB/s</item>
-        <item>TiB/s</item>
-    </string-array>
+    <string name="transfer_rate_unit_B_s">B/s</string>
+    <string name="transfer_rate_unit_KiB_s">KiB/s</string>
+    <string name="transfer_rate_unit_MiB_s">MiB/s</string>
+    <string name="transfer_rate_unit_GiB_s">GiB/s</string>
+    <string name="transfer_rate_unit_TiB_s">TiB/s</string>
     <string name="state_up_to_date">最新化</string>
     <string name="state_scanning">スキャン中</string>
     <string name="state_syncing_general">同期中</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -105,11 +105,9 @@
     <!-- Setting title -->
     <string name="compression">압축</string>
     <!-- Strings representing compression options -->
-    <string-array name="compress_entries">
-        <item>안함</item>
-        <item>메타데이터</item>
-        <item>항상</item>
-    </string-array>
+    <string name="compress_never">안함</string>
+    <string name="compress_metadata">메타데이터</string>
+    <string name="compress_always">항상</string>
     <!-- Setting title -->
     <string name="introducer">Introducer</string>
     <!-- ActionBar item -->
@@ -146,13 +144,11 @@
     <string name="preference_language_title">언어</string>
     <string name="preference_language_summary">언어 변경하기</string>
     <string name="pref_language_default">기본 언어</string>
-    <string-array name="versioning_types">
-        <item>없음</item>
-        <item>휴지통</item>
-        <item>단순</item>
-        <item>교차</item>
-        <item>외부</item>
-    </string-array>
+    <string name="versioning_type_none">없음</string>
+    <string name="versioning_type_trashcan">휴지통</string>
+    <string name="versioning_type_simple">단순</string>
+    <string name="versioning_type_staggered">교차</string>
+    <string name="versioning_type_external">외부</string>
     <string name="device_name">기기명</string>
     <string name="listen_address">동기화 프로토콜 수신 주소</string>
     <string name="max_recv_kbps">다운로드 속도 제한 (KiB/s)</string>
@@ -268,21 +264,17 @@
     <!-- Shown when a device ID is copied to the clipboard -->
     <string name="device_id_copied_to_clipboard">기기 ID가 클립보드에 복사되었습니다</string>
     <!-- Strings representing units for file sizes, from smallest to largest -->
-    <string-array name="file_size_units">
-        <item>B</item>
-        <item>KiB</item>
-        <item>MiB</item>
-        <item>GiB</item>
-        <item>TiB</item>
-    </string-array>
+    <string name="file_size_unit_B">B</string>
+    <string name="file_size_unit_KiB">KiB</string>
+    <string name="file_size_unit_MiB">MiB</string>
+    <string name="file_size_unit_GiB">GiB</string>
+    <string name="file_size_unit_TiB">TiB</string>
     <!-- Strings representing units for transfer rates, from smallest to largest -->
-    <string-array name="transfer_rate_units">
-        <item>B/s</item>
-        <item>KiB/s</item>
-        <item>MiB/s</item>
-        <item>GiB/s</item>
-        <item>TiB/s</item>
-    </string-array>
+    <string name="transfer_rate_unit_B_s">B/s</string>
+    <string name="transfer_rate_unit_KiB_s">KiB/s</string>
+    <string name="transfer_rate_unit_MiB_s">MiB/s</string>
+    <string name="transfer_rate_unit_GiB_s">GiB/s</string>
+    <string name="transfer_rate_unit_TiB_s">TiB/s</string>
     <string name="state_scanning">스캔 중</string>
     <string name="state_syncing">동기화 중 (%1$d%%)</string>
     <string name="state_error">오류</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -94,11 +94,9 @@
     <!-- Setting title -->
     <string name="compression">Komprimering</string>
     <!-- Strings representing compression options -->
-    <string-array name="compress_entries">
-        <item>Aldri</item>
-        <item>Metadata</item>
-        <item>Alltid</item>
-    </string-array>
+    <string name="compress_never">Aldri</string>
+    <string name="compress_metadata">Metadata</string>
+    <string name="compress_always">Alltid</string>
     <!-- Setting title -->
     <string name="introducer">Innføring</string>
     <!-- ActionBar item -->
@@ -197,21 +195,17 @@
     <!-- Shown when a device ID is copied to the clipboard -->
     <string name="device_id_copied_to_clipboard">Enhets-ID kopiert til utklippstavle</string>
     <!-- Strings representing units for file sizes, from smallest to largest -->
-    <string-array name="file_size_units">
-        <item>B</item>
-        <item>KiB</item>
-        <item>MiB</item>
-        <item>GiB</item>
-        <item>TiB</item>
-    </string-array>
+    <string name="file_size_unit_B">B</string>
+    <string name="file_size_unit_KiB">KiB</string>
+    <string name="file_size_unit_MiB">MiB</string>
+    <string name="file_size_unit_GiB">GiB</string>
+    <string name="file_size_unit_TiB">TiB</string>
     <!-- Strings representing units for transfer rates, from smallest to largest -->
-    <string-array name="transfer_rate_units">
-        <item>B/s</item>
-        <item>KiB/s</item>
-        <item>MiB/s</item>
-        <item>GiB/s</item>
-        <item>TiB/s</item>
-    </string-array>
+    <string name="transfer_rate_unit_B_s">B/s</string>
+    <string name="transfer_rate_unit_KiB_s">KiB/s</string>
+    <string name="transfer_rate_unit_MiB_s">MiB/s</string>
+    <string name="transfer_rate_unit_GiB_s">GiB/s</string>
+    <string name="transfer_rate_unit_TiB_s">TiB/s</string>
     <string name="state_scanning">Skanner</string>
     <string name="state_syncing">Synkroniserer (%1$d%%)</string>
     <string name="state_error">Feil</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -137,11 +137,9 @@
     <!-- Setting title -->
     <string name="compression">Compressie</string>
     <!-- Strings representing compression options -->
-    <string-array name="compress_entries">
-        <item>Nooit</item>
-        <item>Alleen metadata</item>
-        <item>Altijd</item>
-    </string-array>
+    <string name="compress_never">Nooit</string>
+    <string name="compress_metadata">Alleen metadata</string>
+    <string name="compress_always">Altijd</string>
     <!-- Setting title -->
     <string name="introducer">Introduceerder</string>
     <!-- Setting title -->
@@ -183,13 +181,11 @@
     <string name="preference_language_title">Taal</string>
     <string name="preference_language_summary">Wijzig de taal van de app</string>
     <string name="pref_language_default">Standaardtaal</string>
-    <string-array name="versioning_types">
-        <item>Geen</item>
-        <item>Prullenbak</item>
-        <item>Eenvoudig</item>
-        <item>Gespreid</item>
-        <item>Extern</item>
-    </string-array>
+    <string name="versioning_type_none">Geen</string>
+    <string name="versioning_type_trashcan">Prullenbak</string>
+    <string name="versioning_type_simple">Eenvoudig</string>
+    <string name="versioning_type_staggered">Gespreid</string>
+    <string name="versioning_type_external">Extern</string>
     <string name="device_name">Apparaatnaam</string>
     <string name="listen_address">Luisteradressen voor synchronisatieprotocol</string>
     <string name="max_recv_kbps">Inkomende snelheidslimiet (KiB/s)</string>
@@ -331,21 +327,17 @@
     <!-- Shown when a device ID is copied to the clipboard -->
     <string name="device_id_copied_to_clipboard">Apparaat-ID gekopieerd naar klembord</string>
     <!-- Strings representing units for file sizes, from smallest to largest -->
-    <string-array name="file_size_units">
-        <item>B</item>
-        <item>KiB</item>
-        <item>MiB</item>
-        <item>GiB</item>
-        <item>TiB</item>
-    </string-array>
+    <string name="file_size_unit_B">B</string>
+    <string name="file_size_unit_KiB">KiB</string>
+    <string name="file_size_unit_MiB">MiB</string>
+    <string name="file_size_unit_GiB">GiB</string>
+    <string name="file_size_unit_TiB">TiB</string>
     <!-- Strings representing units for transfer rates, from smallest to largest -->
-    <string-array name="transfer_rate_units">
-        <item>B/s</item>
-        <item>KiB/s</item>
-        <item>MiB/s</item>
-        <item>GiB/s</item>
-        <item>TiB/s</item>
-    </string-array>
+    <string name="transfer_rate_unit_B_s">B/s</string>
+    <string name="transfer_rate_unit_KiB_s">KiB/s</string>
+    <string name="transfer_rate_unit_MiB_s">MiB/s</string>
+    <string name="transfer_rate_unit_GiB_s">GiB/s</string>
+    <string name="transfer_rate_unit_TiB_s">TiB/s</string>
     <string name="state_scanning">Bezig met scannen</string>
     <string name="state_syncing">Bezig met synchroniseren (%1$d%%)</string>
     <string name="state_error">Fout</string>

--- a/app/src/main/res/values-nn/strings.xml
+++ b/app/src/main/res/values-nn/strings.xml
@@ -94,11 +94,9 @@
     <!-- Setting title -->
     <string name="compression">Komprimering</string>
     <!-- Strings representing compression options -->
-    <string-array name="compress_entries">
-        <item>Aldri</item>
-        <item>Metadata</item>
-        <item>Alltid</item>
-    </string-array>
+    <string name="compress_never">Aldri</string>
+    <string name="compress_metadata">Metadata</string>
+    <string name="compress_always">Alltid</string>
     <!-- Setting title -->
     <string name="introducer">Introduktør</string>
     <!-- ActionBar item -->
@@ -197,21 +195,17 @@
     <!-- Shown when a device ID is copied to the clipboard -->
     <string name="device_id_copied_to_clipboard">Einings-ID kopiert til utklippstavla</string>
     <!-- Strings representing units for file sizes, from smallest to largest -->
-    <string-array name="file_size_units">
-        <item>B</item>
-        <item>KiB</item>
-        <item>MiB</item>
-        <item>GiB</item>
-        <item>TiB</item>
-    </string-array>
+    <string name="file_size_unit_B">B</string>
+    <string name="file_size_unit_KiB">KiB</string>
+    <string name="file_size_unit_MiB">MiB</string>
+    <string name="file_size_unit_GiB">GiB</string>
+    <string name="file_size_unit_TiB">TiB</string>
     <!-- Strings representing units for transfer rates, from smallest to largest -->
-    <string-array name="transfer_rate_units">
-        <item>B/s</item>
-        <item>KiB/s</item>
-        <item>MiB/s</item>
-        <item>GiB/s</item>
-        <item>TiB/s</item>
-    </string-array>
+    <string name="transfer_rate_unit_B_s">B/s</string>
+    <string name="transfer_rate_unit_KiB_s">KiB/s</string>
+    <string name="transfer_rate_unit_MiB_s">MiB/s</string>
+    <string name="transfer_rate_unit_GiB_s">GiB/s</string>
+    <string name="transfer_rate_unit_TiB_s">TiB/s</string>
     <string name="state_scanning">Skannar</string>
     <string name="state_syncing">Synkroniserer (%1$d%%)</string>
     <string name="state_error">Feil</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -190,11 +190,9 @@
     <!-- Setting title -->
     <string name="compression">Kompresja</string>
     <!-- Strings representing compression options -->
-    <string-array name="compress_entries">
-        <item>Brak</item>
-        <item>Metadane</item>
-        <item>Wszystko</item>
-    </string-array>
+    <string name="compress_never">Brak</string>
+    <string name="compress_metadata">Metadane</string>
+    <string name="compress_always">Wszystko</string>
     <!-- Setting title -->
     <string name="introducer">Wprowadzający</string>
     <!-- Setting title -->
@@ -253,13 +251,11 @@
     <string name="preference_language_title">Język</string>
     <string name="preference_language_summary">Zmień język aplikacji</string>
     <string name="pref_language_default">Domyślny język</string>
-    <string-array name="versioning_types">
-        <item>Żaden</item>
-        <item>Śmientik</item>
-        <item>Proste</item>
-        <item>Rozszerzone</item>
-        <item>Zewnętrzne</item>
-    </string-array>
+    <string name="versioning_type_none">Żaden</string>
+    <string name="versioning_type_trashcan">Śmientik</string>
+    <string name="versioning_type_simple">Proste</string>
+    <string name="versioning_type_staggered">Rozszerzone</string>
+    <string name="versioning_type_external">Zewnętrzne</string>
     <string name="device_name">Nazwa urządzenia</string>
     <string name="listen_address">Adres nasłuchiwania protokołu</string>
     <string name="max_recv_kbps">Limit pobierania (KiB/s)</string>
@@ -384,21 +380,17 @@
     <!-- Shown when a device ID is copied to the clipboard -->
     <string name="device_id_copied_to_clipboard">Skopiowano do schowka identyfikator urządzenia</string>
     <!-- Strings representing units for file sizes, from smallest to largest -->
-    <string-array name="file_size_units">
-        <item>B</item>
-        <item>KiB</item>
-        <item>MiB</item>
-        <item>GiB</item>
-        <item>TiB</item>
-    </string-array>
+    <string name="file_size_unit_B">B</string>
+    <string name="file_size_unit_KiB">KiB</string>
+    <string name="file_size_unit_MiB">MiB</string>
+    <string name="file_size_unit_GiB">GiB</string>
+    <string name="file_size_unit_TiB">TiB</string>
     <!-- Strings representing units for transfer rates, from smallest to largest -->
-    <string-array name="transfer_rate_units">
-        <item>B/s</item>
-        <item>KiB/s</item>
-        <item>MiB/s</item>
-        <item>GiB/s</item>
-        <item>TiB/s</item>
-    </string-array>
+    <string name="transfer_rate_unit_B_s">B/s</string>
+    <string name="transfer_rate_unit_KiB_s">KiB/s</string>
+    <string name="transfer_rate_unit_MiB_s">MiB/s</string>
+    <string name="transfer_rate_unit_GiB_s">GiB/s</string>
+    <string name="transfer_rate_unit_TiB_s">TiB/s</string>
     <string name="state_up_to_date">aktualny</string>
     <string name="state_scanning">Skanowanie</string>
     <string name="state_syncing">Synchronizowanie (%1$d%%)</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -225,11 +225,9 @@
     <!-- Setting title -->
     <string name="compression">Compressão</string>
     <!-- Strings representing compression options -->
-    <string-array name="compress_entries">
-        <item>Nunca</item>
-        <item>Metadados</item>
-        <item>Sempre</item>
-    </string-array>
+    <string name="compress_never">Nunca</string>
+    <string name="compress_metadata">Metadados</string>
+    <string name="compress_always">Sempre</string>
     <!-- Setting title -->
     <string name="introducer">Apresentador</string>
     <!-- Setting title -->
@@ -317,11 +315,9 @@
     <string name="sync_only_wifi_ssids_need_to_grant_location_permission">Você precisa dar permissão de localização para usar esse recurso.</string>
     <string name="sync_only_wifi_ssids_location_permission_rejected_dialog_title">Permissão requerida</string>
     <string name="sync_only_wifi_ssids_location_permission_rejected_dialog_content">Iniciando com o Android 8.1, acesso a localização é necessário para ler o nome do WIFI. Você pode usar esse recurso se conceder essa permissão.</string>
-    <string-array name="power_source_entries">
-        <item>Carregando e na bateria.</item>
-        <item>Carregando.</item>
-        <item>Na bateria.</item>
-    </string-array>
+    <string name="power_source_ac_and_battery_power">Carregando e na bateria.</string>
+    <string name="power_source_ac_power">Carregando.</string>
+    <string name="power_source_battery_power">Na bateria.</string>
     <string name="respect_battery_saving_title">Honrar a configuração de economia de bateria do Android</string>
     <string name="run_in_flight_mode_summary">Ativar esta opção fará com que o Syncthing seja executado mesmo quando você estiver offline. Ative se o seu dispositivo tiver problemas para detectar conexões Wi-Fi manuais durante o modo de voo.</string>
     <string name="use_root_title">Executar como Superusuário</string>
@@ -330,27 +326,20 @@
     <string name="preference_language_title">Idioma</string>
     <string name="preference_language_summary">Alterar o idioma do aplicativo</string>
     <string name="pref_language_default">Idioma padrão</string>
-    <string-array name="folder_types">
-        <item>Enviar e receber</item>
-        <item>Somente enviar</item>
-        <item>Somente receber</item>
-        <item>Receber criptografado</item>
-    </string-array>
-    <string-array name="pull_order_types">
-        <item>Aleatório</item>
-        <item>Alfabética</item>
-        <item>Menores primeiro</item>
-        <item>Maiores primeiro</item>
-        <item>Mais velhos primeiro</item>
-        <item>Mais novos primeiro</item>
-    </string-array>
-    <string-array name="versioning_types">
-        <item>Nenhum</item>
-        <item>Lixeira</item>
-        <item>Simples</item>
-        <item>Escalonado</item>
-        <item>Externo</item>
-    </string-array>
+    <string name="folder_type_send_receive">Enviar e receber</string>
+    <string name="folder_type_send_only">Somente enviar</string>
+    <string name="folder_type_receive_only">Somente receber</string>
+    <string name="pull_order_random">Aleatório</string>
+    <string name="pull_order_alphabetic">Alfabética</string>
+    <string name="pull_order_smallest_first">Menores primeiro</string>
+    <string name="pull_order_largest_first">Maiores primeiro</string>
+    <string name="pull_order_oldest_first">Mais velhos primeiro</string>
+    <string name="pull_order_newest_first">Mais novos primeiro</string>
+    <string name="versioning_type_none">Nenhum</string>
+    <string name="versioning_type_trashcan">Lixeira</string>
+    <string name="versioning_type_simple">Simples</string>
+    <string name="versioning_type_staggered">Escalonado</string>
+    <string name="versioning_type_external">Externo</string>
     <string name="device_name">Nome do dispositivo</string>
     <string name="listen_address">Endereços de escuta do protocolo de sincronização</string>
     <string name="max_recv_kbps">Limite de velocidade de recepção (KiB/s)</string>
@@ -527,21 +516,17 @@
     <!-- Shown when a device ID is copied to the clipboard -->
     <string name="device_id_copied_to_clipboard">O ID do dispositivo foi copiado para a área de transferência</string>
     <!-- Strings representing units for file sizes, from smallest to largest -->
-    <string-array name="file_size_units">
-        <item>B</item>
-        <item>KiB</item>
-        <item>MiB</item>
-        <item>GiB</item>
-        <item>TiB</item>
-    </string-array>
+    <string name="file_size_unit_B">B</string>
+    <string name="file_size_unit_KiB">KiB</string>
+    <string name="file_size_unit_MiB">MiB</string>
+    <string name="file_size_unit_GiB">GiB</string>
+    <string name="file_size_unit_TiB">TiB</string>
     <!-- Strings representing units for transfer rates, from smallest to largest -->
-    <string-array name="transfer_rate_units">
-        <item>B/s</item>
-        <item>KiB/s</item>
-        <item>MiB/s</item>
-        <item>GiB/s</item>
-        <item>TiB/s</item>
-    </string-array>
+    <string name="transfer_rate_unit_B_s">B/s</string>
+    <string name="transfer_rate_unit_KiB_s">KiB/s</string>
+    <string name="transfer_rate_unit_MiB_s">MiB/s</string>
+    <string name="transfer_rate_unit_GiB_s">GiB/s</string>
+    <string name="transfer_rate_unit_TiB_s">TiB/s</string>
     <string name="state_up_to_date">Atualizado</string>
     <string name="state_clean_waiting">Esperando para limpar</string>
     <string name="state_scanning">Verificando</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -101,11 +101,9 @@
     <!-- Setting title -->
     <string name="compression">Compressão</string>
     <!-- Strings representing compression options -->
-    <string-array name="compress_entries">
-        <item>Nunca</item>
-        <item>Metadados</item>
-        <item>Sempre</item>
-    </string-array>
+    <string name="compress_never">Nunca</string>
+    <string name="compress_metadata">Metadados</string>
+    <string name="compress_always">Sempre</string>
     <!-- Setting title -->
     <string name="introducer">Apresentador</string>
     <!-- ActionBar item -->
@@ -211,21 +209,17 @@
     <!-- Shown when a device ID is copied to the clipboard -->
     <string name="device_id_copied_to_clipboard">O ID do dispositivo foi copiado para a área de transferência</string>
     <!-- Strings representing units for file sizes, from smallest to largest -->
-    <string-array name="file_size_units">
-        <item>B</item>
-        <item>KiB</item>
-        <item>MiB</item>
-        <item>GiB</item>
-        <item>TiB</item>
-    </string-array>
+    <string name="file_size_unit_B">B</string>
+    <string name="file_size_unit_KiB">KiB</string>
+    <string name="file_size_unit_MiB">MiB</string>
+    <string name="file_size_unit_GiB">GiB</string>
+    <string name="file_size_unit_TiB">TiB</string>
     <!-- Strings representing units for transfer rates, from smallest to largest -->
-    <string-array name="transfer_rate_units">
-        <item>B/s</item>
-        <item>KiB/s</item>
-        <item>MiB/s</item>
-        <item>GiB/s</item>
-        <item>TiB/s</item>
-    </string-array>
+    <string name="transfer_rate_unit_B_s">B/s</string>
+    <string name="transfer_rate_unit_KiB_s">KiB/s</string>
+    <string name="transfer_rate_unit_MiB_s">MiB/s</string>
+    <string name="transfer_rate_unit_GiB_s">GiB/s</string>
+    <string name="transfer_rate_unit_TiB_s">TiB/s</string>
     <string name="state_scanning">Verificando</string>
     <string name="state_syncing">Sincronizando (%1$d%%)</string>
     <string name="state_error">Erro</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -235,11 +235,9 @@
     <!-- Setting title -->
     <string name="compression">Compresie</string>
     <!-- Strings representing compression options -->
-    <string-array name="compress_entries">
-        <item>Niciodată</item>
-        <item>Metadate</item>
-        <item>Mereu</item>
-    </string-array>
+    <string name="compress_never">Niciodată</string>
+    <string name="compress_metadata">Metadate</string>
+    <string name="compress_always">Mereu</string>
     <!-- Setting title -->
     <string name="introducer">Prezentator</string>
     <!-- Setting title -->
@@ -353,11 +351,9 @@
     <string name="sync_only_wifi_ssids_location_permission_rejected_dialog_title">Necesită permisiunea</string>
     <string name="sync_only_wifi_ssids_location_permission_rejected_dialog_content">Începând cu Android 8.1, este necesar accesul la locație pentru a putea citii numele rețelei Wi-Fi. Această caracteristică poate fi folosită doar dacă acordați această permisiune.</string>
     <string name="power_source_title">Rulează atunci când dispozitivul este alimentat de</string>
-    <string-array name="power_source_entries">
-        <item>încărcător și baterie.</item>
-        <item>încărcător.</item>
-        <item>baterie.</item>
-    </string-array>
+    <string name="power_source_ac_and_battery_power">încărcător și baterie.</string>
+    <string name="power_source_ac_power">încărcător.</string>
+    <string name="power_source_battery_power">baterie.</string>
     <string name="respect_battery_saving_title">Se va respecta setarea de economisire a bateriei din Android</string>
     <string name="respect_battery_saving_summary">Dezactivare Syncthing dacă economisirea bateriei este activă.</string>
     <string name="respect_master_sync_title">Se respectă setarea Android „Sincronizare automată a datelor”</string>
@@ -380,27 +376,20 @@
     <string name="preference_language_title">Limbă</string>
     <string name="preference_language_summary">Alegeți limba de afișat în aplicație</string>
     <string name="pref_language_default">Limba implicită</string>
-    <string-array name="folder_types">
-        <item>Trimitere și primire</item>
-        <item>Doar trimitere</item>
-        <item>Doar recepționare</item>
-        <item>Receive Encrypted</item>
-    </string-array>
-    <string-array name="pull_order_types">
-        <item>Aleator</item>
-        <item>Alfabetic</item>
-        <item>Cel mai mic întâi</item>
-        <item>Cel mai mare întâi</item>
-        <item>Cel mai vechi întâi</item>
-        <item>Cel mai nou intâi</item>
-    </string-array>
-    <string-array name="versioning_types">
-        <item>Nici unu</item>
-        <item>Coș de gunoi</item>
-        <item>Simplu</item>
-        <item>Decalat</item>
-        <item>Extern</item>
-    </string-array>
+    <string name="folder_type_send_receive">Trimitere și primire</string>
+    <string name="folder_type_send_only">Doar trimitere</string>
+    <string name="folder_type_receive_only">Doar recepționare</string>
+    <string name="pull_order_random">Aleator</string>
+    <string name="pull_order_alphabetic">Alfabetic</string>
+    <string name="pull_order_smallest_first">Cel mai mic întâi</string>
+    <string name="pull_order_largest_first">Cel mai mare întâi</string>
+    <string name="pull_order_oldest_first">Cel mai vechi întâi</string>
+    <string name="pull_order_newest_first">Cel mai nou intâi</string>
+    <string name="versioning_type_none">Nici unu</string>
+    <string name="versioning_type_trashcan">Coș de gunoi</string>
+    <string name="versioning_type_simple">Simplu</string>
+    <string name="versioning_type_staggered">Decalat</string>
+    <string name="versioning_type_external">Extern</string>
     <string name="device_name">Nume dispozitiv</string>
     <string name="listen_address">Adresa de ascultare a protocolului de sincronizare</string>
     <string name="max_recv_kbps">Limită rată intrare (KiB/s)</string>
@@ -612,21 +601,17 @@
     <!-- Shown when a device ID is copied to the clipboard -->
     <string name="device_id_copied_to_clipboard">ID-ul dispozitivului a fost copiat în memorie</string>
     <!-- Strings representing units for file sizes, from smallest to largest -->
-    <string-array name="file_size_units">
-        <item>O</item>
-        <item>KiO</item>
-        <item>MiO</item>
-        <item>GiO</item>
-        <item>TiO</item>
-    </string-array>
+    <string name="file_size_unit_B">O</string>
+    <string name="file_size_unit_KiB">KiO</string>
+    <string name="file_size_unit_MiB">MiO</string>
+    <string name="file_size_unit_GiB">GiO</string>
+    <string name="file_size_unit_TiB">TiO</string>
     <!-- Strings representing units for transfer rates, from smallest to largest -->
-    <string-array name="transfer_rate_units">
-        <item>O/s</item>
-        <item>KiO/s</item>
-        <item>MiO/s</item>
-        <item>GiO/s</item>
-        <item>TiO/s</item>
-    </string-array>
+    <string name="transfer_rate_unit_B_s">O/s</string>
+    <string name="transfer_rate_unit_KiB_s">KiO/s</string>
+    <string name="transfer_rate_unit_MiB_s">MiO/s</string>
+    <string name="transfer_rate_unit_GiB_s">GiO/s</string>
+    <string name="transfer_rate_unit_TiB_s">TiO/s</string>
     <!-- Possible folder states -->
     <string name="state_failed_items">Elemente eșuate (%1$d)</string>
     <string name="state_up_to_date">Actualizat</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -207,11 +207,9 @@ Android требует разрешение доступа к геолокаци
     <!-- Setting title -->
     <string name="compression">Сжатие</string>
     <!-- Strings representing compression options -->
-    <string-array name="compress_entries">
-        <item>Никогда</item>
-        <item>Метаданные</item>
-        <item>Всегда</item>
-    </string-array>
+    <string name="compress_never">Никогда</string>
+    <string name="compress_metadata">Метаданные</string>
+    <string name="compress_always">Всегда</string>
     <!-- Setting title -->
     <string name="introducer">Рекомендатель</string>
     <!-- Setting title -->
@@ -277,27 +275,20 @@ Android требует разрешение доступа к геолокаци
     <string name="preference_language_title">Язык</string>
     <string name="preference_language_summary">Изменить язык приложения</string>
     <string name="pref_language_default">Язык по умолчанию</string>
-    <string-array name="folder_types">
-        <item>Отправка и получение</item>
-        <item>Только отправка</item>
-        <item>Только получение</item>
-        <item>Receive Encrypted</item>
-    </string-array>
-    <string-array name="pull_order_types">
-        <item>В случайном порядке</item>
-        <item>По алфавиту</item>
-        <item>Сначала маленькие</item>
-        <item>Сначала большие</item>
-        <item>Сначала старые</item>
-        <item>Сначала новые</item>
-    </string-array>
-    <string-array name="versioning_types">
-        <item>Отключить</item>
-        <item>Корзина</item>
-        <item>Простое</item>
-        <item>Ступенчатое</item>
-        <item>Внешнее</item>
-    </string-array>
+    <string name="folder_type_send_receive">Отправка и получение</string>
+    <string name="folder_type_send_only">Только отправка</string>
+    <string name="folder_type_receive_only">Только получение</string>
+    <string name="pull_order_random">В случайном порядке</string>
+    <string name="pull_order_alphabetic">По алфавиту</string>
+    <string name="pull_order_smallest_first">Сначала маленькие</string>
+    <string name="pull_order_largest_first">Сначала большие</string>
+    <string name="pull_order_oldest_first">Сначала старые</string>
+    <string name="pull_order_newest_first">Сначала новые</string>
+    <string name="versioning_type_none">Отключить</string>
+    <string name="versioning_type_trashcan">Корзина</string>
+    <string name="versioning_type_simple">Простое</string>
+    <string name="versioning_type_staggered">Ступенчатое</string>
+    <string name="versioning_type_external">Внешнее</string>
     <string name="device_name">Имя устройства</string>
     <string name="listen_address">Адрес Ожидания Протокола Синхронизации</string>
     <string name="max_recv_kbps">Лимит Скачивания (КБ/с)</string>
@@ -445,21 +436,17 @@ Android требует разрешение доступа к геолокаци
     <!-- Shown when a device ID is copied to the clipboard -->
     <string name="device_id_copied_to_clipboard">ID устройства копирован в буфер обмена</string>
     <!-- Strings representing units for file sizes, from smallest to largest -->
-    <string-array name="file_size_units">
-        <item>Б</item>
-        <item>КБ</item>
-        <item>МБ</item>
-        <item>ГБ</item>
-        <item>ТБ</item>
-    </string-array>
+    <string name="file_size_unit_B">Б</string>
+    <string name="file_size_unit_KiB">КБ</string>
+    <string name="file_size_unit_MiB">МБ</string>
+    <string name="file_size_unit_GiB">ГБ</string>
+    <string name="file_size_unit_TiB">ТБ</string>
     <!-- Strings representing units for transfer rates, from smallest to largest -->
-    <string-array name="transfer_rate_units">
-        <item>б/с</item>
-        <item>Кб/с</item>
-        <item>Мб/с</item>
-        <item>Гб/с</item>
-        <item>Тб/с</item>
-    </string-array>
+    <string name="transfer_rate_unit_B_s">б/с</string>
+    <string name="transfer_rate_unit_KiB_s">Кб/с</string>
+    <string name="transfer_rate_unit_MiB_s">Мб/с</string>
+    <string name="transfer_rate_unit_GiB_s">Гб/с</string>
+    <string name="transfer_rate_unit_TiB_s">Тб/с</string>
     <string name="state_up_to_date">уточненный</string>
     <string name="state_scanning">Сканирование</string>
     <string name="state_syncing">Синхронизация (%1$d%%)</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -86,11 +86,9 @@
     <!-- Setting title -->
     <string name="compression">Kompresia</string>
     <!-- Strings representing compression options -->
-    <string-array name="compress_entries">
-        <item>Nekomprimovať</item>
-        <item>Iba metadáta</item>
-        <item>Všetko</item>
-    </string-array>
+    <string name="compress_never">Nekomprimovať</string>
+    <string name="compress_metadata">Iba metadáta</string>
+    <string name="compress_always">Všetko</string>
     <!-- Setting title -->
     <string name="introducer">Introducer</string>
     <!-- ActionBar item -->
@@ -178,21 +176,17 @@
     <!-- Shown when a device ID is copied to the clipboard -->
     <string name="device_id_copied_to_clipboard">ID zariadenia bolo skopírované do schránky</string>
     <!-- Strings representing units for file sizes, from smallest to largest -->
-    <string-array name="file_size_units">
-        <item>B</item>
-        <item>KiB</item>
-        <item>MiB</item>
-        <item>GiB</item>
-        <item>TiB</item>
-    </string-array>
+    <string name="file_size_unit_B">B</string>
+    <string name="file_size_unit_KiB">KiB</string>
+    <string name="file_size_unit_MiB">MiB</string>
+    <string name="file_size_unit_GiB">GiB</string>
+    <string name="file_size_unit_TiB">TiB</string>
     <!-- Strings representing units for transfer rates, from smallest to largest -->
-    <string-array name="transfer_rate_units">
-        <item>B/s</item>
-        <item>KiB/s</item>
-        <item>MiB/s</item>
-        <item>GiB/s</item>
-        <item>TiB/s</item>
-    </string-array>
+    <string name="transfer_rate_unit_B_s">B/s</string>
+    <string name="transfer_rate_unit_KiB_s">KiB/s</string>
+    <string name="transfer_rate_unit_MiB_s">MiB/s</string>
+    <string name="transfer_rate_unit_GiB_s">GiB/s</string>
+    <string name="transfer_rate_unit_TiB_s">TiB/s</string>
     <string name="state_scanning">Skenovanie</string>
     <string name="state_syncing">Synchronizuje sa (%1$d%%)</string>
     <string name="state_error">Chyba</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -168,11 +168,9 @@
     <!-- Setting title -->
     <string name="compression">Komprimering</string>
     <!-- Strings representing compression options -->
-    <string-array name="compress_entries">
-        <item>Aldrig</item>
-        <item>Metadata</item>
-        <item>Alltid</item>
-    </string-array>
+    <string name="compress_never">Aldrig</string>
+    <string name="compress_metadata">Metadata</string>
+    <string name="compress_always">Alltid</string>
     <!-- Setting title -->
     <string name="introducer">Introduktör</string>
     <!-- Setting title -->
@@ -244,11 +242,9 @@
     <string name="sync_only_wifi_ssids_location_permission_rejected_dialog_title">Behörighet krävs</string>
     <string name="sync_only_wifi_ssids_location_permission_rejected_dialog_content">Från och med Android 8.1 krävs platsåtkomst för att kunna läsa WiFi-namnet. Du kan bara använda den här funktionen om du beviljar denna behörighet.</string>
     <string name="power_source_title">Kör när enheten drivs av</string>
-    <string-array name="power_source_entries">
-        <item>Växelström och batterikraft.</item>
-        <item>Växelström.</item>
-        <item>Batterikraft.</item>
-    </string-array>
+    <string name="power_source_ac_and_battery_power">Växelström och batterikraft.</string>
+    <string name="power_source_ac_power">Växelström.</string>
+    <string name="power_source_battery_power">Batterikraft.</string>
     <string name="respect_battery_saving_title">Respektera Android-batterisparinställning</string>
     <string name="respect_battery_saving_summary">Inaktivera Syncthing om batteribesparing är aktiv.</string>
     <string name="run_in_flight_mode_title">Kör utan nätverksanslutning</string>
@@ -261,27 +257,20 @@
     <string name="preference_language_title">Språk</string>
     <string name="preference_language_summary">Ändra appens språk</string>
     <string name="pref_language_default">Standardspråk</string>
-    <string-array name="folder_types">
-        <item>Skicka &amp; ta emot</item>
-        <item>Skicka endast</item>
-        <item>Ta emot endast</item>
-        <item>Receive Encrypted</item>
-    </string-array>
-    <string-array name="pull_order_types">
-        <item>Slumpmässig</item>
-        <item>Alfabetisk</item>
-        <item>Minsta först</item>
-        <item>Största först</item>
-        <item>Äldsta först</item>
-        <item>Nyaste först</item>
-    </string-array>
-    <string-array name="versioning_types">
-        <item>Ingen</item>
-        <item>Papperskorg</item>
-        <item>Enkel</item>
-        <item>Förskutna</item>
-        <item>Extern</item>
-    </string-array>
+    <string name="folder_type_send_receive">Skicka &amp; ta emot</string>
+    <string name="folder_type_send_only">Skicka endast</string>
+    <string name="folder_type_receive_only">Ta emot endast</string>
+    <string name="pull_order_random">Slumpmässig</string>
+    <string name="pull_order_alphabetic">Alfabetisk</string>
+    <string name="pull_order_smallest_first">Minsta först</string>
+    <string name="pull_order_largest_first">Största först</string>
+    <string name="pull_order_oldest_first">Äldsta först</string>
+    <string name="pull_order_newest_first">Nyaste först</string>
+    <string name="versioning_type_none">Ingen</string>
+    <string name="versioning_type_trashcan">Papperskorg</string>
+    <string name="versioning_type_simple">Enkel</string>
+    <string name="versioning_type_staggered">Förskutna</string>
+    <string name="versioning_type_external">Extern</string>
     <string name="device_name">Enhetens namn</string>
     <string name="listen_address">Synkroniseringsprotokollets lyssnaradresser</string>
     <string name="max_recv_kbps">Inkommande hastighetsgräns (KiB/s)</string>
@@ -451,21 +440,17 @@
     <!-- Shown when a device ID is copied to the clipboard -->
     <string name="device_id_copied_to_clipboard">Enhets-ID kopierad till urklipp</string>
     <!-- Strings representing units for file sizes, from smallest to largest -->
-    <string-array name="file_size_units">
-        <item>B</item>
-        <item>KiB</item>
-        <item>MiB</item>
-        <item>GiB</item>
-        <item>TiB</item>
-    </string-array>
+    <string name="file_size_unit_B">B</string>
+    <string name="file_size_unit_KiB">KiB</string>
+    <string name="file_size_unit_MiB">MiB</string>
+    <string name="file_size_unit_GiB">GiB</string>
+    <string name="file_size_unit_TiB">TiB</string>
     <!-- Strings representing units for transfer rates, from smallest to largest -->
-    <string-array name="transfer_rate_units">
-        <item>B/s</item>
-        <item>KiB/s</item>
-        <item>MiB/s</item>
-        <item>GiB/s</item>
-        <item>TiB/s</item>
-    </string-array>
+    <string name="transfer_rate_unit_B_s">B/s</string>
+    <string name="transfer_rate_unit_KiB_s">KiB/s</string>
+    <string name="transfer_rate_unit_MiB_s">MiB/s</string>
+    <string name="transfer_rate_unit_GiB_s">GiB/s</string>
+    <string name="transfer_rate_unit_TiB_s">TiB/s</string>
     <string name="state_scanning">Skannar</string>
     <string name="state_syncing_general">Synkroniserar</string>
     <string name="state_syncing">Synkroniserar (%1$d%%)</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -98,11 +98,9 @@
     <!-- Setting title -->
     <string name="compression">Sıkıştırma</string>
     <!-- Strings representing compression options -->
-    <string-array name="compress_entries">
-        <item>Asla</item>
-        <item>Üstveri</item>
-        <item>Her zaman</item>
-    </string-array>
+    <string name="compress_never">Asla</string>
+    <string name="compress_metadata">Üstveri</string>
+    <string name="compress_always">Her zaman</string>
     <!-- Setting title -->
     <string name="introducer">Tanıtıcı</string>
     <!-- ActionBar item -->
@@ -207,21 +205,17 @@
     <!-- Shown when a device ID is copied to the clipboard -->
     <string name="device_id_copied_to_clipboard">Aygıt ID panoya kopyalandı</string>
     <!-- Strings representing units for file sizes, from smallest to largest -->
-    <string-array name="file_size_units">
-        <item>B</item>
-        <item>KiB</item>
-        <item>MiB</item>
-        <item>GiB</item>
-        <item>TiB</item>
-    </string-array>
+    <string name="file_size_unit_B">B</string>
+    <string name="file_size_unit_KiB">KiB</string>
+    <string name="file_size_unit_MiB">MiB</string>
+    <string name="file_size_unit_GiB">GiB</string>
+    <string name="file_size_unit_TiB">TiB</string>
     <!-- Strings representing units for transfer rates, from smallest to largest -->
-    <string-array name="transfer_rate_units">
-        <item>B/s</item>
-        <item>KiB/s</item>
-        <item>MiB/s</item>
-        <item>GiB/s</item>
-        <item>TiB/s</item>
-    </string-array>
+    <string name="transfer_rate_unit_B_s">B/s</string>
+    <string name="transfer_rate_unit_KiB_s">KiB/s</string>
+    <string name="transfer_rate_unit_MiB_s">MiB/s</string>
+    <string name="transfer_rate_unit_GiB_s">GiB/s</string>
+    <string name="transfer_rate_unit_TiB_s">TiB/s</string>
     <string name="state_scanning">Taranıyor</string>
     <string name="state_syncing">Eşzamanlama gerçekleştiriliyor (%1$d%%)</string>
     <string name="state_error">Hata</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -234,11 +234,9 @@
     <!-- Setting title -->
     <string name="compression">Nén</string>
     <!-- Strings representing compression options -->
-    <string-array name="compress_entries">
-        <item>Không bao giờ</item>
-        <item>Siêu dữ liệu</item>
-        <item>Luôn luôn</item>
-    </string-array>
+    <string name="compress_never">Không bao giờ</string>
+    <string name="compress_metadata">Siêu dữ liệu</string>
+    <string name="compress_always">Luôn luôn</string>
     <!-- Setting title -->
     <string name="introducer">Thiết bị g.thiệu</string>
     <!-- Setting title -->
@@ -352,11 +350,9 @@
     <string name="sync_only_wifi_ssids_location_permission_rejected_dialog_title">Yêu cầu quyền</string>
     <string name="sync_only_wifi_ssids_location_permission_rejected_dialog_content">Bắt đầu từ Android 8.1, quyền truy cập vị trí là bắt buộc để có thể đọc tên mạng Wi-Fi. Bạn chỉ có thể sử dụng tính năng này nếu bạn cấp quyền.</string>
     <string name="power_source_title">Chạy khi thiết bị chạy bằng</string>
-    <string-array name="power_source_entries">
-        <item>AC và pin.</item>
-        <item>AC.</item>
-        <item>Pin.</item>
-    </string-array>
+    <string name="power_source_ac_and_battery_power">AC và pin.</string>
+    <string name="power_source_ac_power">AC.</string>
+    <string name="power_source_battery_power">Pin.</string>
     <string name="respect_battery_saving_title">Tôn trọng cài đặt tiết kiệm pin của Android</string>
     <string name="respect_battery_saving_summary">Tắt Syncthing nếu tiết kiệm pin được bật.</string>
     <string name="respect_master_sync_title">Tôn trọng cài đặt \'Tự động đồng bộ dữ liệu\' của Android</string>
@@ -377,27 +373,20 @@
     <string name="preference_language_title">Ngôn ngữ</string>
     <string name="preference_language_summary">Đổi ngôn ngữ ứng dụng</string>
     <string name="pref_language_default">Ngôn ngữ mặc định</string>
-    <string-array name="folder_types">
-        <item>Gửi &amp; Nhận</item>
-        <item>Chỉ gửi</item>
-        <item>Chỉ nhận</item>
-        <item>Receive Encrypted</item>
-    </string-array>
-    <string-array name="pull_order_types">
-        <item>Ngẫu nhiên</item>
-        <item>Bảng chữ cái</item>
-        <item>Nhỏ nhất trước</item>
-        <item>Lớn nhất trước</item>
-        <item>Cũ nhất trước</item>
-        <item>Mới nhất trước</item>
-    </string-array>
-    <string-array name="versioning_types">
-        <item>Không có</item>
-        <item>Thùng rác</item>
-        <item>Đơn giản</item>
-        <item>Chững lại</item>
-        <item>Ngoài</item>
-    </string-array>
+    <string name="folder_type_send_receive">Gửi &amp; Nhận</string>
+    <string name="folder_type_send_only">Chỉ gửi</string>
+    <string name="folder_type_receive_only">Chỉ nhận</string>
+    <string name="pull_order_random">Ngẫu nhiên</string>
+    <string name="pull_order_alphabetic">Bảng chữ cái</string>
+    <string name="pull_order_smallest_first">Nhỏ nhất trước</string>
+    <string name="pull_order_largest_first">Lớn nhất trước</string>
+    <string name="pull_order_oldest_first">Cũ nhất trước</string>
+    <string name="pull_order_newest_first">Mới nhất trước</string>
+    <string name="versioning_type_none">Không có</string>
+    <string name="versioning_type_trashcan">Thùng rác</string>
+    <string name="versioning_type_simple">Đơn giản</string>
+    <string name="versioning_type_staggered">Chững lại</string>
+    <string name="versioning_type_external">Ngoài</string>
     <string name="device_name">Tên thiết bị</string>
     <string name="listen_address">Đồng bộ các đ.chỉ lắng nghe giao thức</string>
     <string name="max_recv_kbps">Giới hạn t.độ đầu vào (KiB/s)</string>
@@ -641,21 +630,17 @@
     <!-- Shown when a device ID is copied to the clipboard -->
     <string name="device_id_copied_to_clipboard">Đã chép ID thiết bị vào clipboard</string>
     <!-- Strings representing units for file sizes, from smallest to largest -->
-    <string-array name="file_size_units">
-        <item>B</item>
-        <item>KiB</item>
-        <item>MiB</item>
-        <item>GiB</item>
-        <item>TiB</item>
-    </string-array>
+    <string name="file_size_unit_B">B</string>
+    <string name="file_size_unit_KiB">KiB</string>
+    <string name="file_size_unit_MiB">MiB</string>
+    <string name="file_size_unit_GiB">GiB</string>
+    <string name="file_size_unit_TiB">TiB</string>
     <!-- Strings representing units for transfer rates, from smallest to largest -->
-    <string-array name="transfer_rate_units">
-        <item>B/s</item>
-        <item>KiB/s</item>
-        <item>MiB/s</item>
-        <item>GiB/s</item>
-        <item>TiB/s</item>
-    </string-array>
+    <string name="transfer_rate_unit_B_s">B/s</string>
+    <string name="transfer_rate_unit_KiB_s">KiB/s</string>
+    <string name="transfer_rate_unit_MiB_s">MiB/s</string>
+    <string name="transfer_rate_unit_GiB_s">GiB/s</string>
+    <string name="transfer_rate_unit_TiB_s">TiB/s</string>
     <!-- Possible folder states -->
     <string name="state_failed_items">Mục thất bại (%1$d)</string>
     <string name="state_up_to_date">Đã đồng bộ</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -232,11 +232,9 @@
     <!-- Setting title -->
     <string name="compression">压缩</string>
     <!-- Strings representing compression options -->
-    <string-array name="compress_entries">
-        <item>从不</item>
-        <item>元数据</item>
-        <item>总是</item>
-    </string-array>
+    <string name="compress_never">从不</string>
+    <string name="compress_metadata">元数据</string>
+    <string name="compress_always">总是</string>
     <!-- Setting title -->
     <string name="introducer">介绍人</string>
     <!-- Setting title -->
@@ -352,11 +350,9 @@
     <string name="sync_only_wifi_ssids_location_permission_rejected_dialog_title">需要许可</string>
     <string name="sync_only_wifi_ssids_location_permission_rejected_dialog_content">从Android 8.1开始，读取Wi-Fi名称需要获取位置权限。只有授予此权限，才能使用此功能。</string>
     <string name="power_source_title">设备供电方式</string>
-    <string-array name="power_source_entries">
-        <item>电源与电池供电</item>
-        <item>电源供电</item>
-        <item>电池供电</item>
-    </string-array>
+    <string name="power_source_ac_and_battery_power">电源与电池供电</string>
+    <string name="power_source_ac_power">电源供电</string>
+    <string name="power_source_battery_power">电池供电</string>
     <string name="respect_battery_saving_title">遵循 Android 电池省电模式设置</string>
     <string name="respect_battery_saving_summary">省电模式启动时禁用 Syncthing</string>
     <string name="respect_master_sync_title">遵循Android的“自动同步数据”设置</string>
@@ -379,27 +375,20 @@
     <string name="preference_language_title">语言</string>
     <string name="preference_language_summary">更改应用语言</string>
     <string name="pref_language_default">默认语言</string>
-    <string-array name="folder_types">
-        <item>发送与接收</item>
-        <item>仅发送</item>
-        <item>仅接收</item>
-        <item>Receive Encrypted</item>
-    </string-array>
-    <string-array name="pull_order_types">
-        <item>随机</item>
-        <item>拼音</item>
-        <item>小文件优先</item>
-        <item>大文件优先</item>
-        <item>旧文件优先</item>
-        <item>新文件优先</item>
-    </string-array>
-    <string-array name="versioning_types">
-        <item>无</item>
-        <item>垃圾桶</item>
-        <item>简单</item>
-        <item>交错</item>
-        <item>外部</item>
-    </string-array>
+    <string name="folder_type_send_receive">发送与接收</string>
+    <string name="folder_type_send_only">仅发送</string>
+    <string name="folder_type_receive_only">仅接收</string>
+    <string name="pull_order_random">随机</string>
+    <string name="pull_order_alphabetic">拼音</string>
+    <string name="pull_order_smallest_first">小文件优先</string>
+    <string name="pull_order_largest_first">大文件优先</string>
+    <string name="pull_order_oldest_first">旧文件优先</string>
+    <string name="pull_order_newest_first">新文件优先</string>
+    <string name="versioning_type_none">无</string>
+    <string name="versioning_type_trashcan">垃圾桶</string>
+    <string name="versioning_type_simple">简单</string>
+    <string name="versioning_type_staggered">交错</string>
+    <string name="versioning_type_external">外部</string>
     <string name="device_name">设备名称</string>
     <string name="listen_address">同步协议监听地址</string>
     <string name="max_recv_kbps">下载限速（KiB/s）</string>
@@ -645,21 +634,17 @@
     <!-- Shown when a device ID is copied to the clipboard -->
     <string name="device_id_copied_to_clipboard">设备标识已复制到剪贴板</string>
     <!-- Strings representing units for file sizes, from smallest to largest -->
-    <string-array name="file_size_units">
-        <item>B</item>
-        <item>KiB</item>
-        <item>MiB</item>
-        <item>GiB</item>
-        <item>TiB</item>
-    </string-array>
+    <string name="file_size_unit_B">B</string>
+    <string name="file_size_unit_KiB">KiB</string>
+    <string name="file_size_unit_MiB">MiB</string>
+    <string name="file_size_unit_GiB">GiB</string>
+    <string name="file_size_unit_TiB">TiB</string>
     <!-- Strings representing units for transfer rates, from smallest to largest -->
-    <string-array name="transfer_rate_units">
-        <item>B/s</item>
-        <item>KiB/s</item>
-        <item>MiB/s</item>
-        <item>GiB/s</item>
-        <item>TiB/s</item>
-    </string-array>
+    <string name="transfer_rate_unit_B_s">B/s</string>
+    <string name="transfer_rate_unit_KiB_s">KiB/s</string>
+    <string name="transfer_rate_unit_MiB_s">MiB/s</string>
+    <string name="transfer_rate_unit_GiB_s">GiB/s</string>
+    <string name="transfer_rate_unit_TiB_s">TiB/s</string>
     <!-- Possible folder states -->
     <string name="state_failed_items">失败项目(%1$d)</string>
     <string name="state_up_to_date">最新</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -135,11 +135,9 @@
     <!-- Setting title -->
     <string name="compression">壓縮</string>
     <!-- Strings representing compression options -->
-    <string-array name="compress_entries">
-        <item>沒有</item>
-        <item>中繼資料</item>
-        <item>所有</item>
-    </string-array>
+    <string name="compress_never">沒有</string>
+    <string name="compress_metadata">中繼資料</string>
+    <string name="compress_always">所有</string>
     <!-- Setting title -->
     <string name="introducer">引入者</string>
     <!-- ActionBar item -->
@@ -177,13 +175,11 @@
     <string name="preference_language_title">語言</string>
     <string name="preference_language_summary">選擇應用程式語言</string>
     <string name="pref_language_default">預設語言</string>
-    <string-array name="versioning_types">
-        <item>無</item>
-        <item>垃圾筒式</item>
-        <item>簡單</item>
-        <item>變動式</item>
-        <item>外部的</item>
-    </string-array>
+    <string name="versioning_type_none">無</string>
+    <string name="versioning_type_trashcan">垃圾筒式</string>
+    <string name="versioning_type_simple">簡單</string>
+    <string name="versioning_type_staggered">變動式</string>
+    <string name="versioning_type_external">外部的</string>
     <string name="device_name">裝置名稱</string>
     <string name="listen_address">同步通訊協定監聽位址</string>
     <string name="max_recv_kbps">下載速率限制(KiB/s)</string>
@@ -300,21 +296,17 @@
     <!-- Shown when a device ID is copied to the clipboard -->
     <string name="device_id_copied_to_clipboard">裝置識別碼已複製至剪貼版</string>
     <!-- Strings representing units for file sizes, from smallest to largest -->
-    <string-array name="file_size_units">
-        <item>B</item>
-        <item>KiB</item>
-        <item>MiB</item>
-        <item>GiB</item>
-        <item>TiB</item>
-    </string-array>
+    <string name="file_size_unit_B">B</string>
+    <string name="file_size_unit_KiB">KiB</string>
+    <string name="file_size_unit_MiB">MiB</string>
+    <string name="file_size_unit_GiB">GiB</string>
+    <string name="file_size_unit_TiB">TiB</string>
     <!-- Strings representing units for transfer rates, from smallest to largest -->
-    <string-array name="transfer_rate_units">
-        <item>B/s</item>
-        <item>KiB/s</item>
-        <item>MiB/s</item>
-        <item>GiB/s</item>
-        <item>TiB/s</item>
-    </string-array>
+    <string name="transfer_rate_unit_B_s">B/s</string>
+    <string name="transfer_rate_unit_KiB_s">KiB/s</string>
+    <string name="transfer_rate_unit_MiB_s">MiB/s</string>
+    <string name="transfer_rate_unit_GiB_s">GiB/s</string>
+    <string name="transfer_rate_unit_TiB_s">TiB/s</string>
     <string name="state_up_to_date">最新</string>
     <string name="state_scanning">正在掃描</string>
     <string name="state_syncing">正在同步 (%1$d%%)</string>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -8,11 +8,68 @@
         <item>always</item>
     </string-array>
 
+    <string-array name="compress_entries">
+        <item>@string/compress_never</item>
+        <item>@string/compress_metadata</item>
+        <item>@string/compress_always</item>
+    </string-array>
+
     <!-- Preference screen -->
     <string-array name="power_source_values">
         <item>ac_and_battery_power</item>
         <item>ac_power</item>
         <item>battery_power</item>
+    </string-array>
+
+    <string-array name="power_source_entries">
+        <item>@string/power_source_ac_and_battery_power</item>
+        <item>@string/power_source_ac_power</item>
+        <item>@string/power_source_battery_power</item>
+    </string-array>
+
+    <string-array name="notification_type_entries">
+        <item>@string/notification_type_normal</item>
+        <item>@string/notification_type_low_priority</item>
+        <item>@string/notification_type_none</item>
+    </string-array>
+
+    <string-array name="folder_types">
+        <item>@string/folder_type_send_receive</item>
+        <item>@string/folder_type_send_only</item>
+        <item>@string/folder_type_receive_only</item>
+    </string-array>
+
+    <string-array name="pull_order_types">
+        <item>@string/pull_order_random</item>
+        <item>@string/pull_order_alphabetic</item>
+        <item>@string/pull_order_smallest_first</item>
+        <item>@string/pull_order_largest_first</item>
+        <item>@string/pull_order_oldest_first</item>
+        <item>@string/pull_order_newest_first</item>
+    </string-array>
+
+    <string-array name="versioning_types">
+        <item>@string/versioning_type_none</item>
+        <item>@string/versioning_type_trashcan</item>
+        <item>@string/versioning_type_simple</item>
+        <item>@string/versioning_type_staggered</item>
+        <item>@string/versioning_type_external</item>
+    </string-array>
+
+    <string-array name="file_size_units">
+        <item>@string/file_size_unit_B</item>
+        <item>@string/file_size_unit_KiB</item>
+        <item>@string/file_size_unit_MiB</item>
+        <item>@string/file_size_unit_GiB</item>
+        <item>@string/file_size_unit_TiB</item>
+    </string-array>
+
+    <string-array name="transfer_rate_units">
+        <item>@string/transfer_rate_unit_B_s</item>
+        <item>@string/transfer_rate_unit_KiB_s</item>
+        <item>@string/transfer_rate_unit_MiB_s</item>
+        <item>@string/transfer_rate_unit_GiB_s</item>
+        <item>@string/transfer_rate_unit_TiB_s</item>
     </string-array>
 
     <!-- Preference screen -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -345,12 +345,9 @@
     <string name="compression">Compression</string>
 
     <!-- Strings representing compression options -->
-    <string-array name="compress_entries">
-        <item>Never</item>
-        <item>Metadata</item>
-        <item>Always</item>
-    </string-array>
-
+    <string name="compress_never">Never</string>
+    <string name="compress_metadata">Metadata</string>
+    <string name="compress_always">Always</string>
     <!-- Setting title -->
     <string name="introducer">Introducer</string>
 
@@ -522,11 +519,9 @@
 
     <string name="power_source_title">Run when device is powered by</string>
 
-    <string-array name="power_source_entries">
-        <item>AC and battery power.</item>
-        <item>AC power.</item>
-        <item>Battery power.</item>
-    </string-array>
+    <string name="power_source_ac_and_battery_power">AC and battery power.</string>
+    <string name="power_source_ac_power">AC power.</string>
+    <string name="power_source_battery_power">Battery power.</string>
 
     <string name="respect_battery_saving_title">Respect Android battery saving setting</string>
     <string name="respect_battery_saving_summary">Disable Syncthing if battery saving is active.</string>
@@ -563,29 +558,22 @@
 
     <string name="pref_language_default">Default Language</string>
 
-    <string-array name="folder_types">
-        <item>Send &amp; Receive</item>
-        <item>Send Only</item>
-        <item>Receive Only</item>
-        <item>Receive Encrypted</item>
-    </string-array>
+    <string name="folder_type_send_receive">Send &amp; Receive</string>
+    <string name="folder_type_send_only">Send Only</string>
+    <string name="folder_type_receive_only">Receive Only</string>
 
-    <string-array name="pull_order_types">
-        <item>Random</item>
-        <item>Alphabetic</item>
-        <item>Smallest First</item>
-        <item>Largest First</item>
-        <item>Oldest First</item>
-        <item>Newest First</item>
-    </string-array>
+    <string name="pull_order_random">Random</string>
+    <string name="pull_order_alphabetic">Alphabetic</string>
+    <string name="pull_order_smallest_first">Smallest First</string>
+    <string name="pull_order_largest_first">Largest First</string>
+    <string name="pull_order_oldest_first">Oldest First</string>
+    <string name="pull_order_newest_first">Newest First</string>
 
-    <string-array name="versioning_types">
-        <item>None</item>
-        <item>TrashCan</item>
-        <item>Simple</item>
-        <item>Staggered</item>
-        <item>External</item>
-    </string-array>
+    <string name="versioning_type_none">None</string>
+    <string name="versioning_type_trashcan">TrashCan</string>
+    <string name="versioning_type_simple">Simple</string>
+    <string name="versioning_type_staggered">Staggered</string>
+    <string name="versioning_type_external">External</string>
 
     <string name="device_name">Device Name</string>
 
@@ -965,22 +953,18 @@
     <string name="device_id_copied_to_clipboard">Device ID copied to clipboard</string>
 
     <!-- Strings representing units for file sizes, from smallest to largest -->
-    <string-array name="file_size_units">
-        <item>B</item>
-        <item>KB</item>
-        <item>MB</item>
-        <item>GB</item>
-        <item>TB</item>
-    </string-array>
+    <string name="file_size_unit_B">B</string>
+    <string name="file_size_unit_KiB">KB</string>
+    <string name="file_size_unit_MiB">MB</string>
+    <string name="file_size_unit_GiB">GB</string>
+    <string name="file_size_unit_TiB">TB</string>
 
     <!-- Strings representing units for transfer rates, from smallest to largest -->
-    <string-array name="transfer_rate_units">
-        <item>B/s</item>
-        <item>KB/s</item>
-        <item>MB/s</item>
-        <item>GB/s</item>
-        <item>TB/s</item>
-    </string-array>
+    <string name="transfer_rate_unit_B_s">B/s</string>
+    <string name="transfer_rate_unit_KiB_s">KB/s</string>
+    <string name="transfer_rate_unit_MiB_s">MB/s</string>
+    <string name="transfer_rate_unit_GiB_s">GB/s</string>
+    <string name="transfer_rate_unit_TiB_s">TB/s</string>
 
     <!-- Possible folder states -->
     <string name="state_failed_items">Failed Items (%1$d)</string>


### PR DESCRIPTION
This fixes missing strings in Weblate translation, although they are supposedly in the strings.xml files. Ref. https://github.com/syncthing/syncthing-android/pull/2012

Introduce string-array elements matching those from the source strings.xml, but instead pointing to a @string reference. The latter is to be translated based on the assigned sub item's key.

Weblate does not handle string-arrays, but needs this indirection, see https://docs.weblate.org/en/latest/formats/android.html

All existing translations are pulled in by migrating the <string-array name="..."><item>... elements to <string name="..."> elements instead. This was done using an XSLT stylesheet, so can be easily reproduced.

IMPORTANT, MERGING ORDER:

* [ ] The automated Weblate PR should be merged first, after committing any outstanding translation changes on Weblate.
* [ ] Then rebase this branch, best re-applying the XSLT in case of conflicts.
* [ ] Then merge this PR without much delay, to avoid new translations coming in on Weblate causing new conflicts.