### PR TITLE
Fix connectivity issues when using a VPN and network binding at the same time

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
@@ -1,5 +1,7 @@
 package com.nutomic.syncthingandroid.service;
 
+import static com.nutomic.syncthingandroid.service.SyncthingService.EXTRA_STOP_AFTER_CRASHED_NATIVE;
+
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.Intent;
@@ -43,8 +45,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import javax.inject.Inject;
 
 import eu.chainfire.libsuperuser.Shell;
-
-import static com.nutomic.syncthingandroid.service.SyncthingService.EXTRA_STOP_AFTER_CRASHED_NATIVE;
 
 /**
  * Runs the syncthing binary from command line, and prints its output to logcat.
@@ -136,7 +136,7 @@ public class SyncthingRunnable implements Runnable {
      *    Android will auto route the request through the mobile network.
      * 2. User only wants to sync through mobile network, but not use WiFi.
      */
-    private void bindNetwork() {
+    public void bindNetwork() {
         clearBindNetwork();
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
             return;

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
@@ -1,21 +1,22 @@
 package com.nutomic.syncthingandroid.service;
 
-import android.annotation.TargetApi;
 import android.app.Service;
+import android.content.Context;
 import android.content.Intent;
-import android.content.pm.PackageManager;
-import android.content.res.Resources;
 import android.content.SharedPreferences;
-import android.Manifest;
+import android.content.res.Resources;
+import android.net.ConnectivityManager;
+import android.net.Network;
+import android.net.NetworkCapabilities;
+import android.net.NetworkRequest;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.core.content.ContextCompat;
 
-import com.annimon.stream.Stream;
 import com.google.common.io.Files;
 import com.nutomic.syncthingandroid.R;
 import com.nutomic.syncthingandroid.SyncthingApp;
@@ -27,7 +28,6 @@ import com.nutomic.syncthingandroid.util.ConfigXml;
 import com.nutomic.syncthingandroid.util.FileUtils;
 import com.nutomic.syncthingandroid.util.PermissionUtil;
 import com.nutomic.syncthingandroid.util.Util;
-import com.nutomic.syncthingandroid.service.SyncthingRunnable.ExecutableNotFoundException;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -35,7 +35,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashSet;
@@ -240,6 +239,14 @@ public class SyncthingService extends Service {
     private boolean mPrefBroadcastServiceControl = false;
 
     /**
+     * ConnectivityManager and NetworkCallback are used to restart syncthing
+     * when a VPN capable connection is changed, to prevent connectivity
+     * issues due to network binding
+     */
+    private ConnectivityManager connectivityManager;
+    private ConnectivityManager.NetworkCallback networkCallback;
+
+    /**
      * Starts the native binary.
      */
     @Override
@@ -264,6 +271,28 @@ public class SyncthingService extends Service {
 
         // Read pref.
         mPrefBroadcastServiceControl = mPreferences.getBoolean(Constants.PREF_BROADCAST_SERVICE_CONTROL, false);
+
+        connectivityManager = (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
+
+        NetworkRequest networkRequest = new NetworkRequest.Builder()
+                .removeCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN)
+                .build();
+
+        networkCallback = new ConnectivityManager.NetworkCallback() {
+            @Override
+            public void onAvailable(@NonNull Network network) {
+                Log.d(TAG, "VPN capable network connection established, restarting syncthing");
+                SyncthingService.this.startService(new Intent(SyncthingService.this, SyncthingService.class).setAction(SyncthingService.ACTION_RESTART));
+            }
+
+            @Override
+            public void onLost(@NonNull Network network) {
+                Log.d(TAG, "VPN capable network connection lost, restarting syncthing");
+                SyncthingService.this.startService(new Intent(SyncthingService.this, SyncthingService.class).setAction(SyncthingService.ACTION_RESTART));
+            }
+        };
+
+        connectivityManager.registerNetworkCallback(networkRequest, networkCallback);
     }
 
     /**
@@ -676,6 +705,11 @@ public class SyncthingService extends Service {
             Log.i(TAG, "Shutting down syncthing binary due to missing storage permission.");
         }
         shutdown(State.DISABLED);
+
+        if (networkCallback != null) {
+            connectivityManager.unregisterNetworkCallback(networkCallback);
+        }
+
         super.onDestroy();
     }
 

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
@@ -239,9 +239,9 @@ public class SyncthingService extends Service {
     private boolean mPrefBroadcastServiceControl = false;
 
     /**
-     * ConnectivityManager and NetworkCallback are used to restart syncthing
-     * when a VPN capable connection is changed, to prevent connectivity
-     * issues due to network binding
+     * ConnectivityManager and NetworkCallback are used to rebind syncthing
+     * to the current network when a VPN capable connection is changed
+     * to prevent connectivity issues due to network binding
      */
     private ConnectivityManager connectivityManager;
     private ConnectivityManager.NetworkCallback networkCallback;
@@ -281,14 +281,18 @@ public class SyncthingService extends Service {
         networkCallback = new ConnectivityManager.NetworkCallback() {
             @Override
             public void onAvailable(@NonNull Network network) {
-                Log.d(TAG, "VPN capable network connection established, restarting syncthing");
-                SyncthingService.this.startService(new Intent(SyncthingService.this, SyncthingService.class).setAction(SyncthingService.ACTION_RESTART));
+                if (mSyncthingRunnable != null) {
+                    Log.d(TAG, "VPN capable network connection established, rebinding network");
+                    mSyncthingRunnable.bindNetwork();
+                }
             }
 
             @Override
             public void onLost(@NonNull Network network) {
-                Log.d(TAG, "VPN capable network connection lost, restarting syncthing");
-                SyncthingService.this.startService(new Intent(SyncthingService.this, SyncthingService.class).setAction(SyncthingService.ACTION_RESTART));
+                if (mSyncthingRunnable != null) {
+                    Log.d(TAG, "VPN capable network connection lost, rebinding network");
+                    mSyncthingRunnable.bindNetwork();
+                }
             }
         };
 


### PR DESCRIPTION
# Description
This PR fixes some connectivity issues regarding the use of a VPN combined with the "bind to active network".

Whenever I connected my VPN after Syncthing was already bound to a network, all my devices would show as "disconnected" because the process was bound to a network that didn't exist in that way anymore, so I made the process rebind itself to the active network whenever a VPN change happens.

This might also help with #957, but the issue didn't happen that way while I made the changes, so I couldn't test it.

# Changes
* Rebind the process to the active network whenever a VPN is established or lost
