### PR TITLE
Remove gui UTF-8 icons

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/views/DevicesAdapter.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/views/DevicesAdapter.java
@@ -127,11 +127,11 @@ public class DevicesAdapter extends ArrayAdapter<Device> {
 
             String bandwidthUpDownText = "\u21f5 ";     // down+up arrow
             bandwidthUpDownText += mContext.getString(R.string.download_title);
-            bandwidthUpDownText += " \u02c5 ";          // down arrow
+            bandwidthUpDownText += " ";
             bandwidthUpDownText += Util.readableTransferRate(getContext(), conn.inBits);
             bandwidthUpDownText += " \u2022 ";          // dot
             bandwidthUpDownText += mContext.getString(R.string.upload_title);
-            bandwidthUpDownText += " \u02c4 ";          // up arrow
+            bandwidthUpDownText += " ";
             bandwidthUpDownText += Util.readableTransferRate(getContext(), conn.outBits);
             binding.bandwidthUpDown.setText(bandwidthUpDownText);
             rateInOutView.setVisibility(VISIBLE);

--- a/app/src/main/java/com/nutomic/syncthingandroid/views/FoldersAdapter.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/views/FoldersAdapter.java
@@ -206,8 +206,7 @@ public class FoldersAdapter extends ArrayAdapter<Folder> {
         showLastItemFinishedUI(binding, cachedFolderStatus);
 
         binding.items.setVisibility(folder.paused ? GONE : VISIBLE);
-        String itemsAndSize = "\u2211 ";
-        itemsAndSize += mContext.getResources()
+        String itemsAndSize = mContext.getResources()
                 .getQuantityString(R.plurals.files, (int) folderStatus.inSyncFiles, folderStatus.inSyncFiles, folderStatus.globalFiles);
         itemsAndSize += " \u2022 ";
         itemsAndSize += mContext.getString(R.string.folder_size_format,
@@ -245,7 +244,7 @@ public class FoldersAdapter extends ArrayAdapter<Folder> {
         binding.lastItemFinishedItem.setText(finishedItemText);
         binding.lastItemFinishedItem.setVisibility(VISIBLE);
 
-        String finishedItemTime = "\u21cc\u231a";
+        String finishedItemTime = "\u21cc";
         finishedItemTime += Util.formatTime(cachedFolderStatus.lastItemFinishedTime);
         binding.lastItemFinishedTime.setText(finishedItemTime);
         binding.lastItemFinishedTime.setVisibility(VISIBLE);
@@ -266,7 +265,7 @@ public class FoldersAdapter extends ArrayAdapter<Folder> {
         String shortenedPath = path.replaceFirst("/storage/emulated/0", "[int]");
         shortenedPath = shortenedPath.replaceFirst("/storage/[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}", "[ext]");
         shortenedPath = shortenedPath.replaceFirst("/" + mContext.getPackageName(), "/[app]");
-        return "\u2756 " + Util.getPathEllipsis(shortenedPath);
+        return Util.getPathEllipsis(shortenedPath);
     }
 
     private void onClickOverride(View view, Folder folder) {


### PR DESCRIPTION
# Description
With the discontinuation of the official Synthing Android app, more less-techy users will use Syncthing Fork. Previously, this app was (my feeling) more aimed at the more tech savvy users. Certain details in the gui were catering to that. Nevertheless, before the discontinuation of the official app, but especially now, it is important to display information without creating confusion/questions or showing information twice.

I have given some workshops on Syncthing for Android and got the kind of questions: I don't understand this. What do the symbols ❖, ∑, etc. stand for? Should I know the meaning of it?

This PR removes a few redundant and possibly confusing symbols to cater better to less technical users. At the same time, it also employs the positioning of the data to reduce the need of these symbols. The change is fairly small but will give the gui a more welcome appearance. 

# Changes
What changes are made in this PR
* In the FOLDERS tab: The diamond `❖` at the beginning of the folder path has been removed. This symbol is not universally recognized, can confuse a user and it is clear that the first line for each folder is the path to the folder. This makes the view more easy and even saves two character spaces.
* In the FOLDERS tab: For the same reasons, the clock `⌚` has been removed. Also because the style of this icon is very different then the style of the other symbols used. It breaks the overall experience. The date and time with the sync symbol at the beginning are enough for the user to deduct that is the date and time.
* In the FOLDERS tab: For the same reasons the sigma `∑` has been removed. The file counts and sizes separated by a slash are enough. Users who didn't like mathematics are a bit put off / scared by this symbol.
* In the DEVICES tab: For the download and upload rate, there is already the words `Download` and `Upload`, hence the symbols `˅` and `˄` are redundant and have been removed. Also, many users will not look at these symbols or it is gives questions and it also saves some space.

I am a big ambassador for Syncthing Fork and continue introducing it to people. Implementing this change will help less-tech savvy users feel more confident using the app. The other symbols used are more comprehensible and should stay.