### PR TITLE
Fix typo #1527

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -597,8 +597,8 @@
         <item quantity="other">%1$d Geräte online und aktuell</item>
     </plurals>
     <plurals name="syncthing_active_syncing_device_online">
-        <item quantity="one">Synce: %1$d %% fertig, %2$d Gerät online</item>
-        <item quantity="other">Synce: %1$d %% fertig, %2$d Geräte online</item>
+        <item quantity="one">Sync: %1$d %% fertig, %2$d Gerät online</item>
+        <item quantity="other">Sync: %1$d %% fertig, %2$d Geräte online</item>
     </plurals>
     <string name="syncthing_disabled">Schläft</string>
     <string name="syncthing_terminated">Beendet</string>


### PR DESCRIPTION
# Description
This fixes the typo mentioned in #1527 

# Changes
* Fix typo #1527

# Screenshots
In case of UI changes, add before and after screenshots

| Before | After |
| ------ | ----- |
| ![before][] | ![after][] |

[before]: ![463359492-dbedba0d-d66c-4253-95e0-b1562c7ec2b6](https://github.com/user-attachments/assets/330c156e-9fb7-4294-a0bf-eadae020c397)

[after]: ![image](https://github.com/user-attachments/assets/67604c40-9cca-482c-b4aa-2ff911628647)
