### PR TITLE
Fix local discovery in go code (fixes #1500)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-feature android:name="android.software.leanback" android:required="false" />
     <uses-feature android:name="android.hardware.touchscreen" android:required="false" />
     <uses-feature android:name="android.hardware.location.gps" android:required="false" />
+    <uses-feature android:name="android.hardware.wifi" android:required="false" />
 
     <uses-sdk tools:overrideLibrary="com.google.zxing.client.android" />
 

--- a/syncthing/build-syncthing.py
+++ b/syncthing/build-syncthing.py
@@ -332,12 +332,13 @@ for target in BUILD_TARGETS:
         target['cc'].format(min_sdk),
     )
 
+    # See why "-checklinkname=0" is required: https://github.com/wlynxg/anet?tab=readme-ov-file#how-to-build-with-go-1230-or-later 
     environ = os.environ.copy()
     environ.update({
         'GOPATH': module_dir,
         'GO111MODULE': 'on',
         'CGO_ENABLED': '1',
-        'EXTRA_LDFLAGS': '-buildid=',
+        'EXTRA_LDFLAGS': '-buildid= -checklinkname=0',
     })
 
     subprocess.check_call([go_bin, 'mod', 'download'], cwd=syncthing_dir)

--- a/syncthing/build-syncthing.py
+++ b/syncthing/build-syncthing.py
@@ -57,6 +57,9 @@ BUILD_TARGETS = [
     }
 ]
 
+# If building locally for Android studio tests, build only required arch.
+if os.environ.get('COMPUTERNAME', '') == 'NET2019':
+    BUILD_TARGETS = [t for t in BUILD_TARGETS if t['arch'] == 'x86_64']
 
 def fail(message, *args, **kwargs):
     print((message % args).format(**kwargs))

--- a/syncthing/build-syncthing.py
+++ b/syncthing/build-syncthing.py
@@ -344,9 +344,6 @@ for target in BUILD_TARGETS:
     subprocess.check_call(
                               [go_bin, 'version'],
                               env=environ, cwd=syncthing_dir)
-    subprocess.check_call(
-                              [go_bin, 'run', 'build.go', 'version'],
-                              env=environ, cwd=syncthing_dir)
     subprocess.check_call([
                               go_bin, 'run', 'build.go', '-goos', 'android',
                               '-goarch', target['goarch'],

--- a/syncthing/build-syncthing.py
+++ b/syncthing/build-syncthing.py
@@ -59,7 +59,7 @@ BUILD_TARGETS = [
 
 # If building locally for Android studio tests, build only required arch.
 if os.environ.get('COMPUTERNAME', '') == 'NET2019':
-    BUILD_TARGETS = [t for t in BUILD_TARGETS if t['arch'] == 'x86_64']
+    BUILD_TARGETS = [t for t in BUILD_TARGETS if t['arch'] in ('arm64', 'x86_64')]
 
 def fail(message, *args, **kwargs):
     print((message % args).format(**kwargs))


### PR DESCRIPTION
by using the go "anet" package.

Branch: https://github.com/Catfriend1/syncthing/tree/v1.29.7-android

```
 [ET76H] .814580 manager.go:92: INFO: Using discovery mechanism: IPv4 local broadcast discovery on port 21027
 [ET76H] .814597 manager.go:92: INFO: Using discovery mechanism: IPv6 local multicast discovery on address [ff12::8384]:21027
 [ET76H] .814837 local.go:127: DEBUG: Nothing to announce
 [ET76H] .814908 local.go:127: DEBUG: Nothing to announce
```