### PR TITLE
Respect user certificates

### DIFF
--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -3,11 +3,11 @@
     <base-config>
        <trust-anchors>
            <certificates src="system" />
+           <certificates src="user" />
        </trust-anchors>
     </base-config>
     <debug-overrides>
         <trust-anchors>
-            <certificates src="user" />
         </trust-anchors>
     </debug-overrides>
 </network-security-config>


### PR DESCRIPTION
# Description
If one wants to run one’s own global discovery inside of a private network in a secure manner, the simplest solution is to use a self signed CA that is already trusted by all network devices. Unfortunately the app currently ignores user certificates from android and doesn’t provide a way to set one’s own, forcing users to use public domain names as a workaround. This is unfortunate.

Given the strong warnings android gives before installing custom CAs, it is likely that anyone with custom certificates installed "knows what they are doing" and out of those, people who would rather trust their CAs are a lot more common.

As such I propose enabling trusting of user CAs. If you think it would be straightforward, I'd be willing to attempt adding a toggle somewhere in the settings for this, if you think it's really necessary.

# Changes
* Respect user defined CAs in release builds.