### PR TITLE
Revert "Fix connectivity issues when using a VPN and network binding at the same time (A10-13) (fixes #957)"

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
@@ -136,7 +136,7 @@ public class SyncthingRunnable implements Runnable {
      *    Android will auto route the request through the mobile network.
      * 2. User only wants to sync through mobile network, but not use WiFi.
      */
-    public void bindNetwork() {
+    private void bindNetwork() {
         clearBindNetwork();
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
             return;

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
@@ -1,20 +1,14 @@
 package com.nutomic.syncthingandroid.service;
 
 import android.app.Service;
-import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.Resources;
-import android.net.ConnectivityManager;
-import android.net.Network;
-import android.net.NetworkCapabilities;
-import android.net.NetworkRequest;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
 
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.google.common.io.Files;
@@ -239,14 +233,6 @@ public class SyncthingService extends Service {
     private boolean mPrefBroadcastServiceControl = false;
 
     /**
-     * ConnectivityManager and NetworkCallback are used to rebind syncthing
-     * to the current network when a VPN capable connection is changed
-     * to prevent connectivity issues due to network binding
-     */
-    private ConnectivityManager connectivityManager;
-    private ConnectivityManager.NetworkCallback networkCallback;
-
-    /**
      * Starts the native binary.
      */
     @Override
@@ -271,32 +257,6 @@ public class SyncthingService extends Service {
 
         // Read pref.
         mPrefBroadcastServiceControl = mPreferences.getBoolean(Constants.PREF_BROADCAST_SERVICE_CONTROL, false);
-
-        connectivityManager = (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
-
-        NetworkRequest networkRequest = new NetworkRequest.Builder()
-                .removeCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN)
-                .build();
-
-        networkCallback = new ConnectivityManager.NetworkCallback() {
-            @Override
-            public void onAvailable(@NonNull Network network) {
-                if (mSyncthingRunnable != null) {
-                    Log.d(TAG, "VPN capable network connection established, rebinding network");
-                    mSyncthingRunnable.bindNetwork();
-                }
-            }
-
-            @Override
-            public void onLost(@NonNull Network network) {
-                if (mSyncthingRunnable != null) {
-                    Log.d(TAG, "VPN capable network connection lost, rebinding network");
-                    mSyncthingRunnable.bindNetwork();
-                }
-            }
-        };
-
-        connectivityManager.registerNetworkCallback(networkRequest, networkCallback);
     }
 
     /**
@@ -709,11 +669,6 @@ public class SyncthingService extends Service {
             Log.i(TAG, "Shutting down syncthing binary due to missing storage permission.");
         }
         shutdown(State.DISABLED);
-
-        if (networkCallback != null) {
-            connectivityManager.unregisterNetworkCallback(networkCallback);
-        }
-
         super.onDestroy();
     }
 


### PR DESCRIPTION
Reverts Catfriend1/syncthing-android#1364

Reason: Doesn't work as intended by the author

If I go to the web UI while ...
* "bind to active network = enabled" 
* and "WiFi has no internet connectivity but is still connected"
... and enable to connect to a relay in settings (Global Discovery := enabled, Relay := enabled)
... I see that the relay is immediately connected  (Timestamp short after : 05-08 21:52:24.672)
EXPECTATION: Relay cannot connect as the active network is bound to WiFi
REAL STATE: Relay is connected, reason: SyncthingService rebound the active network to mobile data whilst WiFi was connected

(No VPN was used during testing)

CMD:
```
adb logcat SyncthingService:D *:S
```

Log:
```
# Connected WiFi - internet connection available
05-08 21:49:49.047 17013 17013 I SyncthingService: shouldRun decision changed to true according to configured run conditions.
05-08 21:49:49.069 17013 17013 I SyncthingService: onServiceStateChange: from DISABLED to STARTING
05-08 21:49:49.070 17013 17013 I SyncthingService: Web GUI will be available at https://127.0.0.1:28384
05-08 21:49:49.240 17013 17062 D SyncthingService: VPN capable network connection established, rebinding network
05-08 21:49:49.887 17013 17013 I SyncthingService: Web GUI has come online at https://127.0.0.1:28384
05-08 21:49:49.951 17013 17013 I SyncthingService: onServiceStateChange: from STARTING to ACTIVE
05-08 21:49:49.952 17013 17013 D SyncthingService: onServiceStateChange: Called with unchanged state ACTIVE
05-08 21:49:59.954 17013 17013 D SyncthingService: onServiceStateChange: Called with unchanged state ACTIVE
05-08 21:50:19.569 17013 17062 D SyncthingService: VPN capable network connection lost, rebinding network
05-08 21:50:33.639 17013 17013 D SyncthingService: Forced re-evaluating run conditions ...
05-08 21:50:34.847 17013 17013 D SyncthingService: onStartCommand
# Disconnected router from the internet - WiFi still active and connected - Android has the "!" = "no internet" marker on the WiFi symbol
05-08 21:52:24.672 17013 17062 D SyncthingService: VPN capable network connection established, rebinding network
05-08 21:52:35.498 17013 17013 D SyncthingService: Forced re-evaluating run conditions ...
05-08 21:52:36.859 17013 17013 D SyncthingService: onStartCommand
```