### PR TITLE
Improve log file share by file provider (fixes #1454)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/LogActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/LogActivity.java
@@ -137,8 +137,10 @@ public class LogActivity extends SyncthingActivity {
             if (logActivity.mShareIntent != null) {
                 logActivity.mShareIntent.putExtra(android.content.Intent.EXTRA_TEXT, log);
             }
-            // Scroll to bottom
-            logActivity.mScrollView.post(() -> logActivity.mScrollView.scrollTo(0, logActivity.mLog.getBottom()));
+            if (!logActivity.mSyncthingLog) {
+                // Scroll Android log to bottom.
+                logActivity.mScrollView.post(() -> logActivity.mScrollView.scrollTo(0, logActivity.mLog.getBottom()));
+            }
         }
 
         /**

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/LogActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/LogActivity.java
@@ -1,20 +1,24 @@
 package com.nutomic.syncthingandroid.activities;
 
 import android.content.Intent;
+import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
-import androidx.core.view.MenuItemCompat;
-import androidx.appcompat.widget.ShareActionProvider;
 import android.text.TextUtils;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.widget.ScrollView;
 import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.core.content.FileProvider;
 
 import com.nutomic.syncthingandroid.R;
+import com.nutomic.syncthingandroid.service.Constants;
 import com.nutomic.syncthingandroid.util.Util;
 
+import java.io.File;
 import java.lang.ref.WeakReference;
 import java.util.Arrays;
 import java.util.ArrayList;
@@ -73,21 +77,13 @@ public class LogActivity extends SyncthingActivity {
         MenuItem switchLog = menu.findItem(R.id.switch_logs);
         switchLog.setTitle(mSyncthingLog ? R.string.view_android_log : R.string.view_syncthing_log);
 
-        // Add the share button
-        MenuItem shareItem = menu.findItem(R.id.menu_share);
-        ShareActionProvider actionProvider = (ShareActionProvider) MenuItemCompat.getActionProvider(shareItem);
-        mShareIntent = new Intent();
-        mShareIntent.setAction(Intent.ACTION_SEND);
-        mShareIntent.setType("text/plain");
-        mShareIntent.putExtra(android.content.Intent.EXTRA_TEXT, mLog.getText());
-        actionProvider.setShareIntent(mShareIntent);
-
         return true;
     }
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        if (item.getItemId() == R.id.switch_logs) {
+        int itemId = item.getItemId();
+        if (itemId == R.id.switch_logs) {
             mSyncthingLog = !mSyncthingLog;
             if (mSyncthingLog) {
                 item.setTitle(R.string.view_android_log);
@@ -98,6 +94,7 @@ public class LogActivity extends SyncthingActivity {
             }
             updateLog();
             return true;
+        } else if (itemId == R.id.menu_share_log_file) {
         }
         return super.onOptionsItemSelected(item);
     }

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/LogActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/LogActivity.java
@@ -95,6 +95,36 @@ public class LogActivity extends SyncthingActivity {
             updateLog();
             return true;
         } else if (itemId == R.id.menu_share_log_file) {
+            // ToDo
+            /*
+            if (mSyncthingLog) {
+                File logFile = Constants.getLogFile(this);
+                if (!logFile.exists()) {
+                    Toast.makeText(this, getString(R.string.share_log_file_missing), Toast.LENGTH_SHORT).show();
+                    return true;
+                }
+
+                Uri contentUri = FileProvider.getUriForFile(
+                    this,
+                    getPackageName() + ".provider",
+                    logFile
+                );
+
+                Intent shareIntent = new Intent(Intent.ACTION_SEND);
+                shareIntent.setType("text/plain");
+                shareIntent.putExtra(Intent.EXTRA_STREAM, contentUri);
+                shareIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+
+                startActivity(Intent.createChooser(shareIntent, getString(R.string.share_log_file)));
+            } else {
+                // Android log
+                Intent shareIntent = new Intent(Intent.ACTION_SEND);
+                shareIntent.setType("text/plain");
+                shareIntent.putExtra(Intent.EXTRA_TEXT, mLog.getText());
+                startActivity(Intent.createChooser(shareIntent, getString(R.string.share_short_log_via)));
+            }
+            */
+            return true;
         }
         return super.onOptionsItemSelected(item);
     }

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/LogActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/LogActivity.java
@@ -20,7 +20,9 @@ import com.nutomic.syncthingandroid.service.Constants;
 import com.nutomic.syncthingandroid.util.Util;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.InputStreamReader;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
 import java.nio.charset.StandardCharsets;
