### PR TITLE
README: clarify that we are talking about the original

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <a href="https://tooomm.github.io/github-release-stats/?username=Catfriend1&repository=syncthing-android" alt="GitHub Stats"><img src="https://img.shields.io/github/downloads/Catfriend1/syncthing-android/total.svg" /></a>
 <a href="https://hosted.weblate.org/projects/syncthing/android/catfriend1/"><img src="https://hosted.weblate.org/widget/syncthing/android/catfriend1/svg-badge.svg" alt="Translation status" /></a>
 
-A wrapper of [Syncthing](https://github.com/syncthing/syncthing) for Android. Head to the "releases" section or F-Droid for builds. Please open an issue under this fork if you need help. Important: Please don't file bugs at the upstream repository "syncthing-android" if you are using this fork.
+A wrapper of [Syncthing](https://github.com/syncthing/syncthing) for Android. Head to the "releases" section or F-Droid for builds. Please open an issue under this fork if you need help. Important: Please don't file bugs at the upstream repository [syncthing/syncthing-android](https://github.com/syncthing/syncthing-android) if you are using this fork.
 
 <img src="app/src/main/play/listings/en-US/graphics/phone-screenshots/1.png" alt="screenshot 1" width="200" />
 


### PR DESCRIPTION
# Description
Clarifying that we are talking about the original Syncthing Android app, and not this fork, as both repositories are called syncthing-android.


# Changes
What changes are made in this PR
* Makes the text be "syncthing/syncthing-android", instead of "syncthing-android"
* Adds hyperlink for the original Android app