### PR TITLE
Update Building-and-Development.md

### DIFF
--- a/wiki/Building-and-Development.md
+++ b/wiki/Building-and-Development.md
@@ -18,10 +18,9 @@ git clone https://github.com/Catfriend1/syncthing-android.git --recursive
 #
 # Build
 cd ~/git/syncthing-android
-python3 install_minimum_android_sdk_prerequisites.py
+python3 scripts/install_minimum_android_sdk_prerequisites.py
 ./gradlew buildNative
 export ANDROID_HOME=~/git/syncthing-android-prereq
-echo -e "\norg.gradle.jvmargs=-Xmx4096m" >> gradle.properties
 ./gradlew lintDebug
 ./gradlew assembleDebug
 ```


### PR DESCRIPTION
# Changes
What changes are made in this PR
* `echo -e "\norg.gradle.jvmargs=-Xmx4096m" >> gradle.properties` instruction removed as ee389e925b9ca33e0921e1c14fce75b0d63bfbf1 added that to gradle.properties and made it redundant
* Update path from `install_minimum_android_sdk_prerequisites.py` to `scripts/install_minimum_android_sdk_prerequisites.py` (because 71f4a0521601244f0a37b1e053adcb361a14bae1)
