### PR TITLE
Fix executorService crash while exiting the app is in progress

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/service/RestApi.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/RestApi.java
@@ -1218,6 +1218,15 @@ public class RestApi {
         // Execute planned workloads.
         final Boolean finalPlanGetSyncConflictFiles = planGetSyncConflictFiles;
         final Boolean finalPlanOnFolderSyncCompleted = planOnFolderSyncCompleted;
+        if (executorService.isShutdown()) {
+            // We are on the way to shutdown SynchtingNative.
+            return;
+        }
+        if (!finalPlanGetSyncConflictFiles && !finalPlanOnFolderSyncCompleted) {
+            // No work to do.
+            return;
+        }
+
         executorService.execute(() -> {
             if (finalPlanGetSyncConflictFiles) {
                 // Check for ".sync-conflict-YYYYMMDD-HHMMSS-DEVICEI*" files.


### PR DESCRIPTION
Crash while exiting the app:

```
2025-06-25 19:41:53.839 15888-15888 AndroidRuntime          pid-15888                            E  FATAL EXCEPTION: main
                                                                                                    Process: com.github.catfriend1.syncthingandroid.debug, PID: 15888
                                                                                                    java.util.concurrent.RejectedExecutionException: Task com.nutomic.syncthingandroid.service.RestApi$$ExternalSyntheticLambda0@6979ceb rejected from java.util.concurrent.ThreadPoolExecutor@91f9a48[Terminated, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 0]
                                                                                                    	at java.util.concurrent.ThreadPoolExecutor$AbortPolicy.rejectedExecution(ThreadPoolExecutor.java:2082)
                                                                                                    	at java.util.concurrent.ThreadPoolExecutor.reject(ThreadPoolExecutor.java:842)
                                                                                                    	at java.util.concurrent.ThreadPoolExecutor.execute(ThreadPoolExecutor.java:1374)
                                                                                                    	at java.util.concurrent.Executors$DelegatedExecutorService.execute(Executors.java:678)
                                                                                                    	at com.nutomic.syncthingandroid.service.RestApi.setRemoteCompletionInfo(RestApi.java:1221)
                                                                                                    	at com.nutomic.syncthingandroid.service.EventProcessor.onFolderCompletion(EventProcessor.java:342)
                                                                                                    	at com.nutomic.syncthingandroid.service.EventProcessor.onEvent(EventProcessor.java:144)
                                                                                                    	at com.nutomic.syncthingandroid.service.RestApi.lambda$getEvents$32(RestApi.java:1063)
                                                                                                    	at com.nutomic.syncthingandroid.service.RestApi.$r8$lambda$d1Jf-gi6g7hbXsin4UwawVCAvz0(Unknown Source:0)
                                                                                                    	at com.nutomic.syncthingandroid.service.RestApi$$ExternalSyntheticLambda19.onSuccess(D8$$SyntheticClass:0)
                                                                                                    	at com.nutomic.syncthingandroid.http.ApiRequest.lambda$connect$0(ApiRequest.java:107)
                                                                                                    	at com.nutomic.syncthingandroid.http.ApiRequest$$ExternalSyntheticLambda0.onResponse(D8$$SyntheticClass:0)
                                                                                                    	at com.android.volley.toolbox.StringRequest.deliverResponse(StringRequest.java:82)
                                                                                                    	at com.android.volley.toolbox.StringRequest.deliverResponse(StringRequest.java:29)
                                                                                                    	at com.android.volley.ExecutorDelivery$ResponseDeliveryRunnable.run(ExecutorDelivery.java:102)
                                                                                                    	at android.os.Handler.handleCallback(Handler.java:959)
                                                                                                    	at android.os.Handler.dispatchMessage(Handler.java:100)
                                                                                                    	at android.os.Looper.loopOnce(Looper.java:232)
                                                                                                    	at android.os.Looper.loop(Looper.java:317)
                                                                                                    	at android.app.ActivityThread.main(ActivityThread.java:8705)
                                                                                                    	at java.lang.reflect.Method.invoke(Native Method)
                                                                                                    	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:580)
                                                                                                    	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:886)
```