### PR TITLE
Update RestApi.java

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/service/RestApi.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/RestApi.java
@@ -1104,7 +1104,8 @@ public class RestApi {
     private void sendBroadcastToApps(Intent intent) {
         String[] packageIdList = {
             // "com.example.syncthingreceiver",
-            "org.decsync.cc"
+            "org.decsync.cc",
+            "com.eclectosaurus.excalibre"
         };
         // intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
         for (String packageId : packageIdList) {


### PR DESCRIPTION
# Description
Adding the packageId to RestApi.java for an Android app I'm writing for browsing the calibre database that syncthing-fork is syncing onto my Android devices

# Changes
What changes are made in this PR
* Added the package id "com.eclectosaurus.excalibre" to the list of package ids which can receive broadcasts about syncthing-fork's state
