### PR TITLE
Fix duplicate .nomedia and DO_NOT_DELETE.txt files created if folder is readded (fixes #1504)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
@@ -976,30 +976,11 @@ public class FolderActivity extends SyncthingActivity {
         }
 
         // Create ".stfolder/DO_NOT_DELETE" file.
-        DocumentFile dfDoNotDeleteFile = dfFolderMarkerDir.createFile("text/plain", DO_NOT_DELETE_FILE_NAME);
-        if (dfDoNotDeleteFile == null) {
-            Log.w(TAG, "preCreateFolderStruct: Failed to create file '" + strDoNotDeleteFile + "' #1");
-            return;
-        }
-        Log.v(TAG, "preCreateFolderStruct: Created file '" + strDoNotDeleteFile + "'");
-
-        // Write "DO_NOT_DELETE" text content.
-        OutputStream outputStream = null;
-        try {
-            outputStream = getContentResolver().openOutputStream(dfDoNotDeleteFile.getUri());
-            outputStream.write(DO_NOT_DELETE_FILE_NAME.getBytes(StandardCharsets.ISO_8859_1));
-            outputStream.flush();
-        } catch (IOException e) {
-            Log.e(TAG, "preCreateFolderStruct: Failed to create file '" + strDoNotDeleteFile + "' #2", e);
-        } finally {
-            try {
-                if (outputStream != null) {
-                    outputStream.close();
-                }
-            } catch (IOException e) {
-                Log.e(TAG, "preCreateFolderStruct: Failed to create file '" + strDoNotDeleteFile + "' #3", e);
-            }
-        }
+        safCreateFile(dfFolderMarkerDir.getUri(),
+                            "text/plain",
+                            DO_NOT_DELETE_FILE_NAME,
+                            DO_NOT_DELETE_FILE_NAME
+        );
 
         // Create ".stversions" directory.
         DocumentFile dfStVersionsDir = null;

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
@@ -956,91 +956,16 @@ public class FolderActivity extends SyncthingActivity {
         // Create ".stfolder" directory.
         DocumentFile  dfFolderMarkerDir = safCreateDirectory(dfFolder, FOLDER_MARKER_DIR_NAME);
         if (dfFolderMarkerDir != null) {
-            // Create ".stfolder/DO_NOT_DELETE" file.
-            safCreateFile(dfFolderMarkerDir,
-                                "text/plain",
-                                DO_NOT_DELETE_FILE_NAME,
-                                DO_NOT_DELETE_FILE_NAME
-            );
+            // Create ".stfolder/DO_NOT_DELETE.txt" file.
+            FileUtils.safCreateFile(dfFolderMarkerDir, DO_NOT_DELETE_FILE_NAME + ".txt", DO_NOT_DELETE_FILE_NAME);
         }
 
         // Create ".stversions" directory.
         DocumentFile  dfStVersionsDir = safCreateDirectory(dfFolder, Constants.FOLDER_NAME_STVERSIONS);
         if (dfStVersionsDir != null) {
-            // Write ".stversions/.nomedia" file.
-            safCreateFile(dfStVersionsDir,
-                                "application/octet-stream",
-                                ".nomedia",
-                                ""
-            );
+            // Create ".stversions/.nomedia" file.
+            FileUtils.safCreateFile(dfStVersionsDir, ".nomedia", "");
         }
-    }
-
-    private final DocumentFile safCreateDirectory(final DocumentFile parentFolder,
-                                                        final String folderName) {
-        if (parentFolder == null) {
-            Log.w(TAG, "safCreateDirectory: parentFolder == null");
-            return null;
-        }
-        DocumentFile dfNewFolder = null;
-        for (DocumentFile file : parentFolder.listFiles()) {
-            if (file.isDirectory() && file.getName().equals(folderName)) {
-                Log.v(TAG, "safCreateDirectory: Directory already exists '" + folderName + "'");
-                return file;
-            }
-        }
-        dfNewFolder = parentFolder.createDirectory(folderName);
-        if (dfNewFolder == null) {
-            Log.w(TAG, "safCreateDirectory: Failed to create directory '" + folderName + "'");
-            return null;
-        }
-        Log.v(TAG, "safCreateDirectory: Created directory '" + folderName + "'");
-        return dfNewFolder;
-    }
-
-    private final boolean safCreateFile(final DocumentFile parentFolder,
-                                            final String fileMimeType,
-                                            final String fileName,
-                                            final String content) {
-        for (DocumentFile file : parentFolder.listFiles()) {
-            if (file.isFile() && file.getName().equals(fileName)) {
-                Log.v(TAG, "safCreateFile: File already exists '" + fileName + "'");
-                return true;
-            }
-        }
-
-        boolean failSuccess = false;
-        OutputStream outputStream = null;
-        try {
-            Uri fileUri = DocumentsContract.createDocument(
-                    getContentResolver(),
-                    parentFolder.getUri(),
-                    fileMimeType,
-                    fileName
-            );
-            if (fileUri == null) {
-                Log.e(TAG, "safCreateFile: Failed to create file '" + fileName + "' #1");
-                return false;
-            }
-            outputStream = getContentResolver().openOutputStream(fileUri);
-            if (!content.isEmpty()) {
-                outputStream.write(content.getBytes(StandardCharsets.ISO_8859_1));
-            }
-            outputStream.flush();
-            Log.v(TAG, "safCreateFile: Created file '" + fileName + "'");
-            failSuccess = true;
-        } catch (Exception e) {
-            Log.e(TAG, "safCreateFile: Failed to create file '" + fileName + "' #2", e);
-        } finally {
-            try {
-                if (outputStream != null) {
-                    outputStream.close();
-                }
-            } catch (IOException e) {
-                Log.e(TAG, "safCreateFile: Failed to create file '" + fileName + "' #3", e);
-            }
-        }
-        return failSuccess;
     }
 
     private void showDiscardDialog(){

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
@@ -952,61 +952,50 @@ public class FolderActivity extends SyncthingActivity {
 
         // Derive DocumentFile handle from SAF tree Uri where we have write access.
         DocumentFile dfFolder = DocumentFile.fromTreeUri(this, uriFolderRoot);
-        if (dfFolder == null) {
-            Log.w(TAG, "preCreateFolderStruct: dfFolder == null");
-            return;
-        }
 
-        // Create ".stfolder" marker directory.
-        DocumentFile dfFolderMarkerDir = null;
-        for (DocumentFile file : dfFolder.listFiles()) {
-            if (file.isDirectory() && file.getName().equals(FOLDER_MARKER_DIR_NAME)) {
-                dfFolderMarkerDir = file;
-                Log.v(TAG, "preCreateFolderStruct: Directory already exists '" + strFolderMarkerPath + "'");
-                break;
-            }
+        // Create ".stfolder" directory.
+        DocumentFile  dfFolderMarkerDir = safCreateDirectory(dfFolder, FOLDER_MARKER_DIR_NAME);
+        if (dfFolderMarkerDir != null) {
+            // Create ".stfolder/DO_NOT_DELETE" file.
+            safCreateFile(dfFolderMarkerDir.getUri(),
+                                "text/plain",
+                                DO_NOT_DELETE_FILE_NAME,
+                                DO_NOT_DELETE_FILE_NAME
+            );
         }
-        if (dfFolderMarkerDir == null) {
-            dfFolderMarkerDir = dfFolder.createDirectory(FOLDER_MARKER_DIR_NAME);
-            if (dfFolderMarkerDir == null) {
-                Log.w(TAG, "preCreateFolderStruct: Failed to create directory '" + strFolderMarkerPath + "'");
-                return;
-            }
-            Log.v(TAG, "preCreateFolderStruct: Created directory '" + strFolderMarkerPath + "'");
-        }
-
-        // Create ".stfolder/DO_NOT_DELETE" file.
-        safCreateFile(dfFolderMarkerDir.getUri(),
-                            "text/plain",
-                            DO_NOT_DELETE_FILE_NAME,
-                            DO_NOT_DELETE_FILE_NAME
-        );
 
         // Create ".stversions" directory.
-        DocumentFile dfStVersionsDir = null;
-        for (DocumentFile file : dfFolder.listFiles()) {
-            if (file.isDirectory() && file.getName().equals(Constants.FOLDER_NAME_STVERSIONS)) {
-                dfStVersionsDir = file;
-                Log.v(TAG, "preCreateFolderStruct: Directory already exists '" + strStVersionsPath + "'");
-                break;
-            }
+        DocumentFile  dfStVersionsDir = safCreateDirectory(dfFolder, Constants.FOLDER_NAME_STVERSIONS);
+        if (dfStVersionsDir != null) {
+            // Write ".stversions/.nomedia" file.
+            safCreateFile(dfStVersionsDir.getUri(),
+                                "application/octet-stream",
+                                ".nomedia",
+                                ""
+            );
         }
-        if (dfStVersionsDir == null) {
-            dfStVersionsDir = dfFolder.createDirectory(Constants.FOLDER_NAME_STVERSIONS);
-            if (dfStVersionsDir == null) {
-                Log.w(TAG, "preCreateFolderStruct: Failed to create directory '" + strStVersionsPath + "'");
-                return;
-            }
-            Log.v(TAG, "preCreateFolderStruct: Created directory '" + strStVersionsPath + "'");
-        }
-
-        // Write ".stversions/.nomedia" file.
-        safCreateFile(dfStVersionsDir.getUri(),
-                            "application/octet-stream",
-                            ".nomedia",
-                            ""
-        );
     }
+
+    private final DocumentFile safCreateDirectory(final DocumentFile parentFolder,
+                                                        final String folderName) {
+        if (parentFolder == null) {
+            Log.w(TAG, "safCreateDirectory: parentFolder == null");
+            return null;
+        }
+        DocumentFile dfNewFolder = null;
+        for (DocumentFile file : parentFolder.listFiles()) {
+            if (file.isDirectory() && file.getName().equals(folderName)) {
+                Log.v(TAG, "safCreateDirectory: Directory already exists '" + folderName + "'");
+                return file;
+            }
+        }
+        dfNewFolder = parentFolder.createDirectory(folderName);
+        if (dfNewFolder == null) {
+            Log.w(TAG, "safCreateDirectory: Failed to create directory '" + folderName + "'");
+            return null;
+        }
+        Log.v(TAG, "safCreateDirectory: Created directory '" + folderName + "'");
+        return dfNewFolder;
     }
 
     private final boolean safCreateFile(final Uri parentFolderUri,

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
@@ -1020,6 +1020,9 @@ public class FolderActivity extends SyncthingActivity {
         }
 
         // Write ".stversions/.nomedia" file.
+        safCreateFile(dfStVersionsDir.getUri(), ".nomedia", "");
+    }
+
     private final boolean safCreateFile(final Uri parentFolderUri,
                                             final String fileName,
                                             final String content) {

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
@@ -11,7 +11,6 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.IBinder;
-import android.provider.DocumentsContract;
 import android.text.Editable;
 import android.text.TextUtils;
 import android.text.TextWatcher;
@@ -53,9 +52,6 @@ import com.nutomic.syncthingandroid.util.Util;
 
 import java.io.File;
 import java.io.FileWriter;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -954,17 +950,17 @@ public class FolderActivity extends SyncthingActivity {
         DocumentFile dfFolder = DocumentFile.fromTreeUri(this, uriFolderRoot);
 
         // Create ".stfolder" directory.
-        DocumentFile  dfFolderMarkerDir = safCreateDirectory(dfFolder, FOLDER_MARKER_DIR_NAME);
+        DocumentFile dfFolderMarkerDir = FileUtils.safCreateDirectory(dfFolder, FOLDER_MARKER_DIR_NAME);
         if (dfFolderMarkerDir != null) {
             // Create ".stfolder/DO_NOT_DELETE.txt" file.
-            FileUtils.safCreateFile(dfFolderMarkerDir, DO_NOT_DELETE_FILE_NAME + ".txt", DO_NOT_DELETE_FILE_NAME);
+            FileUtils.safCreateFile(this, dfFolderMarkerDir, DO_NOT_DELETE_FILE_NAME + ".txt", DO_NOT_DELETE_FILE_NAME);
         }
 
         // Create ".stversions" directory.
-        DocumentFile  dfStVersionsDir = safCreateDirectory(dfFolder, Constants.FOLDER_NAME_STVERSIONS);
+        DocumentFile dfStVersionsDir = FileUtils.safCreateDirectory(dfFolder, Constants.FOLDER_NAME_STVERSIONS);
         if (dfStVersionsDir != null) {
             // Create ".stversions/.nomedia" file.
-            FileUtils.safCreateFile(dfStVersionsDir, ".nomedia", "");
+            FileUtils.safCreateFile(this, dfStVersionsDir, ".nomedia", "");
         }
     }
 

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
@@ -1020,23 +1020,41 @@ public class FolderActivity extends SyncthingActivity {
         }
 
         // Write ".stversions/.nomedia" file.
+    private final boolean safCreateFile(final Uri parentFolderUri,
+                                            final String fileName,
+                                            final String content) {
+        boolean failSuccess = false;
+        OutputStream outputStream = null;
         try {
             Uri fileUri = DocumentsContract.createDocument(
                     getContentResolver(),
-                    dfStVersionsDir.getUri(),
+                    parentFolderUri,
                     "application/octet-stream",
-                    ".nomedia"
+                    fileName
             );
-            if (fileUri != null) {
-                OutputStream os = getContentResolver().openOutputStream(fileUri);
-                if (os != null) {
-                    os.close();
-                }
+            if (fileUri == null) {
+                Log.e(TAG, "safCreateFile: Failed to create file '" + fileName + "' #1");
+                return false;
             }
-            Log.v(TAG, "preCreateFolderStruct: Created file '" + strStVersionsNoMediaFile + "'");
+            outputStream = getContentResolver().openOutputStream(fileUri);
+            if (!content.isEmpty()) {
+                outputStream.write(content.getBytes(StandardCharsets.ISO_8859_1));
+            }
+            outputStream.flush();
+            Log.v(TAG, "safCreateFile: Created file '" + fileName + "'");
+            failSuccess = true;
         } catch (Exception e) {
-            Log.e(TAG, "preCreateFolderStruct: Failed to create " + strStVersionsNoMediaFile + " file.", e);
+            Log.e(TAG, "safCreateFile: Failed to create file '" + fileName + "' #2", e);
+        } finally {
+            try {
+                if (outputStream != null) {
+                    outputStream.close();
+                }
+            } catch (IOException e) {
+                Log.e(TAG, "safCreateFile: Failed to create file '" + fileName + "' #3", e);
+            }
         }
+        return failSuccess;
     }
 
     private void showDiscardDialog(){

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
@@ -957,7 +957,7 @@ public class FolderActivity extends SyncthingActivity {
         DocumentFile  dfFolderMarkerDir = safCreateDirectory(dfFolder, FOLDER_MARKER_DIR_NAME);
         if (dfFolderMarkerDir != null) {
             // Create ".stfolder/DO_NOT_DELETE" file.
-            safCreateFile(dfFolderMarkerDir.getUri(),
+            safCreateFile(dfFolderMarkerDir,
                                 "text/plain",
                                 DO_NOT_DELETE_FILE_NAME,
                                 DO_NOT_DELETE_FILE_NAME
@@ -968,7 +968,7 @@ public class FolderActivity extends SyncthingActivity {
         DocumentFile  dfStVersionsDir = safCreateDirectory(dfFolder, Constants.FOLDER_NAME_STVERSIONS);
         if (dfStVersionsDir != null) {
             // Write ".stversions/.nomedia" file.
-            safCreateFile(dfStVersionsDir.getUri(),
+            safCreateFile(dfStVersionsDir,
                                 "application/octet-stream",
                                 ".nomedia",
                                 ""
@@ -998,16 +998,23 @@ public class FolderActivity extends SyncthingActivity {
         return dfNewFolder;
     }
 
-    private final boolean safCreateFile(final Uri parentFolderUri,
+    private final boolean safCreateFile(final DocumentFile parentFolder,
                                             final String fileMimeType,
                                             final String fileName,
                                             final String content) {
+        for (DocumentFile file : parentFolder.listFiles()) {
+            if (file.isFile() && file.getName().equals(fileName)) {
+                Log.v(TAG, "safCreateFile: File already exists '" + fileName + "'");
+                return true;
+            }
+        }
+
         boolean failSuccess = false;
         OutputStream outputStream = null;
         try {
             Uri fileUri = DocumentsContract.createDocument(
                     getContentResolver(),
-                    parentFolderUri,
+                    parentFolder.getUri(),
                     fileMimeType,
                     fileName
             );

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/FolderActivity.java
@@ -1020,10 +1020,16 @@ public class FolderActivity extends SyncthingActivity {
         }
 
         // Write ".stversions/.nomedia" file.
-        safCreateFile(dfStVersionsDir.getUri(), ".nomedia", "");
+        safCreateFile(dfStVersionsDir.getUri(),
+                            "application/octet-stream",
+                            ".nomedia",
+                            ""
+        );
+    }
     }
 
     private final boolean safCreateFile(final Uri parentFolderUri,
+                                            final String fileMimeType,
                                             final String fileName,
                                             final String content) {
         boolean failSuccess = false;
@@ -1032,7 +1038,7 @@ public class FolderActivity extends SyncthingActivity {
             Uri fileUri = DocumentsContract.createDocument(
                     getContentResolver(),
                     parentFolderUri,
-                    "application/octet-stream",
+                    fileMimeType,
                     fileName
             );
             if (fileUri == null) {

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/FileUtils.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/FileUtils.java
@@ -664,6 +664,7 @@ public class FileUtils {
         mimeTypes.put("mvc", "application/x-miva-compiled");
         mimeTypes.put("mxp", "application/x-mmxp");
         mimeTypes.put("nc", "application/x-netcdf");
+        mimeTypes.put("nomedia", "application/octet-stream");
         mimeTypes.put("nsc", "video/x-ms-asf");
         mimeTypes.put("nws", "message/rfc822");
         mimeTypes.put("ocx", "application/octet-stream");

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/FileUtils.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/FileUtils.java
@@ -1012,17 +1012,23 @@ public class FileUtils {
 
     public static final boolean safCreateFile(final Context context,
                                                     final DocumentFile parentFolder,
-                                                    final String fileName,
+                                                    final String fileNameAndExtension,
                                                     final String content) {
         for (DocumentFile file : parentFolder.listFiles()) {
-            if (file.isFile() && file.getName().equals(fileName)) {
-                Log.v(TAG, "safCreateFile: File already exists '" + fileName + "'");
+            if (file.isFile() && file.getName().equals(fileNameAndExtension)) {
+                Log.v(TAG, "safCreateFile: File already exists '" + fileNameAndExtension + "'");
                 return true;
             }
         }
 
-        String fileExtension = MimeTypeMap.getFileExtensionFromUrl(fileName);
-        final String fileMimeType = FileUtils.getMimeTypeFromFileExtension(fileExtension);
+        String fileExtension = MimeTypeMap.getFileExtensionFromUrl(fileNameAndExtension);
+        final String fileMimeType = FileUtils.getMimeTypeFromFileExtension(fileNameAndExtension);
+
+        String fileName = fileNameAndExtension;
+        int dotIndex = fileNameAndExtension.lastIndexOf('.');
+        if (dotIndex > 0) {
+            fileName = fileNameAndExtension.substring(0, dotIndex);
+        }
 
         boolean failSuccess = false;
         OutputStream outputStream = null;
@@ -1034,7 +1040,7 @@ public class FileUtils {
                     fileName
             );
             if (fileUri == null) {
-                Log.e(TAG, "safCreateFile: Failed to create file '" + fileName + "' #1");
+                Log.e(TAG, "safCreateFile: Failed to create file '" + fileNameAndExtension + "' #1");
                 return false;
             }
             outputStream = context.getContentResolver().openOutputStream(fileUri);
@@ -1042,17 +1048,17 @@ public class FileUtils {
                 outputStream.write(content.getBytes(StandardCharsets.ISO_8859_1));
             }
             outputStream.flush();
-            Log.v(TAG, "safCreateFile: Created file '" + fileName + "', type '" + fileMimeType + "'");
+            Log.v(TAG, "safCreateFile: Created file '" + fileNameAndExtension + "', type '" + fileMimeType + "'");
             failSuccess = true;
         } catch (Exception e) {
-            Log.e(TAG, "safCreateFile: Failed to create file '" + fileName + "' #2", e);
+            Log.e(TAG, "safCreateFile: Failed to create file '" + fileNameAndExtension + "' #2", e);
         } finally {
             try {
                 if (outputStream != null) {
                     outputStream.close();
                 }
             } catch (IOException e) {
-                Log.e(TAG, "safCreateFile: Failed to create file '" + fileName + "' #3", e);
+                Log.e(TAG, "safCreateFile: Failed to create file '" + fileNameAndExtension + "' #3", e);
             }
         }
         return failSuccess;

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/FileUtils.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/FileUtils.java
@@ -1022,7 +1022,7 @@ public class FileUtils {
         }
 
         String fileExtension = MimeTypeMap.getFileExtensionFromUrl(fileNameAndExtension);
-        final String fileMimeType = FileUtils.getMimeTypeFromFileExtension(fileNameAndExtension);
+        final String fileMimeType = FileUtils.getMimeTypeFromFileExtension(fileExtension);
 
         String fileName = fileNameAndExtension;
         int dotIndex = fileNameAndExtension.lastIndexOf('.');

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/FileUtils.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/FileUtils.java
@@ -989,7 +989,7 @@ public class FileUtils {
     }
 
     public static final DocumentFile safCreateDirectory(final DocumentFile parentFolder,
-                                                        final String folderName) {
+                                                                final String folderName) {
         if (parentFolder == null) {
             Log.w(TAG, "safCreateDirectory: parentFolder == null");
             return null;
@@ -1010,10 +1010,10 @@ public class FileUtils {
         return dfNewFolder;
     }
 
-    public static final boolean safCreateFile(Context context,
-                                            final DocumentFile parentFolder,
-                                            final String fileName,
-                                            final String content) {
+    public static final boolean safCreateFile(final Context context,
+                                                    final DocumentFile parentFolder,
+                                                    final String fileName,
+                                                    final String content) {
         for (DocumentFile file : parentFolder.listFiles()) {
             if (file.isFile() && file.getName().equals(fileName)) {
                 Log.v(TAG, "safCreateFile: File already exists '" + fileName + "'");

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/FileUtils.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/FileUtils.java
@@ -18,15 +18,19 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.core.content.ContextCompat;
 import androidx.core.content.FileProvider;
+import androidx.documentfile.provider.DocumentFile;
 
 import com.nutomic.syncthingandroid.R;
 
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
+import java.io.FileWriter;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.lang.reflect.Array;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -984,7 +988,7 @@ public class FileUtils {
         return (fileMimeType == null) ? "" : fileMimeType;
     }
 
-    public final DocumentFile safCreateDirectory(final DocumentFile parentFolder,
+    public static final DocumentFile safCreateDirectory(final DocumentFile parentFolder,
                                                         final String folderName) {
         if (parentFolder == null) {
             Log.w(TAG, "safCreateDirectory: parentFolder == null");
@@ -1004,6 +1008,54 @@ public class FileUtils {
         }
         Log.v(TAG, "safCreateDirectory: Created directory '" + folderName + "'");
         return dfNewFolder;
+    }
+
+    public static final boolean safCreateFile(Context context,
+                                            final DocumentFile parentFolder,
+                                            final String fileName,
+                                            final String content) {
+        for (DocumentFile file : parentFolder.listFiles()) {
+            if (file.isFile() && file.getName().equals(fileName)) {
+                Log.v(TAG, "safCreateFile: File already exists '" + fileName + "'");
+                return true;
+            }
+        }
+
+        String fileExtension = MimeTypeMap.getFileExtensionFromUrl(fileName);
+        final String fileMimeType = FileUtils.getMimeTypeFromFileExtension(fileExtension);
+
+        boolean failSuccess = false;
+        OutputStream outputStream = null;
+        try {
+            Uri fileUri = DocumentsContract.createDocument(
+                    context.getContentResolver(),
+                    parentFolder.getUri(),
+                    fileMimeType,
+                    fileName
+            );
+            if (fileUri == null) {
+                Log.e(TAG, "safCreateFile: Failed to create file '" + fileName + "' #1");
+                return false;
+            }
+            outputStream = context.getContentResolver().openOutputStream(fileUri);
+            if (!content.isEmpty()) {
+                outputStream.write(content.getBytes(StandardCharsets.ISO_8859_1));
+            }
+            outputStream.flush();
+            Log.v(TAG, "safCreateFile: Created file '" + fileName + "', type '" + fileMimeType + "'");
+            failSuccess = true;
+        } catch (Exception e) {
+            Log.e(TAG, "safCreateFile: Failed to create file '" + fileName + "' #2", e);
+        } finally {
+            try {
+                if (outputStream != null) {
+                    outputStream.close();
+                }
+            } catch (IOException e) {
+                Log.e(TAG, "safCreateFile: Failed to create file '" + fileName + "' #3", e);
+            }
+        }
+        return failSuccess;
     }
 
     /**

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/FileUtils.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/FileUtils.java
@@ -984,6 +984,28 @@ public class FileUtils {
         return (fileMimeType == null) ? "" : fileMimeType;
     }
 
+    public final DocumentFile safCreateDirectory(final DocumentFile parentFolder,
+                                                        final String folderName) {
+        if (parentFolder == null) {
+            Log.w(TAG, "safCreateDirectory: parentFolder == null");
+            return null;
+        }
+        DocumentFile dfNewFolder = null;
+        for (DocumentFile file : parentFolder.listFiles()) {
+            if (file.isDirectory() && file.getName().equals(folderName)) {
+                Log.v(TAG, "safCreateDirectory: Directory already exists '" + folderName + "'");
+                return file;
+            }
+        }
+        dfNewFolder = parentFolder.createDirectory(folderName);
+        if (dfNewFolder == null) {
+            Log.w(TAG, "safCreateDirectory: Failed to create directory '" + folderName + "'");
+            return null;
+        }
+        Log.v(TAG, "safCreateDirectory: Created directory '" + folderName + "'");
+        return dfNewFolder;
+    }
+
     /**
      * Open file in compatible app.
      */

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/FileUtils.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/FileUtils.java
@@ -67,21 +67,21 @@ public class FileUtils {
         return DocumentsContract.buildTreeDocumentUri(authority, documentId);
     }
     
-    public static boolean directoryUriExists(Context context, Uri documentUri) {
+    public static boolean directoryUriExists(final Context context, Uri documentUri) {
         Uri treeUri = convertFromDocumentUriToTreeUri(documentUri);
         String absPath = getAbsolutePathFromSAFUri(context, treeUri);
         return new File(absPath).exists();
     }
     
     @Nullable
-    public static String getAbsolutePathFromSAFUri(Context context, @Nullable final Uri safResultUri) {
+    public static String getAbsolutePathFromSAFUri(final Context context, @Nullable final Uri safResultUri) {
         Uri treeUri = DocumentsContract.buildDocumentUriUsingTree(safResultUri,
             DocumentsContract.getTreeDocumentId(safResultUri));
         return getAbsolutePathFromTreeUri(context, treeUri);
     }
 
     @Nullable
-    public static String getAbsolutePathFromTreeUri(Context context, @Nullable final Uri treeUri) {
+    public static String getAbsolutePathFromTreeUri(final Context context, @Nullable final Uri treeUri) {
         if (treeUri == null) {
             Log.w(TAG, "getAbsolutePathFromTreeUri: called with treeUri == null");
             return null;
@@ -152,7 +152,7 @@ public class FileUtils {
     }
 
     @SuppressLint("ObsoleteSdkInt")
-    private static String getVolumePath(final String volumeId, Context context) {
+    private static String getVolumePath(final String volumeId, final Context context) {
         try {
             if (HOME_VOLUME_NAME.equals(volumeId)) {
                 Log.v(TAG, "getVolumePath: isHomeVolume");
@@ -207,11 +207,11 @@ public class FileUtils {
         // return null;
     }
 
-    public static File getExternalFilesDir(Context context, String type) {
+    public static File getExternalFilesDir(final Context context, String type) {
         return getExternalFilesDir(context, ExternalStorageDirType.DATA, type);
     }
 
-    public static File getExternalFilesDir(Context context, ExternalStorageDirType extDirType, String type) {
+    public static File getExternalFilesDir(final Context context, ExternalStorageDirType extDirType, String type) {
         /**
          * Determine the app's private data folder on external storage if present.
          * e.g. "/storage/abcd-efgh/Android/data/[PACKAGE_NAME]/files"
@@ -266,7 +266,7 @@ public class FileUtils {
      * API for getExternalFilesDirs(): 19+ (KITKAT+)
      * API for getExternalMediaDirs(): 21+ (LOLLIPOP+)
      */
-    public static android.net.Uri getExternalFilesDirUri(Context context, ExternalStorageDirType extDirType) {
+    public static android.net.Uri getExternalFilesDirUri(final Context context, ExternalStorageDirType extDirType) {
         try {
             File externalFilesDir = getExternalFilesDir(context, extDirType, null);
             if (externalFilesDir == null) {
@@ -1061,7 +1061,7 @@ public class FileUtils {
     /**
      * Open file in compatible app.
      */
-    public static void openFile(Context context, String fullPathAndFilename) {
+    public static void openFile(final Context context, String fullPathAndFilename) {
         Uri fileUri = Uri.parse(fullPathAndFilename);
         String fileExtension = MimeTypeMap.getFileExtensionFromUrl(fileUri.toString());
         String mimeType = FileUtils.getMimeTypeFromFileExtension(fileExtension);
@@ -1095,7 +1095,7 @@ public class FileUtils {
     /**
      * Open folder in compatible file manager app.
      */
-    public static void openFolder(Context context, String folderPath) {
+    public static void openFolder(final Context context, String folderPath) {
         PackageManager pm = context.getPackageManager();
 
         // Try to find a compatible file manager app supporting the "resource/folder" Uri type.
@@ -1129,7 +1129,7 @@ public class FileUtils {
         suggestFileManagerApp(context);
     }
 
-    private static void suggestFileManagerApp(Context context) {
+    private static void suggestFileManagerApp(final Context context) {
         AlertDialog mSuggestFileManagerAppDialog = new AlertDialog.Builder(context)
                 .setTitle(R.string.suggest_file_manager_app_dialog_title)
                 .setMessage(R.string.suggest_file_manager_app_dialog_text)


### PR DESCRIPTION
Log of first folder addition:
```
2025-06-28 20:20:20.322  4729-4729  FolderActivity          com...riend1.syncthingandroid.debug  D  Initializing create mode ...
2025-06-28 20:20:40.045  4729-4729  FolderActivity          com...riend1.syncthingandroid.debug  V  onPathViewClick: INITIAL_URI = content://com.android.externalstorage.documents/document/primary%3A
2025-06-28 20:20:52.944  4729-4729  FolderActivity          com...riend1.syncthingandroid.debug  V  onActivityResult/CHOOSE_FOLDER_REQUEST: Got directory path '/storage/0000-0000/Test'
2025-06-28 20:21:06.235  4729-4729  FolderActivity          com...riend1.syncthingandroid.debug  V  onSave: Adding folder with ID = 'ecowh-4yrcm'
2025-06-28 20:21:06.280  4729-4729  FolderActivity          com...riend1.syncthingandroid.debug  V  safCreateDirectory: Created directory '.stfolder'
2025-06-28 20:21:06.293  4729-4729  FolderActivity          com...riend1.syncthingandroid.debug  V  safCreateFile: Created file 'DO_NOT_DELETE'
2025-06-28 20:21:06.326  4729-4729  FolderActivity          com...riend1.syncthingandroid.debug  V  safCreateDirectory: Created directory '.stversions'
2025-06-28 20:21:06.337  4729-4729  FolderActivity          com...riend1.syncthingandroid.debug  V  safCreateFile: Created file '.nomedia'
```

AVD 9 x86-64 using SAF:
```
adb shell find /storage/0000-0000/Test
/storage/0000-0000/Test
/storage/0000-0000/Test/.stfolder
/storage/0000-0000/Test/.stfolder/DO_NOT_DELETE.txt
/storage/0000-0000/Test/.stversions
/storage/0000-0000/Test/.stversions/.nomedia
```