### PR TITLE
Offer "Android/data" and "Android/obb" in gear icon folder picker (fixes #1123)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderPickerActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderPickerActivity.java
@@ -126,7 +126,7 @@ public class FolderPickerActivity extends SyncthingActivity
             roots.remove(getExternalFilesDir(null));
             roots.remove(null);      // getExternalFilesDirs may return null for an ejected SDcard.
 
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+            if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.R) {
                 // Add "/storage/emulated/0/Android/data"
                 roots.add(getExternalFilesDir(null).getParentFile().getParentFile());
 

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderPickerActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderPickerActivity.java
@@ -126,13 +126,11 @@ public class FolderPickerActivity extends SyncthingActivity
             roots.remove(getExternalFilesDir(null));
             roots.remove(null);      // getExternalFilesDirs may return null for an ejected SDcard.
 
-            if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.R) {
-                // Add "/storage/emulated/0/Android/data"
-                roots.add(getExternalFilesDir(null).getParentFile().getParentFile());
+            // Add "/storage/emulated/0/Android/data"
+            roots.add(getExternalFilesDir(null).getParentFile().getParentFile());
 
-                // Add "/storage/emulated/0/Android/obb"
-                roots.add(getObbDir().getParentFile());
-            }
+            // Add "/storage/emulated/0/Android/obb"
+            roots.add(getObbDir().getParentFile());
 
             roots.add(Environment.getExternalStorageDirectory());
             roots.add(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_MOVIES));

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderPickerActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderPickerActivity.java
@@ -126,11 +126,13 @@ public class FolderPickerActivity extends SyncthingActivity
             roots.remove(getExternalFilesDir(null));
             roots.remove(null);      // getExternalFilesDirs may return null for an ejected SDcard.
 
-            // Add "/storage/emulated/0/Android/data"
-            roots.add(getExternalFilesDir(null).getParentFile().getParentFile());
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+                // Add "/storage/emulated/0/Android/data"
+                roots.add(getExternalFilesDir(null).getParentFile().getParentFile());
 
-            // Add "/storage/emulated/0/Android/obb"
-            roots.add(getObbDir().getParentFile());
+                // Add "/storage/emulated/0/Android/obb"
+                roots.add(getObbDir().getParentFile());
+            }
 
             roots.add(Environment.getExternalStorageDirectory());
             roots.add(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_MOVIES));

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderPickerActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderPickerActivity.java
@@ -125,6 +125,13 @@ public class FolderPickerActivity extends SyncthingActivity
             roots.addAll(Arrays.asList(getExternalFilesDirs(null)));
             roots.remove(getExternalFilesDir(null));
             roots.remove(null);      // getExternalFilesDirs may return null for an ejected SDcard.
+
+            // Add "/storage/emulated/0/Android/data"
+            roots.add(getExternalFilesDir(null).getParentFile().getParentFile());
+
+            // Add "/storage/emulated/0/Android/obb"
+            roots.add(getObbDir().getParentFile());
+
             roots.add(Environment.getExternalStorageDirectory());
             roots.add(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_MOVIES));
             roots.add(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_MUSIC));


### PR DESCRIPTION
Not working on Android AVD nor Android 15.
Did not pass a single verification test I did. 🙁

See https://github.com/Catfriend1/syncthing-android/issues/1123#issuecomment-2994417712