### PR TITLE
model/Folder: maxConcurrentWrites = 0

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/model/Folder.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/model/Folder.java
@@ -61,8 +61,8 @@ public class Folder {
     public String blockPullOrder = "standard";
     // see PR #6588
     public Boolean disableFsync = false;
-    // see PR #6573
-    public int maxConcurrentWrites = 2;
+    // see PR #6573, #10200
+    public int maxConcurrentWrites = 0;
 
     // Since v1.8.0
     // see PR #6746: "all", "copy_file_range", "duplicate_extents", "ioctl", "sendfile", "standard"


### PR DESCRIPTION
to default to SyncthingNative's default of 16.
ref: https://github.com/syncthing/syncthing/pull/10200

Should improve performance if syncing many small files at once on Android.