### PR TITLE
F-Droid builds: Use correct go version from Dockerfile (fixes #1383)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,6 +70,15 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    signingConfigs {
+        create("release") {
+            storeFile = System.getenv("SYNCTHING_RELEASE_STORE_FILE")?.let(::file)
+            storePassword = System.getenv("SIGNING_PASSWORD")
+            keyAlias = System.getenv("SYNCTHING_RELEASE_KEY_ALIAS")
+            keyPassword = System.getenv("SIGNING_PASSWORD")
+        }
+    }
+
     buildTypes {
         getByName("debug") {
             applicationIdSuffix = ".debug"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,15 +70,6 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
-    signingConfigs {
-        create("release") {
-            storeFile = System.getenv("SYNCTHING_RELEASE_STORE_FILE")?.let(::file)
-            storePassword = System.getenv("SIGNING_PASSWORD")
-            keyAlias = System.getenv("SYNCTHING_RELEASE_KEY_ALIAS")
-            keyPassword = System.getenv("SIGNING_PASSWORD")
-        }
-    }
-
     buildTypes {
         getByName("debug") {
             applicationIdSuffix = ".debug"

--- a/fdroid/com.github.catfriend1.syncthingandroid.yml
+++ b/fdroid/com.github.catfriend1.syncthingandroid.yml
@@ -2590,12 +2590,22 @@ Builds:
       - apt-get install -y -t bookworm-backports golang-go
     gradle:
       - yes
+    srclibs:
+      - go@go1.23.0
     prebuild:
+      - export goVersion=$(grep "ENV GO_VERSION" "docker/Dockerfile" | cut -d "=" -f2)
+      - [[ $goVersion ]] || exit 1
+      - git -C $$go$$ checkout -f go$goVersion
       - sed -i -e '/signingConfig/,+2d' build.gradle.kts
       - sed -i -e 's/java.net.URI/uri/' ../settings.gradle.kts
     scanignore:
       - syncthing/src/github.com/syncthing/syncthing/lib/model/testdata
     build:
+      - pushd $$go$$/src
+      - ./make.bash
+      - popd
+      - export GOPATH=$$go$$
+      - export PATH="$GOPATH/bin:$PATH"
       - export ndkversion=$(grep "ndkVersionShared" ../build.gradle.kts | cut -d '"'
         -f 4)
       - sdkmanager "ndk;$ndkversion"

--- a/fdroid/com.github.catfriend1.syncthingandroid.yml
+++ b/fdroid/com.github.catfriend1.syncthingandroid.yml
@@ -2588,8 +2588,6 @@ Builds:
       - apt-get install -y autogen automake autopoint bzip2 g++ libc-dev make gettext
         libtool pkg-config rename shtool
       - apt-get install -y -t bookworm-backports golang-go
-    gradle:
-      - no
     srclibs:
       - go@go1.23.0
     prebuild:

--- a/fdroid/com.github.catfriend1.syncthingandroid.yml
+++ b/fdroid/com.github.catfriend1.syncthingandroid.yml
@@ -2593,7 +2593,8 @@ Builds:
     srclibs:
       - go@go1.23.0
     prebuild:
-      - export goVersion=$(grep "ENV GO_VERSION" "docker/Dockerfile" | cut -d "=" -f2)
+      - export goVersion=$(grep "ENV GO_VERSION" "docker/Dockerfile" | cut -d "="
+        -f2)
       - '[[ $goVersion ]] || exit 1'
       - git -C $$go$$ checkout -f go$goVersion
       - sed -i -e '/signingConfig/,+2d' build.gradle.kts

--- a/fdroid/com.github.catfriend1.syncthingandroid.yml
+++ b/fdroid/com.github.catfriend1.syncthingandroid.yml
@@ -2590,6 +2590,7 @@ Builds:
       - apt-get install -y -t bookworm-backports golang-go
     srclibs:
       - go@go1.23.0
+    output: app/build/outputs/apk/release/app-release-unsigned.apk
     prebuild:
       - export goVersion=$(grep "ENV GO_VERSION" ../docker/Dockerfile | cut -d "="
         -f2)

--- a/fdroid/com.github.catfriend1.syncthingandroid.yml
+++ b/fdroid/com.github.catfriend1.syncthingandroid.yml
@@ -2594,7 +2594,7 @@ Builds:
       - go@go1.23.0
     prebuild:
       - export goVersion=$(grep "ENV GO_VERSION" "docker/Dockerfile" | cut -d "=" -f2)
-      - [[ $goVersion ]] || exit 1
+      - '[[ $goVersion ]] || exit 1'
       - git -C $$go$$ checkout -f go$goVersion
       - sed -i -e '/signingConfig/,+2d' build.gradle.kts
       - sed -i -e 's/java.net.URI/uri/' ../settings.gradle.kts

--- a/fdroid/com.github.catfriend1.syncthingandroid.yml
+++ b/fdroid/com.github.catfriend1.syncthingandroid.yml
@@ -2588,7 +2588,8 @@ Builds:
       - apt-get install -y autogen automake autopoint bzip2 g++ libc-dev make gettext
         libtool pkg-config rename shtool
       - apt-get install -y -t bookworm-backports golang-go
-    output: build/outputs/apk/release/app-release-unsigned.apk
+    gradle:
+      - yes
     srclibs:
       - go@go1.23.0
     prebuild:
@@ -2598,20 +2599,16 @@ Builds:
       - git -C $$go$$ checkout -f go$goVersion
       - sed -i -e '/signingConfig/,+2d' build.gradle.kts
       - sed -i -e 's/java.net.URI/uri/' ../settings.gradle.kts
-      - gradle clean
+      - sed -i -e 's|go_bin = which("go");|go_bin = "$$go$$/bin/go"|' ../syncthing/build-syncthing.py
     scanignore:
       - syncthing/src/github.com/syncthing/syncthing/lib/model/testdata
     build:
       - pushd $$go$$/src
       - ./make.bash
       - popd
-      - export GOPATH=$$go$$
-      - export PATH="$GOPATH/bin:$PATH"
       - export ndkversion=$(grep "ndkVersionShared" ../build.gradle.kts | cut -d '"'
         -f 4)
       - sdkmanager "ndk;$ndkversion"
-      - export ANDROID_NDK_HOME=$$SDK$$/ndk/$ndkversion
-      - gradle assembleRelease
 
 MaintainerNotes: |-
   The submodule in syncthing/src/github.com/syncthing/syncthing must be

--- a/fdroid/com.github.catfriend1.syncthingandroid.yml
+++ b/fdroid/com.github.catfriend1.syncthingandroid.yml
@@ -2588,7 +2588,7 @@ Builds:
       - apt-get install -y autogen automake autopoint bzip2 g++ libc-dev make gettext
         libtool pkg-config rename shtool
       - apt-get install -y -t bookworm-backports golang-go
-    output: app/build/outputs/apk/release/app-release-unsigned.apk
+    output: build/outputs/apk/release/app-release-unsigned.apk
     srclibs:
       - go@go1.23.0
     prebuild:

--- a/fdroid/com.github.catfriend1.syncthingandroid.yml
+++ b/fdroid/com.github.catfriend1.syncthingandroid.yml
@@ -2611,7 +2611,7 @@ Builds:
         -f 4)
       - sdkmanager "ndk;$ndkversion"
       - export ANDROID_NDK_HOME=$$SDK$$/ndk/$ndkversion
-      - gradle buildRelease
+      - gradle assembleRelease
 
 MaintainerNotes: |-
   The submodule in syncthing/src/github.com/syncthing/syncthing must be

--- a/fdroid/com.github.catfriend1.syncthingandroid.yml
+++ b/fdroid/com.github.catfriend1.syncthingandroid.yml
@@ -2593,7 +2593,7 @@ Builds:
     srclibs:
       - go@go1.23.0
     prebuild:
-      - export goVersion=$(grep "ENV GO_VERSION" "docker/Dockerfile" | cut -d "="
+      - export goVersion=$(grep "ENV GO_VERSION" ../docker/Dockerfile | cut -d "="
         -f2)
       - '[[ $goVersion ]] || exit 1'
       - git -C $$go$$ checkout -f go$goVersion

--- a/fdroid/com.github.catfriend1.syncthingandroid.yml
+++ b/fdroid/com.github.catfriend1.syncthingandroid.yml
@@ -2588,9 +2588,9 @@ Builds:
       - apt-get install -y autogen automake autopoint bzip2 g++ libc-dev make gettext
         libtool pkg-config rename shtool
       - apt-get install -y -t bookworm-backports golang-go
+    output: app/build/outputs/apk/release/app-release-unsigned.apk
     srclibs:
       - go@go1.23.0
-    output: app/build/outputs/apk/release/app-release-unsigned.apk
     prebuild:
       - export goVersion=$(grep "ENV GO_VERSION" ../docker/Dockerfile | cut -d "="
         -f2)

--- a/fdroid/com.github.catfriend1.syncthingandroid.yml
+++ b/fdroid/com.github.catfriend1.syncthingandroid.yml
@@ -2589,7 +2589,7 @@ Builds:
         libtool pkg-config rename shtool
       - apt-get install -y -t bookworm-backports golang-go
     gradle:
-      - yes
+      - no
     srclibs:
       - go@go1.23.0
     prebuild:
@@ -2599,6 +2599,7 @@ Builds:
       - git -C $$go$$ checkout -f go$goVersion
       - sed -i -e '/signingConfig/,+2d' build.gradle.kts
       - sed -i -e 's/java.net.URI/uri/' ../settings.gradle.kts
+      - gradle clean
     scanignore:
       - syncthing/src/github.com/syncthing/syncthing/lib/model/testdata
     build:
@@ -2611,6 +2612,7 @@ Builds:
         -f 4)
       - sdkmanager "ndk;$ndkversion"
       - export ANDROID_NDK_HOME=$$SDK$$/ndk/$ndkversion
+      - gradle buildRelease
 
 MaintainerNotes: |-
   The submodule in syncthing/src/github.com/syncthing/syncthing must be


### PR DESCRIPTION
See https://gitlab.com/fdroid/fdroiddata/-/merge_requests/24172 and https://forum.f-droid.org/t/syncthing-fork-reproducible-build-work-in-progress/32714

* Related to: Reproducible builds

Working recipe without modifying "syncthing/build-syncthing.py" during F-Droid build run:
```
  - versionName: 1.29.7.5
    versionCode: 1290705
    commit: 6e3783867abfefa3c2629b877168618023ccaab4
    subdir: app
    submodules: true
    sudo:
      - apt-get update
      - apt-get install -y autogen automake autopoint bzip2 g++ libc-dev make gettext
        libtool pkg-config rename shtool
      - apt-get install -y -t bookworm-backports golang-go
    output: build/outputs/apk/release/app-release-unsigned.apk
    srclibs:
      - go@go1.23.0
    prebuild:
      - export goVersion=$(grep "ENV GO_VERSION" ../docker/Dockerfile | cut -d "="
        -f2)
      - '[[ $goVersion ]] || exit 1'
      - git -C $$go$$ checkout -f go$goVersion
      - sed -i -e '/signingConfig/,+2d' build.gradle.kts
      - sed -i -e 's/java.net.URI/uri/' ../settings.gradle.kts
      - gradle clean
    scanignore:
      - syncthing/src/github.com/syncthing/syncthing/lib/model/testdata
    build:
      - pushd $$go$$/src
      - ./make.bash
      - popd
      - export GOPATH=$$go$$
      - export PATH="$GOPATH/bin:$PATH"
      - export ndkversion=$(grep "ndkVersionShared" ../build.gradle.kts | cut -d '"'
        -f 4)
      - sdkmanager "ndk;$ndkversion"
      - export ANDROID_NDK_HOME=$$SDK$$/ndk/$ndkversion
      - gradle assembleRelease
```