@@ -267,8 +269,31 @@ public class LogActivity extends SyncthingActivity {
      * Read or write log file.
      */
     private static String readLogFile(final File file) {
-        // ToDo
-        return "Test";
+        String content = "";
+        FileInputStream fileInputStream = null;
+        try {
+            if (file.exists()) {
+                fileInputStream = new FileInputStream(file);
+                InputStreamReader inputStreamReader = new InputStreamReader(fileInputStream, StandardCharsets.UTF_8);
+                byte[] data = new byte[(int) file.length()];
+                fileInputStream.read(data);
+                content = new String(data, StandardCharsets.UTF_8);
+            } else {
+                // File not found.
+                Log.e(TAG, "readLogFile: File missing '" + file.toString() + "'");
+            }
+        } catch (IOException e) {
+            Log.e(TAG, "readLogFile: Failed to read '" + file.toString() + "' #1", e);
+        } finally {
+            try {
+                if (fileInputStream != null) {
+                    fileInputStream.close();
+                }
+            } catch (IOException e) {
+                Log.e(TAG, "readLogFile: Failed to read '" + file.toString() + "' #2", e);
+            }
+        }
+        return content;
     }
 
     private static void writeLogFile(final File file, String logContent) {

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/LogActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/LogActivity.java
@@ -5,6 +5,7 @@ import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.text.TextUtils;
+import android.util.Log;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
@@ -19,7 +20,10 @@ import com.nutomic.syncthingandroid.service.Constants;
 import com.nutomic.syncthingandroid.util.Util;
 
 import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.lang.ref.WeakReference;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.ListIterator;
@@ -244,6 +248,33 @@ public class LogActivity extends SyncthingActivity {
                 it.set(logline);
             }
             return TextUtils.join("\n", list.toArray(new String[0]));
+        }
+    }
+
+    /**
+     * Stores ignore list for given folder.
+     */
+    public void writeLogFile(final String absoluteFn, String logContent) {
+        File file;
+        FileOutputStream fileOutputStream = null;
+        try {
+            file = new File(absoluteFn);
+            if (!file.exists()) {
+                file.createNewFile();
+            }
+            fileOutputStream = new FileOutputStream(file);
+            fileOutputStream.write(logContent.getBytes(StandardCharsets.UTF_8));
+            fileOutputStream.flush();
+        } catch (IOException e) {
+            Log.w(TAG, "writeLogFile: Failed to write '" + absoluteFn + "' #1", e);
+        } finally {
+            try {
+                if (fileOutputStream != null) {
+                    fileOutputStream.close();
+                }
+            } catch (IOException e) {
+                Log.e(TAG, "writeLogFile: Failed to write '" + absoluteFn + "' #2", e);
+            }
         }
     }
 

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/LogActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/LogActivity.java
@@ -137,10 +137,8 @@ public class LogActivity extends SyncthingActivity {
             if (logActivity.mShareIntent != null) {
                 logActivity.mShareIntent.putExtra(android.content.Intent.EXTRA_TEXT, log);
             }
-            if (!logActivity.mSyncthingLog) {
-                // Scroll Android log to bottom.
-                logActivity.mScrollView.post(() -> logActivity.mScrollView.scrollTo(0, logActivity.mLog.getBottom()));
-            }
+            // Scroll to bottom
+            logActivity.mScrollView.post(() -> logActivity.mScrollView.scrollTo(0, logActivity.mLog.getBottom()));
         }
 
         /**

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/LogActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/LogActivity.java
@@ -219,12 +219,15 @@ public class LogActivity extends SyncthingActivity {
                             logline.contains("I/ConfigStore") ||
                             logline.contains("/dalvikvm") ||
                             logline.contains("/DecorView") ||
+                            logline.contains("/EGL") ||                      
                             logline.contains("/eglCodecCommon") ||
-                            logline.contains("W/Gralloc3") ||
+                            logline.contains("W/Gralloc") ||
                             logline.contains("W/HWUI") ||
                             logline.contains("/InputEventReceiver") ||
                             logline.contains("/InputMethodManager") ||
                             logline.contains("/libEGL") ||
+                            logline.contains("W/libsyncthingnat") ||
+                            logline.contains("W/netstat") ||
                             logline.contains("/ngandroid.debu") ||
                             logline.contains("/OpenGLRenderer") ||
                             logline.contains("/PacProxySelector") ||

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/LogActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/LogActivity.java
@@ -248,6 +248,7 @@ public class LogActivity extends SyncthingActivity {
                             logline.contains("I/Timeline") ||
                             logline.contains("/VideoCapabilities") ||
                             logline.contains("I/WebViewFactory") ||
+                            logline.contains("WindowOnBackDispatcher") ||
                             logline.contains("I/X509Util") ||
                             logline.contains("/zygote") ||
                             logline.contains("/zygote64")

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/LogActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/LogActivity.java
@@ -200,11 +200,12 @@ public class LogActivity extends SyncthingActivity {
                             logline.contains("W/ActionBarDrawerToggle") ||
                             logline.contains("W/ActivityThread") ||
                             logline.contains("I/Adreno") ||
-                            logline.contains("AssistStructure") ||
+                            logline.contains("/AssistStructure") ||
                             logline.contains("I/chatty") ||
                             logline.contains("/Choreographer") ||
                             logline.contains("W/chmod") ||
                             logline.contains("/chromium") ||
+                            logline.contains("/ContentCaptureHelper") ||
                             logline.contains("/ContentCatcher") ||
                             logline.contains("/cr_AwContents") ||
                             logline.contains("/cr_base") ||
@@ -219,6 +220,8 @@ public class LogActivity extends SyncthingActivity {
                             logline.contains("/dalvikvm") ||
                             logline.contains("/DecorView") ||
                             logline.contains("/eglCodecCommon") ||
+                            logline.contains("W/Gralloc3") ||
+                            logline.contains("W/HWUI") ||
                             logline.contains("/InputEventReceiver") ||
                             logline.contains("/InputMethodManager") ||
                             logline.contains("/libEGL") ||
@@ -231,6 +234,7 @@ public class LogActivity extends SyncthingActivity {
                             logline.contains("W/sh") ||
                             logline.contains("/StrictMode") ||
                             logline.contains("I/System.out") ||
+                            logline.contains("W/TextView") ||
                             logline.contains("I/Timeline") ||
                             logline.contains("/VideoCapabilities") ||
                             logline.contains("I/WebViewFactory") ||

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/LogActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/LogActivity.java
@@ -99,35 +99,14 @@ public class LogActivity extends SyncthingActivity {
             updateLog();
             return true;
         } else if (itemId == R.id.menu_share_log_file) {
-            // ToDo
-            /*
             if (mSyncthingLog) {
-                File logFile = Constants.getLogFile(this);
-                if (!logFile.exists()) {
-                    Toast.makeText(this, getString(R.string.share_log_file_missing), Toast.LENGTH_SHORT).show();
-                    return true;
-                }
-
-                Uri contentUri = FileProvider.getUriForFile(
-                    this,
-                    getPackageName() + ".provider",
-                    logFile
-                );
-
-                Intent shareIntent = new Intent(Intent.ACTION_SEND);
-                shareIntent.setType("text/plain");
-                shareIntent.putExtra(Intent.EXTRA_STREAM, contentUri);
-                shareIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-
-                startActivity(Intent.createChooser(shareIntent, getString(R.string.share_log_file)));
+                File syncthingLog = Constants.getSyncthingLogFile(this);
+                shareLogFile(syncthingLog);
             } else {
-                // Android log
-                Intent shareIntent = new Intent(Intent.ACTION_SEND);
-                shareIntent.setType("text/plain");
-                shareIntent.putExtra(Intent.EXTRA_TEXT, mLog.getText());
-                startActivity(Intent.createChooser(shareIntent, getString(R.string.share_short_log_via)));
+                File androidLog = Constants.getAndroidLogFile(this);
+                // ToDo Overwrite with logcat output.
+                shareLogFile(androidLog);
             }
-            */
             return true;
         }
         return super.onOptionsItemSelected(item);

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/LogActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/LogActivity.java
@@ -149,7 +149,7 @@ public class LogActivity extends SyncthingActivity {
         private String getLog(final boolean syncthingLog) {
             String output;
             if (syncthingLog) {
-                output = Util.runShellCommandGetOutput("/system/bin/logcat -t 900 -v time -s SyncthingNativeCode", false);
+                output = Util.runShellCommandGetOutput("/system/bin/logcat -t 200000 -v time -s SyncthingNativeCode", false);
             } else {
                 // Get Android log.
                 output = Util.runShellCommandGetOutput("/system/bin/logcat -t 900 -v time *:i ps:s art:s", false);

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/LogActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/LogActivity.java
@@ -36,15 +36,20 @@ public class LogActivity extends SyncthingActivity {
 
     private final static String TAG = "LogActivity";
 
+    private static final int ANDROID_LOG_FILE_MAX_LINES = 2000;
+
     /**
      * Show Android Log by default.
      */
-    private boolean mSyncthingLog = false;
+    private boolean mShowSyncthingLog = false;
 
     private TextView mLog;
     private AsyncTask mFetchLogTask = null;
     private ScrollView mScrollView;
     private Intent mShareIntent;
+   
+    private String androidLogContent = "";   
+    private String syncthingLogContent = "";
 
     /**
      * Initialize Log.
@@ -57,20 +62,20 @@ public class LogActivity extends SyncthingActivity {
         setTitle(R.string.android_log_title);
 
         if (savedInstanceState != null) {
-            mSyncthingLog = savedInstanceState.getBoolean("syncthingLog");
+            mShowSyncthingLog = savedInstanceState.getBoolean("showSyncthingLog");
             invalidateOptionsMenu();
         }
 
         mLog = findViewById(R.id.log);
         mScrollView = findViewById(R.id.scroller);
 
-        updateLog();
+        fetchAndViewLog();
     }
 
     @Override
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
-        outState.putBoolean("syncthingLog", mSyncthingLog);
+        outState.putBoolean("showSyncthingLog", mShowSyncthingLog);
     }
 
     @Override
@@ -79,7 +84,7 @@ public class LogActivity extends SyncthingActivity {
         inflater.inflate(R.menu.log_list, menu);
 
         MenuItem switchLog = menu.findItem(R.id.switch_logs);
-        switchLog.setTitle(mSyncthingLog ? R.string.view_android_log : R.string.view_syncthing_log);
+        switchLog.setTitle(mShowSyncthingLog ? R.string.view_android_log : R.string.view_syncthing_log);
 
         return true;
     }
@@ -88,23 +93,22 @@ public class LogActivity extends SyncthingActivity {
     public boolean onOptionsItemSelected(MenuItem item) {
         int itemId = item.getItemId();
         if (itemId == R.id.switch_logs) {
-            mSyncthingLog = !mSyncthingLog;
-            if (mSyncthingLog) {
+            mShowSyncthingLog = !mShowSyncthingLog;
+            if (mShowSyncthingLog) {
                 item.setTitle(R.string.view_android_log);
                 setTitle(R.string.syncthing_log_title);
             } else {
                 item.setTitle(R.string.view_syncthing_log);
                 setTitle(R.string.android_log_title);
             }
-            updateLog();
+            fetchAndViewLog();
             return true;
         } else if (itemId == R.id.menu_share_log_file) {
-            if (mSyncthingLog) {
+            if (mShowSyncthingLog) {
                 File syncthingLog = Constants.getSyncthingLogFile(this);
                 shareLogFile(syncthingLog);
             } else {
                 File androidLog = Constants.getAndroidLogFile(this);
-                // ToDo Overwrite with logcat output.
                 shareLogFile(androidLog);
             }
             return true;
@@ -133,7 +137,7 @@ public class LogActivity extends SyncthingActivity {
         return true;
     }
 
-    private void updateLog() {
+    private void fetchAndViewLog() {
         if (mFetchLogTask != null) {
             mFetchLogTask.cancel(true);
         }
@@ -141,33 +145,40 @@ public class LogActivity extends SyncthingActivity {
         mFetchLogTask = new UpdateLogTask(this).execute();
     }
 
-    private static class UpdateLogTask extends AsyncTask<Void, Void, String> {
+    private static class UpdateLogTask extends AsyncTask<Void, Void, Void> {
         private WeakReference<LogActivity> refLogActivity;
 
         UpdateLogTask(LogActivity context) {
             refLogActivity = new WeakReference<>(context);
         }
 
-        protected String doInBackground(Void... params) {
+        protected Void doInBackground(Void... voids) {
             // Get a reference to the activity if it is still there.
             LogActivity logActivity = refLogActivity.get();
             if (logActivity == null || logActivity.isFinishing()) {
                 cancel(true);
-                return "";
+                return null;
             }
-            return getLog(logActivity.mSyncthingLog);
+
+            // Get Android log.
+            logActivity.androidLogContent = getAndroidLog();
+            writeLogFile(Constants.getAndroidLogFile(logActivity), logActivity.androidLogContent);
+
+            // Get SyncthingNative log.
+            logActivity.syncthingLogContent = readLogFile(Constants.getSyncthingLogFile(logActivity));
+            return null;
         }
 
-        protected void onPostExecute(String log) {
+        protected void onPostExecute(Void aVoid) {
             // Get a reference to the activity if it is still there.
             LogActivity logActivity = refLogActivity.get();
             if (logActivity == null || logActivity.isFinishing()) {
                 return;
             }
-            logActivity.mLog.setText(log);
-            if (logActivity.mShareIntent != null) {
-                logActivity.mShareIntent.putExtra(android.content.Intent.EXTRA_TEXT, log);
-            }
+
+            // Show one of the two logs available.
+            logActivity.mLog.setText(logActivity.mShowSyncthingLog ? logActivity.syncthingLogContent : logActivity.androidLogContent);
+
             // Scroll to bottom
             logActivity.mScrollView.post(() -> logActivity.mScrollView.scrollTo(0, logActivity.mLog.getBottom()));
         }
@@ -177,14 +188,8 @@ public class LogActivity extends SyncthingActivity {
          *
          * @param syncthingLog Filter on Syncthing's native messages.
          */
-        private String getLog(final boolean syncthingLog) {
-            String output;
-            if (syncthingLog) {
-                output = Util.runShellCommandGetOutput("/system/bin/logcat -t 200000 -v time -s SyncthingNativeCode", false);
-            } else {
-                // Get Android log.
-                output = Util.runShellCommandGetOutput("/system/bin/logcat -t 900 -v time *:i ps:s art:s", false);
-            }
+        private String getAndroidLog() {
+            String output = Util.runShellCommandGetOutput("/system/bin/logcat -t " + Integer.toString(ANDROID_LOG_FILE_MAX_LINES) + " -v time *:i ps:s art:s", false);
 
             // Filter Android log.
             output = output.replaceAll("I/SyncthingNativeCode", "");
@@ -259,13 +264,16 @@ public class LogActivity extends SyncthingActivity {
     }
 
     /**
-     * Stores ignore list for given folder.
+     * Read or write log file.
      */
-    public void writeLogFile(final String absoluteFn, String logContent) {
-        File file;
+    private static String readLogFile(final File file) {
+        // ToDo
+        return "Test";
+    }
+
+    private static void writeLogFile(final File file, String logContent) {
         FileOutputStream fileOutputStream = null;
         try {
-            file = new File(absoluteFn);
             if (!file.exists()) {
                 file.createNewFile();
             }
@@ -273,14 +281,14 @@ public class LogActivity extends SyncthingActivity {
             fileOutputStream.write(logContent.getBytes(StandardCharsets.UTF_8));
             fileOutputStream.flush();
         } catch (IOException e) {
-            Log.w(TAG, "writeLogFile: Failed to write '" + absoluteFn + "' #1", e);
+            Log.w(TAG, "writeLogFile: Failed to write '" + file.toString() + "' #1", e);
         } finally {
             try {
                 if (fileOutputStream != null) {
                     fileOutputStream.close();
                 }
             } catch (IOException e) {
-                Log.e(TAG, "writeLogFile: Failed to write '" + absoluteFn + "' #2", e);
+                Log.e(TAG, "writeLogFile: Failed to write '" + file.toString() + "' #2", e);
             }
         }
     }

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/LogActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/LogActivity.java
@@ -133,6 +133,27 @@ public class LogActivity extends SyncthingActivity {
         return super.onOptionsItemSelected(item);
     }
 
+    private boolean shareLogFile(final File logFile) {
+        if (!logFile.exists()) {
+            Toast.makeText(this, getString(R.string.share_log_file_missing), Toast.LENGTH_SHORT).show();
+            return false;
+        }
+
+        Uri contentUri = FileProvider.getUriForFile(
+            this,
+            getPackageName() + ".provider",
+            logFile
+        );
+
+        Intent shareIntent = new Intent(Intent.ACTION_SEND);
+        shareIntent.setType("text/plain");
+        shareIntent.putExtra(Intent.EXTRA_STREAM, contentUri);
+        shareIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+
+        startActivity(Intent.createChooser(shareIntent, getString(R.string.share_log_file)));
+        return true;
+    }
+
     private void updateLog() {
         if (mFetchLogTask != null) {
             mFetchLogTask.cancel(true);

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
@@ -378,7 +378,6 @@ public class SettingsActivity extends SyncthingActivity {
 
             /* Troubleshooting */
             Preference verboseLog                   = findPreference(Constants.PREF_VERBOSE_LOG);
-            Preference logToFile                    = findPreference(Constants.PREF_LOG_TO_FILE);
             Preference openIssueTracker             = findPreference(KEY_OPEN_ISSUE_TRACKER);
             Preference debugFacilitiesEnabled       = findPreference(Constants.PREF_DEBUG_FACILITIES_ENABLED);
             Preference environmentVariables         = findPreference(Constants.PREF_ENVIRONMENT_VARIABLES);
@@ -386,7 +385,6 @@ public class SettingsActivity extends SyncthingActivity {
             Preference stResetDeltas                = findPreference("st_reset_deltas");
 
             verboseLog.setOnPreferenceClickListener(this);
-            logToFile.setOnPreferenceClickListener(this);
             openIssueTracker.setOnPreferenceClickListener(this);
             debugFacilitiesEnabled.setOnPreferenceChangeListener(this);
             environmentVariables.setOnPreferenceChangeListener(this);
@@ -850,14 +848,6 @@ public class SettingsActivity extends SyncthingActivity {
             final Intent intent;
             switch (preference.getKey()) {
                 case Constants.PREF_VERBOSE_LOG:
-                    getAppRestartConfirmationDialog(getActivity())
-                            .setNegativeButton(android.R.string.no, (dialogInterface, i) -> {
-                                // Revert.
-                                ((CheckBoxPreference) preference).setChecked(!((CheckBoxPreference) preference).isChecked());
-                            })
-                            .show();
-                    return true;
-                case Constants.PREF_LOG_TO_FILE:
                     getAppRestartConfirmationDialog(getActivity())
                             .setNegativeButton(android.R.string.no, (dialogInterface, i) -> {
                                 // Revert.

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/SettingsActivity.java
@@ -378,6 +378,7 @@ public class SettingsActivity extends SyncthingActivity {
 
             /* Troubleshooting */
             Preference verboseLog                   = findPreference(Constants.PREF_VERBOSE_LOG);
+            Preference logToFile                    = findPreference(Constants.PREF_LOG_TO_FILE);
             Preference openIssueTracker             = findPreference(KEY_OPEN_ISSUE_TRACKER);
             Preference debugFacilitiesEnabled       = findPreference(Constants.PREF_DEBUG_FACILITIES_ENABLED);
             Preference environmentVariables         = findPreference(Constants.PREF_ENVIRONMENT_VARIABLES);
@@ -385,6 +386,7 @@ public class SettingsActivity extends SyncthingActivity {
             Preference stResetDeltas                = findPreference("st_reset_deltas");
 
             verboseLog.setOnPreferenceClickListener(this);
+            logToFile.setOnPreferenceClickListener(this);
             openIssueTracker.setOnPreferenceClickListener(this);
             debugFacilitiesEnabled.setOnPreferenceChangeListener(this);
             environmentVariables.setOnPreferenceChangeListener(this);
@@ -848,6 +850,14 @@ public class SettingsActivity extends SyncthingActivity {
             final Intent intent;
             switch (preference.getKey()) {
                 case Constants.PREF_VERBOSE_LOG:
+                    getAppRestartConfirmationDialog(getActivity())
+                            .setNegativeButton(android.R.string.no, (dialogInterface, i) -> {
+                                // Revert.
+                                ((CheckBoxPreference) preference).setChecked(!((CheckBoxPreference) preference).isChecked());
+                            })
+                            .show();
+                    return true;
+                case Constants.PREF_LOG_TO_FILE:
                     getAppRestartConfirmationDialog(getActivity())
                             .setNegativeButton(android.R.string.no, (dialogInterface, i) -> {
                                 // Revert.

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
@@ -62,7 +62,6 @@ public class Constants {
 
     // Preferences - Troubleshooting
     public static final String PREF_VERBOSE_LOG                 = "verbose_log";
-    public static final String PREF_LOG_TO_FILE                 = "log_to_file";
     public static final String PREF_ENVIRONMENT_VARIABLES       = "environment_variables";
     public static final String PREF_DEBUG_FACILITIES_ENABLED    = "debug_facilities_enabled";
 
@@ -263,7 +262,16 @@ public class Constants {
         return new File(context.getApplicationInfo().nativeLibraryDir, FILENAME_SYNCTHING_BINARY);
     }
 
-    public static File getLogFile(Context context) {
+    /**
+     * Log file storage locations.
+     */
+    public static File getAndroidLogFile(Context context) {
+        // e.g. /data/data/com.github.catfriend1.syncthingandroid.debug/cache/android.log
+        return new File(context.getFilesDir(), "android.log");
+    }
+
+    public static File getSyncthingLogFile(Context context) {
+        // e.g. /data/data/com.github.catfriend1.syncthingandroid.debug/files/syncthing.log
         return new File(context.getFilesDir(), "syncthing.log");
     }
 

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
@@ -267,7 +267,7 @@ public class Constants {
      */
     public static File getAndroidLogFile(Context context) {
         // e.g. /data/data/com.github.catfriend1.syncthingandroid.debug/cache/android.log
-        return new File(context.getFilesDir(), "android.log");
+        return new File(context.getCacheDir(), "android.log");
     }
 
     public static File getSyncthingLogFile(Context context) {

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
@@ -263,7 +263,7 @@ public class Constants {
         return new File(context.getApplicationInfo().nativeLibraryDir, FILENAME_SYNCTHING_BINARY);
     }
 
-    static File getLogFile(Context context) {
+    public static File getLogFile(Context context) {
         return new File(context.getFilesDir(), "syncthing.log");
     }
 

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
@@ -56,14 +56,14 @@ public class SyncthingRunnable implements Runnable {
     private static final String TAG_NICE = "SyncthingRunnableIoNice";
 
     private Boolean ENABLE_VERBOSE_LOG = false;
-    private Boolean LOG_TO_FILE = false;
+    private Boolean IS_DEBUGGABLE = false;
     private static final int LOG_FILE_MAX_LINES = 200000;
 
     private static final AtomicReference<Process> mSyncthing = new AtomicReference<>();
     private final Context mContext;
     private final File mSyncthingBinary;
     private String[] mCommand;
-    private final File mLogFile;
+    private final File mSyncthingLogFile;
     private final boolean mUseRoot;
 
     @Inject
@@ -88,11 +88,11 @@ public class SyncthingRunnable implements Runnable {
     public SyncthingRunnable(Context context, Command command) {
         ((SyncthingApp) context.getApplicationContext()).component().inject(this);
         ENABLE_VERBOSE_LOG = AppPrefs.getPrefVerboseLog(mPreferences);
-        LOG_TO_FILE = mPreferences.getBoolean(Constants.PREF_LOG_TO_FILE, false);
+        IS_DEBUGGABLE = Constants.isDebuggable(context);
         mContext = context;
         // Example: mSyncthingBinary="/data/app/com.github.catfriend1.syncthingandroid.debug-8HsN-IsVtZXc8GrE5-Hepw==/lib/x86/libsyncthingnative.so"
         mSyncthingBinary = Constants.getSyncthingBinary(mContext);
-        mLogFile = Constants.getLogFile(mContext);
+        mSyncthingLogFile = Constants.getSyncthingLogFile(mContext);
 
         // Get preferences relevant to starting syncthing core.
         mUseRoot = mPreferences.getBoolean(Constants.PREF_USE_ROOT, false) && Shell.SU.available();
@@ -134,7 +134,7 @@ public class SyncthingRunnable implements Runnable {
         String capturedStdOut = "";
 
         // Trim Syncthing log.
-        trimLogFile();
+        trimSyncthingLogFile();
 
         /**
          * Potential fix for #498, keep the CPU running while native binary is running.
@@ -194,8 +194,8 @@ public class SyncthingRunnable implements Runnable {
                         br.close();
                 }
             } else {
-                lInfo = log(process.getInputStream(), Log.INFO, LOG_TO_FILE);
-                lWarn = log(process.getErrorStream(), Log.WARN, LOG_TO_FILE);
+                lInfo = log(process.getInputStream(), Log.INFO);
+                lWarn = log(process.getErrorStream(), Log.WARN);
             }
 
             niceSyncthing();
@@ -404,20 +404,20 @@ public class SyncthingRunnable implements Runnable {
      *
      * @param is       The stream to log.
      * @param priority The priority level.
-     * @param saveLog  True if the log should be stored to {@link #mLogFile}.
+     * @param saveLog  True if the log should be stored to {@link #mSyncthingLogFile}.
      */
-    private Thread log(final InputStream is, final int priority, final boolean saveLog) {
+    private Thread log(final InputStream is, final int priority) {
         Thread t = new Thread(() -> {
             BufferedReader br = null;
             try {
                 br = new BufferedReader(new InputStreamReader(is, Charsets.UTF_8));
                 String line;
                 while ((line = br.readLine()) != null) {
-                    Log.println(priority, TAG_NATIVE, line);
-
-                    if (saveLog) {
-                        Files.append(line + "\n", mLogFile, Charsets.UTF_8);
+                    if (IS_DEBUGGABLE) {
+                        Log.println(priority, TAG_NATIVE, line);
                     }
+                    // Always output SynchtingNative's output to "syncthing.log".
+                    Files.append(line + "\n", mSyncthingLogFile, Charsets.UTF_8);
                 }
             } catch (IOException e) {
                 Log.w(TAG, "Failed to read Syncthing's command line output", e);
@@ -437,13 +437,13 @@ public class SyncthingRunnable implements Runnable {
     /**
      * Only keep last {@link #LOG_FILE_MAX_LINES} lines in log file, to avoid bloat.
      */
-    private void trimLogFile() {
-        if (!mLogFile.exists()) {
+    private void trimSyncthingLogFile() {
+        if (!mSyncthingLogFile.exists()) {
             return;
         }
 
         try {
-            LineNumberReader lnr = new LineNumberReader(new FileReader(mLogFile));
+            LineNumberReader lnr = new LineNumberReader(new FileReader(mSyncthingLogFile));
             lnr.skip(Long.MAX_VALUE);
 
             int lineCount = lnr.getLineNumber();
@@ -451,7 +451,7 @@ public class SyncthingRunnable implements Runnable {
 
             File tempFile = new File(mContext.getFilesDir().toString(), "syncthing.log.tmp");
 
-            BufferedReader reader = new BufferedReader(new FileReader(mLogFile));
+            BufferedReader reader = new BufferedReader(new FileReader(mSyncthingLogFile));
             BufferedWriter writer = new BufferedWriter(new FileWriter(tempFile));
 
             String currentLine;
@@ -463,7 +463,7 @@ public class SyncthingRunnable implements Runnable {
             }
             writer.close();
             reader.close();
-            tempFile.renameTo(mLogFile);
+            tempFile.renameTo(mSyncthingLogFile);
         } catch (IOException e) {
             Log.w(TAG, "Failed to trim log file", e);
         }

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
@@ -449,7 +449,7 @@ public class SyncthingRunnable implements Runnable {
             int lineCount = lnr.getLineNumber();
             lnr.close();
 
-            File tempFile = new File(FileUtils.getExternalFilesDir(mContext, null), "syncthing.log.tmp");
+            File tempFile = new File(mContext.getFilesDir().toString(), "syncthing.log.tmp");
 
             BufferedReader reader = new BufferedReader(new FileReader(mLogFile));
             BufferedWriter writer = new BufferedWriter(new FileWriter(tempFile));
@@ -477,10 +477,6 @@ public class SyncthingRunnable implements Runnable {
 
         targetEnv.put("STTRACE", TextUtils.join(" ",
                 mPreferences.getStringSet(Constants.PREF_DEBUG_FACILITIES_ENABLED, new HashSet<>())));
-        File externalFilesDir = FileUtils.getExternalFilesDir(mContext, null);
-        if (externalFilesDir != null) {
-            targetEnv.put("STGUIASSETS", externalFilesDir.getAbsolutePath() + "/gui");
-        }
         targetEnv.put("STMONITORED", "1");
         targetEnv.put("STNOUPGRADE", "1");
         if (mPreferences.getBoolean(Constants.PREF_USE_TOR, false)) {

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
@@ -104,13 +104,13 @@ public class SyncthingRunnable implements Runnable {
                 mCommand = new String[]{mSyncthingBinary.getPath(), "--generate=" + mContext.getFilesDir().toString(), "--no-default-folder", "--logflags=0"};
                 break;
             case main:
-                mCommand = new String[]{mSyncthingBinary.getPath(), "--home=" + mContext.getFilesDir().toString(), "--no-browser", "--logflags=0"};
+                mCommand = new String[]{mSyncthingBinary.getPath(), "--home=" + mContext.getFilesDir().toString(), "--no-browser"};
                 break;
             case resetdatabase:
-                mCommand = new String[]{mSyncthingBinary.getPath(), "--home=" + mContext.getFilesDir().toString(), "--reset-database", "--logflags=0"};
+                mCommand = new String[]{mSyncthingBinary.getPath(), "--home=" + mContext.getFilesDir().toString(), "--reset-database"};
                 break;
             case resetdeltas:
-                mCommand = new String[]{mSyncthingBinary.getPath(), "--home=" + mContext.getFilesDir().toString(), "--reset-deltas", "--logflags=0"};
+                mCommand = new String[]{mSyncthingBinary.getPath(), "--home=" + mContext.getFilesDir().toString(), "--reset-deltas"};
                 break;
             default:
                 throw new InvalidParameterException("Unknown command option");

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
@@ -414,7 +414,8 @@ public class SyncthingRunnable implements Runnable {
                 String line;
                 while ((line = br.readLine()) != null) {
                     if (IS_DEBUGGABLE) {
-                        Log.println(priority, TAG_NATIVE, line);
+                        String lineWithoutTimestamp = line.replaceFirst("\\d{4}/\\d{2}/\\d{2} \\d{2}:\\d{2}:\\d{2} ?", "");
+                        Log.println(priority, TAG_NATIVE, lineWithoutTimestamp);
                     }
                     // Always output SynchtingNative's output to "syncthing.log".
                     Files.append(line + "\n", mSyncthingLogFile, Charsets.UTF_8);

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
@@ -57,7 +57,7 @@ public class SyncthingRunnable implements Runnable {
 
     private Boolean ENABLE_VERBOSE_LOG = false;
     private Boolean LOG_TO_FILE = false;
-    private static final int LOG_FILE_MAX_LINES = 10;
+    private static final int LOG_FILE_MAX_LINES = 200000;
 
     private static final AtomicReference<Process> mSyncthing = new AtomicReference<>();
     private final Context mContext;

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
@@ -987,6 +987,7 @@ public class SyncthingService extends Service {
                             case "first_start":
                             case "advanced_folder_picker":
                             case "bind_network":
+                            case "log_to_file":
                             case "notification_type":
                             case "notify_crashes":
                             case "suggest_new_folder_root":

--- a/app/src/main/res/menu/log_list.xml
+++ b/app/src/main/res/menu/log_list.xml
@@ -8,8 +8,8 @@
         android:title="@string/view_android_log" />
 
       <item
-        android:id="@+id/menu_share"
-        android:title="@string/share_title"
+        android:id="@+id/menu_share_log_file"
+        android:title="@string/share_log_file"
         app:actionProviderClass="androidx.appcompat.widget.ShareActionProvider" />
 
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -820,6 +820,10 @@
     <string name="syncthing_log_title">Syncthing Log</string>
     <string name="android_log_title">Android Log</string>
 
+    <string name="share_log_file_missing">The logfile to share is missing.</string>
+
+    <string name="share_log_file">Share log file</string>
+
     <!-- Title of the "log android" menu button -->
     <string name="view_android_log">View Android Log</string>
 

--- a/app/src/main/res/xml/app_settings.xml
+++ b/app/src/main/res/xml/app_settings.xml
@@ -360,14 +360,6 @@
             android:singleLineTitle="false"
             android:defaultValue="false" />
 
-        <!-- Log to file -->
-        <CheckBoxPreference
-            android:key="log_to_file"
-            android:title="@string/log_to_file_title"
-            android:summary="@string/log_to_file_summary"
-            android:singleLineTitle="false"
-            android:defaultValue="false" />
-
         <!-- Open Android or SyncthingNative log -->
         <Preference
             android:title="@string/open_log"

--- a/app/src/main/res/xml/app_settings.xml
+++ b/app/src/main/res/xml/app_settings.xml
@@ -360,7 +360,7 @@
             android:singleLineTitle="false"
             android:defaultValue="false" />
 
-        <!-- Verbose log -->
+        <!-- Log to file -->
         <CheckBoxPreference
             android:key="log_to_file"
             android:title="@string/log_to_file_title"

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -4,4 +4,5 @@
     <external-media-path name="my_images" />
     <external-path name="external" path="." />
     <files-path name="internal" path="." />
+    <cache-path name="cache" path="." />
 </paths>

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -3,4 +3,5 @@
     <external-files-path name="my_images" />
     <external-media-path name="my_images" />
     <external-path name="external" path="." />
+    <files-path name="internal" path="." />
 </paths>


### PR DESCRIPTION
This PR changes the Synchting(Native) log to be always enabled and it will be written plus trimmed.

When the user hits the share log button, let's write out logcat output to a file "android.log", "syncthing.log" already exists, start the share to app chooser.

Screenshots:
![image](https://github.com/user-attachments/assets/c1bb5d77-d013-402d-83dc-2d8dfc9f97da)

![image](https://github.com/user-attachments/assets/4ed429da-6e5b-453a-b5e6-200b096c46eb)
