### PR TITLE
Add Hebrew and Galician translation templates

### DIFF
--- a/app/src/main/play/listings/he/full-description.txt
+++ b/app/src/main/play/listings/he/full-description.txt
@@ -1,0 +1,38 @@
+This is a fork of the Syncthing-Android wrapper for Syncthing that brings major enhancements like:
+* Folder, device and overall sync progress can easily be read off the UI.
+* "Syncthing Camera" - an optional feature (with optional permission to use the camera) where you can take pictures with your friend, partner, ... on two phones into one shared and private Syncthing folder. No cloud involved. - FEATURE CURRENTLY IN BETA STAGE -
+* "Sync every hour" to save even more battery
+* Individual sync conditions can be applied per device and per folder
+* Recent changes UI, click to open files.
+* Changes to folder and device config can be made regardless if Syncthing is running or not
+* UI explains why syncthing is running or not.
+* "Battery eater" problem is fixed.
+* Discover other Syncthing devices on the same network and easily add them.
+* Supports two-way synchronization on external SD card since Android 11.
+
+Syncthing-Fork for Android is a wrapper for Syncthing that provides an Android UI instead of Syncthing's built-in Web UI. Syncthing replaces proprietary sync and cloud services with something open, trustworthy and decentralized. Your data is your data alone and you deserve to choose where it is stored, if it is shared with some third party and how it's transmitted over the Internet.
+
+Goals of the fork:
+* Develop and try out enhancements together with the community.
+* Release the wrapper more frequently to identify and fix bugs caused by changes in the syncthing submodule
+* Make enhancements configurable in the UI, users should be able to turn them on and off
+
+Comparison between upstream and fork at the time of writing this:
+* Both contain the syncthing binary built from the official source at GitHub
+* Syncing functionality and reliability depends on the syncthing binary submodule version.
+* Fork gets along with upstream and sometimes they pick up my improvements.
+* Strategy and release frequency is different
+* Only the wrapper containing the Android UI is addressed by the fork.
+
+Website: https://github.com/Catfriend1/syncthing-android
+
+Source code: https://github.com/Catfriend1/syncthing-android
+
+How Syncthing writes to external SD card: https://github.com/Catfriend1/syncthing-android/blob/master/wiki/SD-card-write-access.md
+
+Wiki, FAQ and helpful articles: https://github.com/Catfriend1/syncthing-android/wiki
+
+Issues: https://github.com/Catfriend1/syncthing-android/issues
+
+Please help with the
+Translation: https://hosted.weblate.org/projects/syncthing/android/catfriend1

--- a/app/src/main/play/listings/he/short-description.txt
+++ b/app/src/main/play/listings/he/short-description.txt
@@ -1,0 +1,1 @@
+Wrapper for Syncthing - Open and decentralized file synchronization

--- a/app/src/main/play/listings/he/title.txt
+++ b/app/src/main/play/listings/he/title.txt
@@ -1,0 +1,1 @@
+Syncthing-Fork

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+</resources>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+</resources>


### PR DESCRIPTION
# Description
Empty templates for strings, English version for Play listings.

# Changes
* Add Hebrew (he / iw) translation template for app strings and GPlay. Requested by user `@xocodokie` on Hosted Weblate. The language codes are different between Google Play and the Android app framework, according to these resources:
https://support.google.com/googleplay/android-developer/table/4419860?hl=en#query
https://support.google.com/googleplay/android-developer/answer/9844778?hl=en#zippy=%2Cview-list-of-available-languages

* Add Galician (gl) translation template for app strings. Request by user `@ghose` on Hosted Weblate.
