### PR TITLE
Make "ignore doze" permission recommended instead of mandatory (fixes #1049)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FirstStartActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FirstStartActivity.java
@@ -291,14 +291,15 @@ public class FirstStartActivity extends AppCompatActivity {
             // As the ignore doze permission is a prerequisite to run syncthing, refuse to continue without it.
             if (!haveIgnoreDozePermission()) {
                 /**
-                 * a) Phones, tablets: The ignore doze permission is mandatory.
+                 * a) Phones, tablets: The ignore doze permission is recommended.
                  * b) TVs: The ignore doze permission is optional as it can only set by ADB on Android 8+.
                  */
-                if (!mUserDecisionIgnoreDozePermission || !mRunningOnTV) {
+                if (!mUserDecisionIgnoreDozePermission && !mRunningOnTV) {
                     new AlertDialog.Builder(FirstStartActivity.this)
                             .setMessage(R.string.dialog_confirm_skip_ignore_doze_permission)
                             .setPositiveButton(android.R.string.yes, (dialog, which) -> {
                                     mUserDecisionIgnoreDozePermission = true;
+                                    onBtnNextClick();
                             })
                             .setNegativeButton(android.R.string.no, (dialog, which) -> {
                                     mUserDecisionIgnoreDozePermission = false;

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FirstStartActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FirstStartActivity.java
@@ -2,6 +2,7 @@ package com.nutomic.syncthingandroid.activities;
 
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
+import android.app.AlertDialog;
 import android.content.ActivityNotFoundException;
 import android.content.ComponentName;
 import android.content.Context;
@@ -97,6 +98,7 @@ public class FirstStartActivity extends AppCompatActivity {
     SharedPreferences mPreferences;
 
     private Boolean mRunningOnTV = false;
+    private Boolean mUserDecisionIgnoreDozePermission = false;
 
     /**
      * Handles activity behaviour depending on prerequisites.
@@ -125,7 +127,6 @@ public class FirstStartActivity extends AppCompatActivity {
          * start directly into MainActivity.
          */
         if (!showSlideStoragePermission &&
-                !showSlideIgnoreDozePermission &&
                 !showSlideNotificationPermission &&
                 !showSlideKeyGeneration) {
             startApp();
@@ -289,13 +290,21 @@ public class FirstStartActivity extends AppCompatActivity {
         if (mViewPager.getCurrentItem() == mSlidePosIgnoreDozePermission) {
             // As the ignore doze permission is a prerequisite to run syncthing, refuse to continue without it.
             if (!haveIgnoreDozePermission()) {
-                Toast.makeText(this, R.string.toast_ignore_doze_permission_required,
-                        Toast.LENGTH_LONG).show();
                 /**
                  * a) Phones, tablets: The ignore doze permission is mandatory.
                  * b) TVs: The ignore doze permission is optional as it can only set by ADB on Android 8+.
                  */
-                if (!mRunningOnTV) {
+                if (!mUserDecisionIgnoreDozePermission || !mRunningOnTV) {
+                    new AlertDialog.Builder(FirstStartActivity.this)
+                            .setMessage(R.string.dialog_confirm_skip_ignore_doze_permission)
+                            .setPositiveButton(android.R.string.yes, (dialog, which) -> {
+                                    mUserDecisionIgnoreDozePermission = true;
+                            })
+                            .setNegativeButton(android.R.string.no, (dialog, which) -> {
+                                    mUserDecisionIgnoreDozePermission = false;
+                            })
+                            .show();
+
                     // Case a) - Prevent user moving on with the slides.
                     return;
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,6 +28,7 @@
     <string name="ignore_doze_permission_desc">Android may stop synchronization after some time. To prevent this, turn off battery optimization. Some devices have additional task-killing apps preinstalled. You should add Syncthing to their whitelist, as well.</string>
     <string name="toast_ignore_doze_permission_required">This app only works reliably if it is exempted from \"doze\" power save mode.</string>
     <string name="dialog_disable_battery_optimizations_not_supported">Your device does not support disabling battery optimizations</string>
+    <string name="dialog_confirm_skip_ignore_doze_permission">Careful: If SyncthingNative is interrupted and does something strange, you\'re to blame. Really skip?</string>
 
     <!-- Slide "Location Permission" -->
     <string name="location_permission_title">Location Permission</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,7 +28,7 @@
     <string name="ignore_doze_permission_desc">Android may stop synchronization after some time. To prevent this, turn off battery optimization. Some devices have additional task-killing apps preinstalled. You should add Syncthing to their whitelist, as well.</string>
     <string name="toast_ignore_doze_permission_required">This app only works reliably if it is exempted from \"doze\" power save mode.</string>
     <string name="dialog_disable_battery_optimizations_not_supported">Your device does not support disabling battery optimizations</string>
-    <string name="dialog_confirm_skip_ignore_doze_permission">Careful: If SyncthingNative is interrupted and does something strange, you\'re to blame. Really skip?</string>
+    <string name="dialog_confirm_skip_ignore_doze_permission">Careful: If SyncthingNative is interrupted and does something strange, you\'re to blame. Only skip in case your device does not support granting the permission. Really skip?</string>
 
     <!-- Slide "Location Permission" -->
     <string name="location_permission_title">Location Permission</string>


### PR DESCRIPTION
Reason: Some devices do not allow the user to grant the permission. (these are non-TVs, as TVs are already excluded and the permission is considered optional on ATV platform)