### PR TITLE
chore(strings): shorten notification text (fixes #1113)

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -892,8 +892,8 @@
     <string name="exit">Exit</string>
 
     <!-- Title of the notification shown while syncthing is running and enabled -->
-    <string name="syncthing_active">Syncthing is running</string>
-    <string name="syncthing_active_details">Syncthing is running: %1$s</string>
+    <string name="syncthing_active">Running</string>
+    <string name="syncthing_active_details">Running: %1$s</string>
     <string name="no_remote_devices_connected">No remote devices connected</string>
 
     <plurals name="device_online_up_to_date">
@@ -906,9 +906,9 @@
         <item quantity="other">Syncing: %1$d%% complete, %2$d devices online</item>
     </plurals>
 
-    <string name="syncthing_disabled">Syncthing is sleeping</string>
+    <string name="syncthing_disabled">Sleeping</string>
 
-    <string name="syncthing_terminated">Syncthing was terminated</string>
+    <string name="syncthing_terminated">Terminated</string>
 
     <!-- Toast shown if syncthing failed to create or read the config -->
     <string name="executable_not_found">Core executable \"%s\" is missing. Check build and logcat output.</string>


### PR DESCRIPTION
I've tested Sleeping and Running, but I don't know how to trigger the Terminated condition, and therefore I don't know if that works.

# Description
As suggested by @Catfriend1 in a
[comment](https://github.com/Catfriend1/syncthing-android/issues/1113#issuecomment-2553284015), we can just remove the "Syncthing is/was..." text from the notification to reduce the length.

# Changes
* Remove the "Syncthing is/was..." prefix from the notifications

# Screenshots

| Before | After |
| ------ | ----- |
| ![before](https://github.com/user-attachments/assets/26646904-567b-4e7f-a0ec-160483372d84) | ![after](https://github.com/user-attachments/assets/c7dcf909-d470-451a-b961-b8edcb6bdf39)

