### PR TITLE
Default folder path: Home shortcut (~) broken

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/util/FileUtils.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/FileUtils.java
@@ -307,6 +307,14 @@ public class FileUtils {
             .map(java.nio.file.Path::toFile)
             .forEach(File::delete);
     }
+    
+    /**
+     * Expands the "~" path.
+     * Result: e.g. /storage/emulated/0
+     */
+    public static String getInternalStorageRootAbsolutePath() {
+        return Environment.getExternalStorageDirectory().getAbsolutePath();
+    }
 
     /**
      * Derives the mime type from file extension.


### PR DESCRIPTION
Only occurs if user fiddles with the Web UI which is not supported.
Should support that rare use case.