### PR TITLE
importConfig: Ignore outdated user pref (fixes #1375)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
@@ -1012,6 +1012,10 @@ public class SyncthingService extends Service {
                     for (Map.Entry<?, ?> e : sharedPrefsMap.entrySet()) {
                         String prefKey = (String) e.getKey();
                         switch (prefKey) {
+                            // Preferences that should not be imported as they may be outdated and already changed by the user.
+                            case Constants.PREF_BACKUP_FOLDER_NAME:
+                                LogV("importConfig: Ignoring outdated user pref \"" + prefKey + "\".");
+                                break;
                             // Preferences that are no longer used and left-overs from previous versions of the app.
                             case "first_start":
                             case "advanced_folder_picker":


### PR DESCRIPTION
BACKUP_FOLDER_PREF will not be imported. We don't know if it fits to a probably new phone target with another internal storage folder structure and/or user desires. Plus, the user already manually set this location when importing a backup.