### PR TITLE
Update strings.xml

### DIFF
--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -99,7 +99,7 @@
     <string name="override_changes">Ignora le Modifiche</string>
     <!-- Override Changes Confirmation Dialog -->
     <string name="override_changes_question">Annullerà tutte le modifiche fatte sugli altri dispositivi che condividono questa cartella. Vuoi procedere\?</string>
-    <string name="revert_local_changes">Ripristina modifiche locali</string>
+    <string name="revert_local_changes">Sovrascrivi modifiche locali</string>
     <string name="delete_unexpected_items">Elimina elementi inattesi</string>
     <!-- Revert Local Changes Confirmation Dialog -->
     <string name="revert_local_changes_question">Annullerà tutte le modifiche fatte su questo dispositivo all\'interno della cartella. Vuoi procedere\?</string>


### PR DESCRIPTION
This traslation should be fixed (I speak native italian). The current translastion is misleading, because the original word "revert" in this context has the meaning of "overwrite": the local content of the folder will be replaced by the remote one. 

So this cannot be translated with "ripristina" wich literally means "restore". This makes the button misleading, the opposite of the actual meaning. Basically the current translation is literally "restore local changes", which is not what the buttons means.

I propose "sovrascrivi", which means "overwrite".  So in the end: "overwrite local changes".

# Description
Describe what this PR is about

# Changes
What changes are made in this PR
* change 1
* change 2

# Screenshots
In case of UI changes, add before and after screenshots

| Before | After |
| ------ | ----- |
| ![before][] | ![after][] |

[before]: before.png
[after]: after.png
