### PR TITLE
Feat allow choosing backup folders more freely

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
@@ -1020,8 +1020,8 @@ public class SettingsActivity extends SyncthingActivity {
          * Default: /storage/emulated0/backups/syncthing
          */
         private final File getBackupFolder() {
-            String backupFolderName = mPreferences.getString(Constants.PREF_BACKUP_FOLDER_NAME, "syncthing");
-            return new File(Environment.getExternalStorageDirectory() + "/backups/" + backupFolderName);
+            String backupFolderName = mPreferences.getString(Constants.PREF_BACKUP_FOLDER_NAME, "backups/syncthing");
+            return new File(Environment.getExternalStorageDirectory() + "/" + backupFolderName);
         }
 
         /**

--- a/app/src/main/res/xml/app_settings.xml
+++ b/app/src/main/res/xml/app_settings.xml
@@ -321,7 +321,7 @@
             android:title="@string/backup_folder_name"
             android:summary="@null"
             android:persistent="true"
-            android:defaultValue="syncthing"
+            android:defaultValue="backups/syncthing"
             android:inputType="textNoSuggestions" />
 
         <Preference


### PR DESCRIPTION
# Description
Describe what this PR is about
Previously, the backups folder have to reside under `/storage/emulated0/backups/` folder. This allows to use any folder under `/storage/emulated0/`.

# Changes
What changes are made in this PR
* remove the `backups` prefix when choosing backup folder
* change the default value to `backups/syncthing` to maintain backward compatibility
