### PR TITLE
Bring back launch into web gui (fixes #1331)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FirstStartActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FirstStartActivity.java
@@ -494,7 +494,15 @@ public class FirstStartActivity extends AppCompatActivity {
      */
     private void startApp() {
         Intent mainIntent = new Intent(this, MainActivity.class);
-        startActivity(mainIntent);
+        /**
+          * In case start_into_web_gui option is enabled, start both activities
+          * so that back navigation works as expected.
+          */
+         if (mPreferences.getBoolean(Constants.PREF_START_INTO_WEB_GUI, false)) {
+             startActivities(new Intent[]{mainIntent, new Intent(this, WebGuiActivity.class)});
+         } else {
+             startActivity(mainIntent);
+         }
         finish();
     }
 

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
@@ -49,6 +49,7 @@ public class Constants {
     public static final String PREF_EXPERT_MODE                 = "expert_mode";
 
     // Preferences - Behaviour
+    public static final String PREF_START_INTO_WEB_GUI          = "start_into_web_gui";
     public static final String PREF_USE_ROOT                    = "use_root";
     public static final String PREF_BIND_NETWORK                = "bind_network";
 

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
@@ -1017,7 +1017,6 @@ public class SyncthingService extends Service {
                             case "advanced_folder_picker":
                             case "notification_type":
                             case "notify_crashes":
-                            case "start_into_web_gui":
                             case "suggest_new_folder_root":
                             case "use_legacy_hashing":
                             case "pref_current_language":

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -554,6 +554,10 @@
     <string name="preference_language_title">Language</string>
     <string name="preference_language_summary">Change the app language</string>
 
+    <string name="start_into_web_gui_title">Start directly into web GUI</string>
+ 
+    <string name="start_into_web_gui_summary">When starting the app, open web GUI instead of the main screen</string>
+
     <string name="pref_language_default">Default Language</string>
 
     <string name="folder_type_send_receive">Send &amp; Receive</string>

--- a/app/src/main/res/xml/app_settings.xml
+++ b/app/src/main/res/xml/app_settings.xml
@@ -140,6 +140,12 @@
             android:singleLineTitle="false"
             android:defaultValue="false" />
 
+        <CheckBoxPreference
+             android:key="start_into_web_gui"
+             android:title="@string/start_into_web_gui_title"
+             android:summary="@string/start_into_web_gui_summary"
+             android:defaultValue="false"/>
+
     </PreferenceScreen>
 
     <PreferenceScreen


### PR DESCRIPTION
Reverts https://github.com/Catfriend1/syncthing-android/commit/f0d72e7a4b92fd8857af81fea8718d20ce12bb07

Re-adds:

![image](https://github.com/user-attachments/assets/aa9876fc-62a9-45f4-9c74-9f3e924c5bba)
